### PR TITLE
Add Astro Starlight GitHub Pages site

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,60 @@
+name: Deploy site
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy-site.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Astro site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.astro/
+npm-debug.log*
+.DS_Store

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,25 @@
+# mlx-atomistic site
+
+Astro + Starlight site for https://appautomaton.github.io/mlx-atomistic.
+
+## Local dev
+
+```bash
+cd site
+npm install
+npm run dev      # http://localhost:4321/mlx-atomistic/
+npm run build    # outputs to dist/
+npm run preview  # preview the build
+```
+
+## Structure
+
+- `src/pages/index.astro` — custom landing page (floating nav + bento grid + hero)
+- `src/styles/custom.css` — 2026 palette overrides for Starlight
+- `src/content/docs/` — migrated from `../docs/` with Starlight frontmatter
+- `astro.config.mjs` — site config, sidebar, base path
+
+## Deploy
+
+`.github/workflows/deploy-site.yml` builds and deploys to GitHub Pages on push
+to `main` when `site/**` changes.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,0 +1,51 @@
+import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
+
+export default defineConfig({
+  site: "https://appautomaton.github.io",
+  base: "/mlx-atomistic",
+  trailingSlash: "ignore",
+  integrations: [
+    starlight({
+      title: "mlx-atomistic",
+      description:
+        "Apple Silicon-native atomistic simulation: MLX + Metal DFT and MD runtime.",
+      logo: {
+        src: "./src/assets/logo.svg",
+        replacesTitle: false,
+      },
+      favicon: "./public/favicon.svg",
+      social: [
+        {
+          icon: "github",
+          label: "GitHub",
+          href: "https://github.com/appautomaton/mlx-atomistic",
+        },
+      ],
+      customCss: ["./src/styles/custom.css"],
+      sidebar: [
+        { label: "Overview", slug: "overview" },
+        {
+          label: "Foundations",
+          items: [{ autogenerate: { directory: "foundations" } }],
+        },
+        {
+          label: "Molecular Mechanics",
+          items: [{ autogenerate: { directory: "mm" } }],
+        },
+        {
+          label: "Density Functional Theory",
+          items: [{ autogenerate: { directory: "dft" } }],
+        },
+        {
+          label: "Benchmarks",
+          items: [{ autogenerate: { directory: "benchmarks" } }],
+        },
+        {
+          label: "Project",
+          items: [{ autogenerate: { directory: "project" } }],
+        },
+      ],
+    }),
+  ],
+});

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,0 +1,6205 @@
+{
+  "name": "mlx-atomistic-site",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mlx-atomistic-site",
+      "version": "0.1.0",
+      "dependencies": {
+        "@astrojs/starlight": "^0.40.0",
+        "astro": "^6.4.5",
+        "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-6.0.3.tgz",
+      "integrity": "sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-satteri": "0.3.0",
+        "astro": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-satteri": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/starlight": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.40.0.tgz",
+      "integrity": "sha512-H1NBIXx4Xw6YzKMsoMkazYxFgnTTj6pD4IReUGWj1fqw82AOAgj+WnZLpTDWRExf3b9ZM7Popbl583i4IvDNVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.0",
+        "@astrojs/mdx": "^6.0.2",
+        "@astrojs/sitemap": "^3.7.2",
+        "@pagefind/default-ui": "^1.3.0",
+        "@types/hast": "^3.0.4",
+        "@types/js-yaml": "^4.0.9",
+        "@types/mdast": "^4.0.4",
+        "astro-expressive-code": "^0.43.1",
+        "bcp-47": "^2.1.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-select": "^6.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "hastscript": "^9.0.1",
+        "i18next": "^26.0.7",
+        "js-yaml": "^4.1.1",
+        "klona": "^2.0.6",
+        "magic-string": "^0.30.21",
+        "mdast-util-directive": "^3.1.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "mdast-util-to-string": "^4.0.0",
+        "pagefind": "^1.5.2",
+        "rehype": "^13.0.2",
+        "rehype-format": "^5.0.1",
+        "remark-directive": "^4.0.0",
+        "ultrahtml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-satteri": "^0.2.0",
+        "astro": "^6.4.5"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-satteri": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/telemetry": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
+      "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.4.0",
+        "dset": "^3.1.4",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
+        "which-pm-runs": "^1.1.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+      "integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.2",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@expressive-code/core": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.43.1.tgz",
+      "integrity": "sha512-H4rUJXKyS6y2q9Ig9bIp3dFhWhkZQIeH/jRGl3DROlslrGvfD4OC9qzmvKEFExm+/DtdvvHMQ8/Olmrcfxp+wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.0.4",
+        "hast-util-select": "^6.0.2",
+        "hast-util-to-html": "^9.0.1",
+        "hast-util-to-text": "^4.0.1",
+        "hastscript": "^9.0.0",
+        "postcss": "^8.4.38",
+        "postcss-nested": "^6.0.1",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1"
+      }
+    },
+    "node_modules/@expressive-code/plugin-frames": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.43.1.tgz",
+      "integrity": "sha512-tENfLw2UDeq5h749tTLvUtQYvgjIiQc6W7PBCR5xQ4yuE/QftManKJfUQjwJo6RRsAimVQDN4alhFTJ3aq1Khg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.43.1"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.43.1.tgz",
+      "integrity": "sha512-NdceinYEROXODNgB/ix+7oCdIg+nGyok+E+p2lU9YlWd1xKshXdXpmmptKfkuU27MJ5jjnfhMCI78YYBGi9GtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.43.1",
+        "shiki": "^4.0.2"
+      }
+    },
+    "node_modules/@expressive-code/plugin-text-markers": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.43.1.tgz",
+      "integrity": "sha512-JWf8wdbZSNoGY4TFv3lmt3/NNDaCP7iYL6rRYD05g8YYjKL62hKUHLl5+B47+v0+bqbuMhXDN7qz2wywFUvMkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.43.1"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.5.2.tgz",
+      "integrity": "sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-iterate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/astro": {
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^4.0.0",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
+        "@astrojs/telemetry": "3.3.2",
+        "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
+        "@oslojs/encoding": "^1.1.0",
+        "@rollup/pluginutils": "^5.3.0",
+        "aria-query": "^5.3.2",
+        "axobject-query": "^4.1.0",
+        "ci-info": "^4.4.0",
+        "clsx": "^2.1.1",
+        "common-ancestor-path": "^2.0.0",
+        "cookie": "^1.1.1",
+        "devalue": "^5.8.1",
+        "diff": "^8.0.3",
+        "dset": "^3.1.4",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.27.3",
+        "flattie": "^1.1.1",
+        "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
+        "github-slugger": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "js-yaml": "^4.1.1",
+        "jsonc-parser": "^3.3.1",
+        "magic-string": "^0.30.21",
+        "magicast": "^0.5.2",
+        "mrmime": "^2.0.1",
+        "neotraverse": "^0.6.18",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.4",
+        "rehype": "^13.0.2",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
+        "tinyglobby": "^0.2.15",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.7.4",
+        "unist-util-visit": "^5.1.0",
+        "unstorage": "^1.17.5",
+        "vfile": "^6.0.3",
+        "vite": "^7.3.2",
+        "vitefu": "^1.1.2",
+        "xxhash-wasm": "^1.1.0",
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "astro": "bin/astro.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro-expressive-code": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.43.1.tgz",
+      "integrity": "sha512-xddgwQxFRwpnnAnU7kSfrO82SsOAq7sQrYpXxVcrN9k/0aqNlTH2+mLrOMm1wXm6jdFKepst3hd8/qWojwuunw==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-expressive-code": "^0.43.1"
+      },
+      "peerDependencies": {
+        "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "license": "MIT"
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/expressive-code": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.43.1.tgz",
+      "integrity": "sha512-JdOzanoU825iNvslmk6Kg8Ro61eSHmDK2Zz7BynOxObVrpIXZNzrIZOwQO2uDQcGsjSYShL/8vTrXgeWYnq3NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.43.1",
+        "@expressive-code/plugin-frames": "^0.43.1",
+        "@expressive-code/plugin-shiki": "^0.43.1",
+        "@expressive-code/plugin-text-markers": "^0.43.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flattie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.2"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-whitespace-sensitive-tag-names": "^3.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/html-whitespace-sensitive-tag-names": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/i18next": {
+      "version": "26.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.2.tgz",
+      "integrity": "sha512-QQkXAM1sPDHqhxMQuBeHVMUn6mJchF+wdpOoQerciLAFqO3ZYdxO0EUbeEhruyutnNwpUQIITDVzLjwnNL0T1w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-definitions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neotraverse": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-latin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "@types/unist": "^3.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-modify-children": "^4.0.0",
+        "unist-util-visit-children": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "rehype-parse": "^9.0.0",
+        "rehype-stringify": "^10.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-expressive-code": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.43.1.tgz",
+      "integrity": "sha512-CUOGQVlUcSMSXZgpcq9xL6B+dZqnI3w1R6EZj932XpGgj2Hmy7H6oMqa9W/Z7X2HOILWLWhqu1b9kuYcD+nd6w==",
+      "license": "MIT",
+      "dependencies": {
+        "expressive-code": "^0.43.1"
+      }
+    },
+    "node_modules/rehype-format": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
+      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-format": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-smartypants": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+      "license": "MIT",
+      "dependencies": {
+        "retext": "^9.0.0",
+        "retext-smartypants": "^6.0.0",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retext": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "retext-latin": "^4.0.0",
+        "retext-stringify": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-latin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "parse-latin": "^7.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/engine-oniguruma": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+      "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
+      "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
+      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.1.0",
+        "ofetch": "^1.5.1",
+        "ohash": "^2.0.11"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-modify-children": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "array-iterate": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-children": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/which-pm-runs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mlx-atomistic-site",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/starlight": "^0.40.0",
+    "astro": "^6.4.5",
+    "sharp": "^0.34.0"
+  }
+}

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22d3ee"/>
+      <stop offset="1" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0b0c"/>
+  <circle cx="32" cy="32" r="6" fill="url(#g)"/>
+  <ellipse cx="32" cy="32" rx="22" ry="9" stroke="url(#g)" stroke-width="2.5" opacity="0.85"/>
+  <ellipse cx="32" cy="32" rx="22" ry="9" transform="rotate(60 32 32)" stroke="url(#g)" stroke-width="2.5" opacity="0.55"/>
+  <ellipse cx="32" cy="32" rx="22" ry="9" transform="rotate(120 32 32)" stroke="url(#g)" stroke-width="2.5" opacity="0.35"/>
+</svg>

--- a/site/src/assets/logo.svg
+++ b/site/src/assets/logo.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22d3ee"/>
+      <stop offset="1" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="6" fill="url(#g)"/>
+  <ellipse cx="32" cy="32" rx="26" ry="11" stroke="url(#g)" stroke-width="2.5" opacity="0.85"/>
+  <ellipse cx="32" cy="32" rx="26" ry="11" transform="rotate(60 32 32)" stroke="url(#g)" stroke-width="2.5" opacity="0.55"/>
+  <ellipse cx="32" cy="32" rx="26" ry="11" transform="rotate(120 32 32)" stroke="url(#g)" stroke-width="2.5" opacity="0.35"/>
+</svg>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,0 +1,10 @@
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
+
+const docs = defineCollection({
+  loader: docsLoader(),
+  schema: docsSchema(),
+});
+
+export const collections = { docs };

--- a/site/src/content/docs/benchmarks/README.md
+++ b/site/src/content/docs/benchmarks/README.md
@@ -1,0 +1,124 @@
+---
+title: "Benchmarks"
+---
+
+
+This directory collects benchmark results in a form that is comparable across
+machines, runs, and engines. Each file documents one benchmark: what was run,
+on what hardware, with what config, and how to reproduce it.
+
+## Engine label convention
+
+Per the runtime-boundaries doc, every result carries an engine tag:
+
+- `mlx_atomistic` — the project's MLX/Metal runtime (product output)
+- `openmm-reference` — OpenMM, used as a reference ceiling, not a product path
+- `lammps-reference` — LAMMPS, used as a reference for GPU/OpenCL semantics
+
+Filenames lead with the engine tag plus the platform and system, e.g.
+`openmm-opencl-apoa1.md`.
+
+## File template
+
+Each result file should answer, in order:
+
+1. **Result table** — ns/day (and any other primary metric) for each test,
+   with one column per platform variant if applicable.
+2. **Provenance** — engine version, device, host, date, commit if relevant.
+3. **Config** — timestep, cutoff, constraints, precision, ensemble. Match
+   OpenMM's public benchmark config when comparing against `openmm.org/benchmarks`.
+4. **Reproducer** — exact shell command that regenerates the JSON, plus the
+   path to the raw JSON output (kept under gitignored `results/`).
+5. **External comparison** — links to public reference numbers, with the
+   same config caveats called out.
+
+## Index
+
+| File | Engine | System | Platform | Host |
+|---|---|---|---|---|
+| [inventory-gap-matrix.md](./inventory-gap-matrix.md) | mlx_atomistic | benchmark inventory and Phase 3 gaps | N/A | N/A |
+| [benchmark-ladder.md](./benchmark-ladder.md) | mlx_atomistic/openmm-reference/lammps-reference | benchmark ladder and row decision value | Metal/OpenCL where available | local |
+| [same-workload-comparison-matrix.md](./same-workload-comparison-matrix.md) | mlx_atomistic/openmm-reference | planned same-workload comparison pairs | Metal/OpenCL where available | local |
+| [same-workload-openmm-comparison.md](./same-workload-openmm-comparison.md) | mlx_atomistic/openmm-reference | refreshed controlled same-workload comparison report | Metal/OpenCL where available | local |
+| [same-workload-dhfr-stretch.md](./same-workload-dhfr-stretch.md) | mlx_atomistic/openmm-reference | DHFR stretch status | Metal/OpenCL where available | local |
+| [performance-audit-baseline.md](./performance-audit-baseline.md) | mlx_atomistic | fast baseline audit and ranked backlog | Metal/OpenCL where available | local |
+| [m5max-reference-engines.md](./m5max-reference-engines.md) | openmm-reference/lammps-reference | M5 Max reference-engine manifest overview | OpenCL | Apple M5 Max |
+| [openmm-opencl-dhfr.md](./openmm-opencl-dhfr.md) | openmm-reference | DHFR (23k atoms) | OpenCL | Apple M5 Max |
+| [openmm-opencl-apoa1.md](./openmm-opencl-apoa1.md) | openmm-reference | ApoA1 (92k atoms) | OpenCL | Apple M5 Max |
+| [openmm-opencl-amber20.md](./openmm-opencl-amber20.md) | openmm-reference | Cellulose (409k) + STMV (1.07M atoms) | OpenCL | Apple M5 Max |
+| [lammps-opencl-m5max.md](./lammps-opencl-m5max.md) | lammps-reference | official LAMMPS five-case benchmark set | OpenCL | Apple M5 Max |
+
+The inventory appears first. Result files are ordered by system size, smallest
+first, so the scaling story reads top-to-bottom.
+
+## Command Matrix
+
+Fast developer commands are routine local checks. They must not require OpenMM,
+LAMMPS, OpenCL, large downloaded fixtures, or committed raw outputs.
+
+| Command | Engine | Tier | Output |
+| --- | --- | --- | --- |
+| `uv run pytest tests/test_benchmarks.py -q` | mlx_atomistic | fast developer | pytest stdout; temporary test files only |
+| `uv run python -m mlx_atomistic.benchmarks.mm_force_terms --evaluations 1 --particles 16 --json` | mlx_atomistic | fast developer | normalized JSON on stdout |
+| `uv run python -m mlx_atomistic.benchmarks.md_acceleration --sizes 16 --evaluations 1 --json` | mlx_atomistic | fast developer | normalized JSON on stdout |
+| `uv run python -m mlx_atomistic.benchmarks.md_performance --sizes 32 --steps 1 --sample-interval 1 --diagnostic-interval 1 --evaluation-interval 1 --json` | mlx_atomistic | fast developer | normalized JSON on stdout |
+| `uv run python -m mlx_atomistic.benchmarks.pme_performance --fixture-dir results/missing-pme-fixture --iterations 1 --warmups 0 --json` | mlx_atomistic | fast developer blocked-path smoke | normalized blocked JSON on stdout |
+
+Opt-in performance commands are non-CI and non-routine. They may need Apple
+Silicon/Metal, prepared fixtures, OpenMM/LAMMPS from the `dev` group, OpenCL, or
+downloaded inputs. Raw JSON/CSV belongs under gitignored `results/`; committed
+Markdown summaries should cite those raw paths and reproduction commands.
+
+| Command | Engine | Tier | Output |
+| --- | --- | --- | --- |
+| `uv run python -m mlx_atomistic.benchmarks.md_performance --include-large --steps 100 --json > results/mlx-md-performance.json` | mlx_atomistic | opt-in performance | raw JSON under `results/` |
+| `uv run python -m mlx_atomistic.benchmarks.md_acceleration --include-large --evaluations 10 --json > results/mlx-md-acceleration.json` | mlx_atomistic | opt-in performance | raw JSON under `results/` |
+| `uv run python -m mlx_atomistic.benchmarks.pme_performance --out-dir results/pme-performance --json` | mlx_atomistic | opt-in performance | raw JSON under `results/pme-performance/` |
+| `uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-implicit --steps 1 --json > results/same-workload-openmm-comparison/mlx-dhfr-implicit.json` | mlx_atomistic | opt-in runnable stretch smoke | normalized runnable JSON under `results/` |
+| `uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-explicit-pme --steps 1 --json > results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json` | mlx_atomistic | opt-in blocked-path stretch | normalized blocked JSON under `results/` until PME neutrality policy is resolved |
+| `uv run python scripts/benchmark_openmm_opencl.py --platform OpenCL --particles 4096 --steps 1000 --json --csv results/openmm-opencl-synthetic.csv > results/openmm-opencl-synthetic.json` | openmm-reference | opt-in reference | raw JSON/CSV under `results/` |
+| `uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-implicit --platform Reference --steps 1 --json > results/same-workload-openmm-comparison/openmm-dhfr-implicit.json` | openmm-reference | opt-in reference shape check | raw JSON under `results/` |
+| `uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-explicit-pme --platform Reference --steps 1 --json > results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json` | openmm-reference | opt-in reference shape check | raw JSON under `results/` |
+| `uv run python scripts/benchmark_openmm_opencl.py --platform DefinitelyMissing --particles 16 --steps 1 --json` | openmm-reference | fast blocked-path smoke | normalized blocked JSON on stdout |
+| `uv run python scripts/benchmark_lammps_opencl.py --particles 16 --steps 1 --json` | lammps-reference | opt-in reference / blocked-path smoke | normalized JSON or blocked JSON on stdout |
+| `uv run python scripts/benchmark_m5max_reference.py environment --json` | openmm-reference/lammps-reference | reference environment probe | normalized JSON on stdout |
+| `uv run python scripts/benchmark_m5max_reference.py openmm --dry-run --json` | openmm-reference | opt-in reference command plan | raw path plan under `results/m5max-reference/openmm/` |
+| `uv run python scripts/benchmark_m5max_reference.py lammps --classify-only --json` | lammps-reference | opt-in official case classification | normalized diagnostic JSON on stdout |
+| `uv run python scripts/benchmark_m5max_reference.py run --seconds 30 --json` | openmm-reference/lammps-reference | host-only reference benchmark suite | raw manifest under `results/m5max-reference/` |
+| `uv run python scripts/benchmark_m5max_reference.py validate --manifest results/m5max-reference/manifest.json --json` | openmm-reference/lammps-reference | reference manifest validation | validation JSON on stdout |
+
+## External inputs
+
+Some benchmarks pull input data from upstream sources. The reproducer
+commands handle the download automatically. Downloaded data lands in
+`results/inputs/` (gitignored), with a one-line provenance record in
+`results/inputs/README.md`. Re-running a reproducer is the recommended way
+to refresh; nothing in `results/inputs/` needs to be committed.
+
+## Raw outputs
+
+Raw JSON/CSV produced by the benchmark scripts is written to `results/`,
+which is gitignored. The synthesized markdown report in this directory is
+the committed record; rerunning the reproducer should reproduce the JSON.
+
+## Reference Summaries
+
+The existing OpenMM reports are committed normalized summaries over raw
+reference inputs. Their raw JSON files remain under gitignored `results/` and
+may come from either this repository's synthetic fail-soft script or OpenMM's
+stock upstream benchmark script:
+
+| Summary | Raw reference input | Normalized fields |
+| --- | --- | --- |
+| [openmm-opencl-dhfr.md](./openmm-opencl-dhfr.md) | `results/openmm-opencl-dhfr-m5max.json` from `vendors/openmm/examples/benchmarks/benchmark.py` | engine, fixture/system, atom count, timing metric, runtime, hardware, raw output path |
+| [openmm-opencl-apoa1.md](./openmm-opencl-apoa1.md) | `results/openmm-opencl-apoa1-m5max.json` from `vendors/openmm/examples/benchmarks/benchmark.py` | engine, fixture/system, atom count, timing metric, runtime, hardware, raw output path |
+| [openmm-opencl-amber20.md](./openmm-opencl-amber20.md) | `results/openmm-opencl-amber20-m5max.json` from `vendors/openmm/examples/benchmarks/benchmark.py` | engine, fixture/system, atom count, timing metric, runtime, hardware, raw output path |
+| [m5max-reference-engines.md](./m5max-reference-engines.md) | `results/m5max-reference/manifest.json` from `scripts/benchmark_m5max_reference.py` | engine provenance, required case coverage, OpenMM rows, LAMMPS statuses, raw output paths |
+| [lammps-opencl-m5max.md](./lammps-opencl-m5max.md) | `results/m5max-reference/lammps/*.json` from `scripts/benchmark_m5max_reference.py` | official input paths, style mapping, acceleration classification, loop time or blocker |
+
+`scripts/benchmark_openmm_opencl.py` and
+`scripts/benchmark_lammps_opencl.py` emit the shared normalized JSON schema
+directly. When the optional reference engine, OpenCL platform, fixture, or GPU
+support is unavailable, they return `status: "blocked"` with a concrete
+`blocker` instead of turning reference-engine availability into a routine test
+failure.

--- a/site/src/content/docs/benchmarks/benchmark-ladder.md
+++ b/site/src/content/docs/benchmarks/benchmark-ladder.md
@@ -1,0 +1,47 @@
+---
+title: "Benchmark Ladder"
+---
+
+
+Date: 2026-05-23
+
+This ladder organizes `mlx_atomistic` benchmark rows by decision value. It is
+not a ranking across engines. Reference rows are used only where operation
+semantics and metric families line up.
+
+## Layer Rules
+
+| Layer | Purpose | Comparable rule |
+| --- | --- | --- |
+| micro/kernel | Isolate local MLX costs such as force terms, neighbor work, virtual-site reconstruction, and synchronization. | Diagnostic unless a reference engine exposes the same operation and metric. |
+| controlled MD | Run tiny same-workload MD rows with matching atom and step semantics. | Comparable only when both sides are `ok` and use the same metric family. |
+| feature physics | Time MLX feature rows for GBSA/OBC, TIP4P-Ew, soft-core/lambda, and replica exchange. | Comparable only after a matching OpenMM controlled case exists; otherwise diagnostic. |
+| scaling | Sweep sizes or policies to tell fixed overhead from force-evaluation, neighbor-list, or memory-pressure costs. | Usually MLX-only diagnostic; reference parity is separate. |
+| reference parity | Map controlled OpenMM rows to MLX rows and allow ratios only for matching metrics. | Comparable, diagnostic, or blocked from normalized payload status. |
+| stretch | Track real-system rows such as DHFR until MLX artifacts and runtime parity exist. | Blocked or deferred until the MLX system, physics, and metric match the reference. |
+
+## Must-Ship Rows
+
+| Row | Layer | MLX command | OpenMM command | LAMMPS mapping | Metric family | Raw output | Comparability status | Decision value |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `lj-synthetic-loop` | controlled MD; reference parity | `uv run python -m mlx_atomistic.benchmarks.md_performance --sizes 32 --steps 1 --sample-interval 1 --diagnostic-interval 1 --evaluation-interval 1 --json` | `uv run python scripts/benchmark_openmm_opencl.py --platform OpenCL --particles 32 --steps 1 --warmup-steps 0 --spacing-nm 1.0 --json` | Simple LJ-like smoke mapping may use `uv run python scripts/benchmark_lammps_opencl.py --particles 32 --steps 1 --json`; first-class LAMMPS parity is deferred. | `steps/s`; `ns/day` only when timestep and step semantics are aligned | `results/same-workload-openmm-comparison/mlx-lj-synthetic-loop.json`; `results/same-workload-openmm-comparison/openmm-lj-synthetic-loop.json`; optional `results/performance-audit-harness-hardening/lammps-fast.json` | `comparable` only for MLX/OpenMM rows with matching atom count, step count, and timing metric; LAMMPS is diagnostic/deferred | Decide whether tiny full-loop overhead deserves optimization before larger-system work. |
+| `gbsa-obc-small` | feature physics; reference parity | `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json` | `uv run python scripts/benchmark_openmm_opencl.py --case gbsa-obc-small --platform Reference --particles 4 --steps 1 --json` | deferred; no LAMMPS mapping in this slice | `ms/eval` latency; no mixed unit ratio | MLX combined raw source: `results/same-workload-openmm-comparison/mlx-phase3-controlled.json`; MLX row extract: `results/same-workload-openmm-comparison/mlx-gbsa-obc-small.json`; OpenMM: `results/same-workload-openmm-comparison/openmm-gbsa-obc-small.json`; summary: `results/same-workload-openmm-comparison/summary.json`; audit source `results/performance-audit-harness-hardening/phase3-physics-fast.json` | `comparable` for the refreshed MLX/OpenMM Reference latency row; OpenMM reports `fixture: gbsa_obc_small`, `status: ok`, and `obc_force_setup` | Decide whether GBSA/OBC force evaluation is an optimization target from the controlled latency row. |
+| `tip4p-ew-water` | micro/kernel; feature physics; reference parity | `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json`; micro row: `uv run python -m mlx_atomistic.benchmarks.mm_force_terms --evaluations 1 --particles 16 --json` | `uv run python scripts/benchmark_openmm_opencl.py --case tip4p-ew-water --platform Reference --particles 4 --steps 1 --json` | deferred; no LAMMPS mapping in this slice | `ms/eval` latency for virtual-site reconstruction; no mixed unit ratio | MLX combined raw source: `results/same-workload-openmm-comparison/mlx-phase3-controlled.json`; MLX row extract: `results/same-workload-openmm-comparison/mlx-tip4p-ew-water.json`; OpenMM: `results/same-workload-openmm-comparison/openmm-tip4p-ew-water.json`; summary: `results/same-workload-openmm-comparison/summary.json`; audit sources `results/performance-audit-harness-hardening/phase3-physics-fast.json` and `results/performance-audit-harness-hardening/mm-force-terms-fast.json` | `comparable` for the refreshed MLX/OpenMM Reference virtual-site reconstruction latency row; OpenMM reports `operation_semantics: virtual_site_reconstruction` and `openmm_operation: Context.computeVirtualSites` | Decide whether TIP4P-Ew overhead is reconstruction-specific or part of a broader water-workload cost. |
+| `soft-core-lambda` | feature physics | `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json` | deferred mapping | deferred | `ms/eval` for lambda-grid energy/force derivative work | `results/performance-audit-harness-hardening/phase3-physics-fast.json`; future same-workload path under `results/same-workload-openmm-comparison/` when mapped | `diagnostic`; reference parity deferred | Decide whether lambda derivative work needs a larger opt-in sweep before optimization. |
+| `replica-exchange` | feature physics | `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json` | deferred mapping | deferred | `ms/eval`, per-replica throughput, aggregate replica throughput, swap/history counters | `results/performance-audit-harness-hardening/phase3-physics-fast.json` | `diagnostic`; reference parity deferred | Decide whether replica execution, history materialization, or swap bookkeeping is the next MLX bottleneck. |
+| `scaling-sweep` | scaling | `uv run python -m mlx_atomistic.benchmarks.md_acceleration --include-large --evaluations 10 --json`; `uv run python -m mlx_atomistic.benchmarks.md_performance --include-large --steps 100 --json` | deferred until a controlled OpenMM sweep is specified | deferred except simple LJ-like smoke notes | `ms/eval`, neighbor-build timing, steps/s; keep units separate by row | `results/mlx-md-acceleration.json`; `results/mlx-md-performance.json`; audit smoke sources under `results/performance-audit-harness-hardening/` | `diagnostic` for MLX scaling; reference parity deferred | Decide whether overhead is fixed, neighbor-list dominated, memory-pressure dominated, or force-evaluation dominated. |
+| `dhfr-implicit` | stretch; reference parity | `uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-implicit --steps 1 --json` | `uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-implicit --platform Reference --steps 1 --json` | deferred | `ns/day` for matching one-step GBSA/OBC rows | MLX: `results/same-workload-openmm-comparison/mlx-dhfr-implicit.json`; OpenMM Reference: `results/same-workload-openmm-comparison/openmm-dhfr-implicit.json`; summary: `results/same-workload-openmm-comparison/summary.json`; OpenMM OpenCL context: `results/openmm-opencl-dhfr-m5max.json` | `comparable` for the one-step MLX/OpenMM Reference smoke row; broader OpenCL context remains separate | Track the smaller DHFR real-system path and harden MLX artifact/runtime behavior before broad performance claims. |
+| `dhfr-explicit-pme` | stretch; reference parity | `uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-explicit-pme --steps 1 --json` | `uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-explicit-pme --platform Reference --steps 1 --json` | deferred | `ns/day` only after matching runnable MLX and OpenMM rows exist | MLX: `results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json`; OpenMM Reference: `results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json`; OpenMM OpenCL context: `results/openmm-opencl-dhfr-m5max.json` | `blocked`; PME artifact policy requires neutrality and local Amber20/JAC has `net_charge=-11`; no ratio | Track the production-like DHFR PME path and resolve charged-system/neutralization policy before PME runtime optimization. |
+
+## Reference Coverage Notes
+
+- OpenMM parity rows belong under `scripts/` and emit normalized `ok`,
+  `diagnostic`, or `blocked` payloads. Ratios are valid only for matching
+  `ok` rows.
+- LAMMPS is deferred for this ladder except for simple LJ-like smoke notes. Do
+  not map LAMMPS materials, protein, or package-specific benchmark families to
+  MLX rows without a separate same-workload plan.
+- DHFR now has explicit same-workload row IDs. `dhfr-implicit` is runnable as a
+  one-step GBSA/OBC smoke row; `dhfr-explicit-pme` remains blocked on PME
+  artifact neutrality. ApoA1, Cellulose, and STMV OpenMM reports remain
+  reference context until matching MLX workloads exist.

--- a/site/src/content/docs/benchmarks/inventory-gap-matrix.md
+++ b/site/src/content/docs/benchmarks/inventory-gap-matrix.md
@@ -1,0 +1,76 @@
+---
+title: "Benchmark Inventory And Gap Matrix"
+---
+
+
+Date: 2026-05-22
+
+Scope: `.agent/work/2026-05-22-performance-audit-harness-hardening`.
+This inventory maps the benchmark surface and tracks which Phase 3 coverage
+gaps were closed by the harness-hardening change.
+External OpenMM, LAMMPS, OpenBenchmarking, and MLX material is used only as
+benchmark-design context, not as a pass/fail target for `mlx_atomistic`.
+
+## Tier Rules
+
+| Tier | Purpose | Required availability | Result location |
+| --- | --- | --- | --- |
+| Fast developer | Smoke-check importable MLX benchmark modules and JSON/CSV shape. | `uv run` environment only; no mandatory OpenMM, LAMMPS, OpenCL, or large fixture. | Temporary pytest paths, stdout JSON, or optional local CSV. |
+| Opt-in performance | Larger Apple Silicon runs, prepared production fixtures, and reference-engine context. | Local accelerator, optional OpenMM/LAMMPS/dev reference setup, and optional gitignored fixtures. | Raw JSON/CSV under gitignored `results/`; committed summaries under `docs/benchmarks/`. |
+
+## Current MLX Benchmark Modules
+
+| Module | Current coverage | Test/doc evidence | Result/raw-output location | Tier | Phase 3 gap |
+| --- | --- | --- | --- | --- | --- |
+| `src/mlx_atomistic/benchmarks/lj_md.py` | LJ MD modes and CSV output. | `tests/test_benchmarks.py::test_lj_benchmark_csv_smoke` | Caller-provided `--csv`; stdout otherwise. | Fast developer | Does not cover virtual sites, TIP4P-Ew, GBSA/OBC, soft-core/lambda, or replica exchange. |
+| `src/mlx_atomistic/benchmarks/md_performance.py` | End-to-end synthetic LJ MD throughput, neighbor policy, cadence, synchronization, finite output, and MLX runtime metadata. | `tests/test_benchmarks.py` benchmark smoke coverage. | Stdout JSON/CSV when invoked by module; future raw outputs should land in `results/`. | Fast developer now; opt-in for larger sizes. | No Phase 3 feature-specific row. |
+| `src/mlx_atomistic/benchmarks/md_acceleration.py` | Neighbor build versus force evaluation split, backend policy, pair representation, and waste counters. | `tests/test_benchmarks.py` benchmark smoke coverage. | Stdout JSON/CSV when invoked by module. | Fast developer now; opt-in for larger sizes. | No virtual-site, GBSA/OBC, soft-core/lambda, or replica-exchange overhead row. |
+| `src/mlx_atomistic/benchmarks/cadence_sensitivity.py` | Reporter/evaluation cadence and synchronization/materialization counts. | `tests/test_benchmarks.py` benchmark smoke coverage. | Stdout JSON/CSV when invoked by module. | Fast developer | Can inform future replica exchange history/materialization timing, but does not cover replica exchange today. |
+| `src/mlx_atomistic/benchmarks/mm_force_terms.py` | Bonded autodiff, neighbor-list build, LJ pair eval, direct Coulomb, combined nonbonded, constraints, and TIP4P-Ew virtual-site reconstruction/force redistribution micro-rows. | `tests/test_benchmarks.py::test_force_term_benchmark_includes_profile_rows` | Caller-provided `--csv`; stdout JSON with `--json`. | Fast developer | Still a microbenchmark surface, not a production-scale advanced-water workload. |
+| `src/mlx_atomistic/benchmarks/phase3_physics.py` | Fast normalized rows for virtual sites, TIP4P-Ew M-site reconstruction, GBSA/OBC energy/forces and surface-area term, soft-core/lambda derivative grid, and two-replica exchange. | `tests/test_benchmarks.py::test_phase3_physics_benchmark_covers_required_feature_rows` | Caller-provided `--csv`; stdout JSON with `--json`; raw audit outputs under `results/performance-audit-harness-hardening/`. | Fast developer | Synthetic probes only; larger opt-in rows are still needed before optimization claims. |
+| `src/mlx_atomistic/benchmarks/pme_performance.py` | PME stage profiling against a prepared parity fixture; blocked payload when fixture data is absent. | `tests/test_benchmarks.py` benchmark smoke coverage. | Default fixture under `results/md-engine-structural-gap-closure/pme-parity`; default raw output under `results/md-engine-structural-gap-closure/baseline/pme-profile.json`. | Opt-in performance; blocked-path smoke is fast. | Adjacent to TIP4P-Ew water work but does not benchmark TIP4P-Ew virtual-site overhead. |
+| `src/mlx_atomistic/benchmarks/ewald_reference.py` | Small-system Ewald correctness/backend timing, explicitly not GPCRmd-scale PME. | `tests/test_benchmarks.py::test_ewald_reference_benchmark_json_and_csv_smoke` | Caller-provided `--csv`; stdout JSON with `--json`. | Fast developer | Does not cover soft-core/lambda derivatives or advanced water models. |
+| `src/mlx_atomistic/benchmarks/stability.py` | NVE/NVT stability diagnostics for small systems. | `tests/test_benchmarks.py::test_stability_cli_json_and_csv_smoke` | Caller-provided `--csv`; stdout JSON with `--json`. | Fast developer | Could catch stability impacts after Phase 3 rows exist, but no Phase 3 timing row today. |
+| `src/mlx_atomistic/benchmarks/validation_gauntlet.py` | Finite-difference force validation cases. | `tests/test_benchmarks.py::test_validation_gauntlet_cli_json_and_csv` | Caller-provided `--csv`; stdout JSON with `--json`. | Fast developer | Validation-oriented, not a performance row for Phase 3 features. |
+| `src/mlx_atomistic/benchmarks/schema.py` | Shared normalized benchmark fields and default command helpers. | Imported by current benchmark modules and exercised by `tests/test_benchmarks.py`. | N/A helper module. | Fast developer support | New benchmark rows should use this helper to keep report joins simple. |
+| `src/mlx_atomistic/benchmarks/gpcrmd_runtime.py` | Shared GPCRmd runtime reporting helpers for output directory size, resident memory, PME mesh summary, and diagnostic reductions. | Covered indirectly by production/probe workflows and available to benchmark reports; no dedicated smoke test in `tests/test_benchmarks.py` today. | N/A helper module; consumers should write raw run artifacts under `results/`. | Opt-in performance support | Helper-only surface; does not create Phase 3 feature timing rows by itself. |
+| DFT benchmark modules: `dft_scf.py`, `dft_operator.py`, `dft_pseudopotential.py`, `dft_geometry.py`, `dft_nonlocal.py`, `dft_solver.py`, `dft_spin_kpoints.py`, `dft_relaxation.py` | DFT operation and solver smoke timings. | DFT smoke tests in `tests/test_benchmarks.py`. | Caller-provided `--csv`; stdout JSON with `--json`. | Fast developer | Out of the Phase 3 MD physics gap set. |
+
+## Reference Scripts And Docs
+
+| Surface | Current coverage | Test/doc evidence | Result/raw-output location | Tier | Boundary |
+| --- | --- | --- | --- | --- | --- |
+| `scripts/benchmark_openmm_opencl.py` | Synthetic OpenMM/OpenCL LJ reference benchmark with blocked payload for unavailable platform. | `tests/test_benchmarks.py::test_openmm_opencl_unavailable_platform_non_json_does_not_crash`; docs under `docs/benchmarks/openmm-opencl-*.md`. | Caller-provided `--csv`; raw OpenMM report examples under `results/openmm-opencl-*.json`. | Opt-in reference; blocked smoke is fast. | `openmm-reference`, design context only. |
+| `scripts/run_openmm_mlx_parity.py` | OpenMM versus MLX parity workflow support. | Existing parity tests outside this slice; not a benchmark smoke in `tests/test_benchmarks.py`. | Local run artifacts under `results/` when invoked. | Opt-in reference/context | Reference parity context, not product runtime dependency. |
+| `scripts/run_openmm_mlx_npt_parity.py` | NPT parity workflow support. | Existing NPT/parity tests outside this slice. | Local run artifacts under `results/` when invoked. | Opt-in reference/context | Reference parity context, not product runtime dependency. |
+| `scripts/run_openmm_production_md_reference.py` | Production MD reference command surface. | Existing production reference tests outside this slice. | Local run artifacts under `results/` when invoked. | Opt-in reference/context | OpenMM context only; not a pass/fail throughput target. |
+| `scripts/run_mlx_production_md_probe.py` | MLX production-probe command surface. | Existing production probe tests outside this slice. | Local run artifacts under `results/` when invoked. | Opt-in performance | MLX product probe, but not a routine fast gate. |
+| `scripts/benchmark_lammps_opencl.py` | Synthetic LAMMPS/OpenCL reference benchmark with normalized ok or blocked payloads. | `tests/test_benchmarks.py::test_lammps_opencl_reference_payload_is_normalized`; docs command matrix and baseline audit. | Caller-provided `--csv`; stdout JSON with `--json`; raw audit output under `results/performance-audit-harness-hardening/lammps-fast.json`. | Opt-in reference; blocked smoke is fast. | `lammps-reference`, design context only. |
+| `docs/benchmarks/README.md` | Engine labels, file template, index, external input policy, raw-output policy. | This inventory is linked from README. | Committed Markdown in `docs/benchmarks/`. | Documentation | Defines `mlx_atomistic`, `openmm-reference`, and `lammps-reference`. |
+| `docs/benchmarks/openmm-opencl-dhfr.md`, `openmm-opencl-apoa1.md`, `openmm-opencl-amber20.md` | OpenMM OpenCL summary reports for DHFR, ApoA1, Cellulose, and STMV on Apple M5 Max. | Indexed from `docs/benchmarks/README.md`. | Raw JSON paths named under gitignored `results/`. | Opt-in reference documentation | External/reference comparison only. |
+
+## Phase 3 Coverage Gaps
+
+| Feature | Current implementation/test evidence | Current benchmark placement | Remaining benchmark gap |
+| --- | --- | --- | --- |
+| virtual sites | `tests/test_virtual_sites.py` covers virtual-site position reconstruction, force redistribution, artifact round trip, runner propagation, and simulation configuration plumbing. | `phase3_physics.py` covers reconstruction and force redistribution; `mm_force_terms.py` adds synchronized TIP4P-Ew micro-rows. | Larger opt-in advanced-water workload. |
+| TIP4P-Ew | `tests/test_virtual_sites.py` covers `tip4p_ew_virtual_site`, reference geometry, prepared-system round trip, and artifact build exposure. | `phase3_physics.py` emits a TIP4P-Ew M-site row; `mm_force_terms.py` emits TIP4P-Ew reconstruction and redistribution rows. | Couple the row to a larger nonbonded/PME workload before optimization claims. |
+| GBSA/OBC | `tests/test_gbsa.py` covers GBSA surface-area energy, OBC force finite-difference behavior, OpenMM OBC reference energy, artifact loading, and save/load parameters. | `phase3_physics.py` emits OBC energy/force and surface-area rows. | Scaling row over larger atom counts. |
+| soft-core/lambda | `tests/test_soft_core.py` covers finite overlap, endpoint equivalence, finite-difference `energy_forces_dlambda`, wrapper delegation, artifact metadata, and fail-closed non-cutoff electrostatics. | `phase3_physics.py` emits an `energy_forces_dlambda` lambda-grid row. | Larger lambda-grid sweep. |
+| replica exchange | `tests/test_replica_exchange.py` covers Metropolis probability, adjacent swaps, lambda-scaled Hamiltonians, odd/even pairing, metadata validation, and unsupported runtime inputs. | `phase3_physics.py` reports per-replica throughput, swap counts, acceptance rate, and history materialization count. | Larger opt-in multi-replica workload. |
+
+## External Context Caveats
+
+| Context source | Useful design signal | Caveat |
+| --- | --- | --- |
+| OpenMM | Public reports commonly use `ns/day` on named systems such as DHFR, ApoA1, Cellulose, and STMV, with platform, precision, timestep, constraints, hydrogen mass, ensemble, and cutoff/PME settings recorded. | OpenMM numbers are reference context only. They are not direct pass/fail targets for MLX because hardware, backend, precision, and engine semantics differ. |
+| LAMMPS | Official benchmark families cover LJ liquid, polymers, metals/EAM, granular systems, and protein/rhodopsin-style systems with atom counts, timesteps, packages, precision/backend, and loop-time style metrics. | LAMMPS coverage should stay opt-in and fail-soft; historical public numbers are context for scaling behavior, not target thresholds. |
+| OpenBenchmarking | The LAMMPS profile records repeatable run metadata and reports `ns/day` for rhodopsin/protein-sized systems with variance reporting. | OpenBenchmarking helps shape provenance and repetition fields; it is not an apples-to-apples MLX acceptance gate. |
+| MLX | Public MLX benchmark practice emphasizes operation-level timing, Apple Silicon device/runtime metadata, synchronization-aware measurements, and CPU/GPU/backend distinctions. | MLX context informs measurement hygiene for `mlx_atomistic`; it does not provide atomistic throughput targets by itself. |
+
+## Slice 1 Findings
+
+- The fast benchmark gate is currently centered on `tests/test_benchmarks.py`.
+- Current committed benchmark docs include OpenMM reference reports, the benchmark README, this inventory, and the baseline audit report.
+- Raw benchmark outputs should remain under gitignored `results/`; committed Markdown in `docs/benchmarks/` should summarize reproducible rows and cite raw output paths.
+- The Phase 3 named features now have normalized fast benchmark rows; remaining gaps are larger opt-in workloads for optimization validation.

--- a/site/src/content/docs/benchmarks/lammps-opencl-m5max.md
+++ b/site/src/content/docs/benchmarks/lammps-opencl-m5max.md
@@ -1,0 +1,76 @@
+---
+title: "LAMMPS OpenCL on Apple M5 Max"
+---
+
+
+Engine: `lammps-reference`. This report covers the five official top-level
+LAMMPS benchmark inputs from `vendors/lammps/bench/` on the single Apple M5 Max
+host. It does not describe `mlx_atomistic` runtime performance.
+
+## Result
+
+| Case | Description | Status | Acceleration class | Loop time, s | Blocker or caveat |
+| --- | --- | ---: | --- | ---: | --- |
+| `lj` | Atomic Lennard-Jones fluid | `ok` | `full_gpu_opencl` | 0.298473 | none |
+| `eam` | Bulk Cu EAM solid | `ok` | `full_gpu_opencl` | 0.725426 | none |
+| `chain` | FENE bead-spring polymer melt | `diagnostic` | `partial_gpu_opencl` | 0.544019 | bond and Langevin styles are not mapped to GPU styles |
+| `chute` | Granular chute flow | `diagnostic` | `cpu_only_diagnostic` | 0.108473 | no relevant mapped GPU/OpenCL styles in this build |
+| `rhodo` | Rhodopsin in solvated lipid bilayer | `blocked` | `partial_gpu_opencl` | N/A | PPPM double-precision build conflicts with the single-precision Apple GPU path |
+
+The raw records are under `results/m5max-reference/lammps/`. Each run copies the
+official input files into a case-local work directory before invoking LAMMPS, so
+the shared vendor tree stays unchanged.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| LAMMPS version | 20250722 |
+| Packaged executable | `.venv/lib/python3.13/site-packages/lammps/lmp` |
+| GPU package | `PKG_GPU=ON` |
+| GPU API | `opencl` |
+| GPU precision | `single` |
+| Device | Apple M5 Max |
+| Run command root | `UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py` |
+
+Do not rely on `.venv/bin/lmp` as the final reproducer. The harness bypasses the
+console script and records the active packaged executable.
+
+## Acceleration Mapping
+
+| Case | Relevant styles | GPU/OpenCL mapping |
+| --- | --- | --- |
+| `lj` | `pair lj/cut`, `fix nve` | both map to `lj/cut/gpu` and `nve/gpu` |
+| `eam` | `pair eam`, `fix nve` | both map to `eam/gpu` and `nve/gpu` |
+| `chain` | `bond fene`, `pair lj/cut`, `fix nve`, `fix langevin` | pair and NVE map to GPU; bond and Langevin do not |
+| `chute` | `pair gran/hooke/history`, `fix gravity`, `fix freeze`, `fix nve/sphere` | no mapped GPU styles in this local build |
+| `rhodo` | harmonic bonds, CHARMM angles/dihedrals, `lj/charmm/coul/long`, `pppm`, `shake`, `npt` | pair, PPPM, and NPT have GPU mappings; bonded terms and SHAKE do not |
+
+The classification is about this local LAMMPS OpenCL build, not about every
+possible LAMMPS build. A different build or precision setting can change the
+mapping and the `rhodo` outcome.
+
+## Blocked Case
+
+`rhodo` reaches PPPM initialization and then fails:
+
+```text
+ERROR: PPPM was compiled for double precision floating point but GPU device supports single precision only.
+```
+
+That is why the suite manifest status is `blocked` even though the manifest
+validates structurally. The failure is preserved in
+`results/m5max-reference/lammps/rhodo.json`, with the LAMMPS log under
+`results/m5max-reference/lammps/rhodo/work/log.lammps`.
+
+## Reproducer
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py lammps --classify-only --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py lammps --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py validate --manifest results/m5max-reference/manifest.json --json
+```
+
+Use a host terminal or approved outside-sandbox command for final GPU/OpenCL
+measurements. The sandbox can hide device access and should only be used for
+dry classification or schema tests.

--- a/site/src/content/docs/benchmarks/m5max-reference-engines.md
+++ b/site/src/content/docs/benchmarks/m5max-reference-engines.md
@@ -1,0 +1,102 @@
+---
+title: "M5 Max Reference Engines"
+---
+
+
+This page is the current single-machine reference benchmark map for OpenMM and
+LAMMPS on the Apple M5 Max host. These are reference-engine results, not
+`mlx_atomistic` runtime performance.
+
+## Run Summary
+
+| Field | Value |
+| --- | --- |
+| Raw manifest | `results/m5max-reference/manifest.json` |
+| Created | 2026-06-01T01:40:45Z |
+| Host | `AppCubics-MacBook-Pro.local` |
+| Hardware | Apple M5 Max, Darwin arm64 |
+| OpenMM | 8.5.1.dev-f7fa0c2, OpenCL platform available |
+| LAMMPS | 20250722, `PKG_GPU=ON`, `GPU_API=opencl`, `GPU_PREC=single` |
+| Harness | `scripts/benchmark_m5max_reference.py` |
+| Manifest validation | `ok` |
+| Suite status | `blocked`, because LAMMPS `rhodo` cannot run with this single-precision OpenCL GPU build |
+
+The LAMMPS package metadata and executable path come from the active `.venv`
+environment. The harness records and invokes the packaged executable under
+`.venv/lib/python3.13/site-packages/lammps/lmp`, so final reproducer commands do
+not depend on console-script shebang details.
+
+## OpenMM Reference Results
+
+The harness reran the upstream OpenMM benchmark script with OpenCL, single
+precision, and 30-second timing targets. Raw wrappers and upstream JSON live
+under `results/m5max-reference/openmm/`.
+
+| Case | Upstream tests | Status | Worst-row ns/day | Raw wrapper |
+| --- | --- | ---: | ---: | --- |
+| DHFR | `gbsa`, `rf`, `pme` | `ok` | 751.19 | `results/m5max-reference/openmm/dhfr.json` |
+| ApoA1 | `apoa1rf`, `apoa1pme`, `apoa1ljpme` | `ok` | 171.31 | `results/m5max-reference/openmm/apoa1.json` |
+| Amber20 | `amber20-cellulose`, `amber20-stmv` | `ok` | 18.01 | `results/m5max-reference/openmm/amber20.json` |
+
+Detailed committed OpenMM reports remain linked here and were not overwritten by
+this rerun:
+
+- [OpenMM OpenCL DHFR](./openmm-opencl-dhfr.md)
+- [OpenMM OpenCL ApoA1](./openmm-opencl-apoa1.md)
+- [OpenMM OpenCL Amber20 Cellulose and STMV](./openmm-opencl-amber20.md)
+
+The fresh rerun agrees with the existing story: OpenMM's OpenCL backend runs the
+selected named systems on the M5 Max, including the large Amber20 Cellulose and
+STMV systems, but these numbers are reference ceilings for this repo.
+
+## LAMMPS Reference Results
+
+LAMMPS coverage uses the five official top-level inputs from
+`vendors/lammps/bench/`. The harness copies each input into
+`results/m5max-reference/lammps/<case>/work/` before running, so `vendors/`
+stays read-only.
+
+| Case | Status | Acceleration class | Loop time, s | Raw wrapper |
+| --- | ---: | --- | ---: | --- |
+| `lj` | `ok` | `full_gpu_opencl` | 0.298473 | `results/m5max-reference/lammps/lj.json` |
+| `eam` | `ok` | `full_gpu_opencl` | 0.725426 | `results/m5max-reference/lammps/eam.json` |
+| `chain` | `diagnostic` | `partial_gpu_opencl` | 0.544019 | `results/m5max-reference/lammps/chain.json` |
+| `chute` | `diagnostic` | `cpu_only_diagnostic` | 0.108473 | `results/m5max-reference/lammps/chute.json` |
+| `rhodo` | `blocked` | `partial_gpu_opencl` | N/A | `results/m5max-reference/lammps/rhodo.json` |
+
+`chain` and `chute` are not failures of the harness. They are diagnostic because
+the official inputs do not map fully to `/gpu` styles in the local
+LAMMPS OpenCL build. `rhodo` is a real blocker:
+
+```text
+ERROR: PPPM was compiled for double precision floating point but GPU device supports single precision only.
+```
+
+See [LAMMPS OpenCL on M5 Max](./lammps-opencl-m5max.md) for the per-case style
+mapping.
+
+## MLX Boundary
+
+The MLX benchmarks in this repo are still development and smoke coverage for
+the product runtime. They are useful for catching regressions and proving
+specific code paths, but they are not yet same-workload production MD results
+against OpenMM or LAMMPS. Keep OpenMM/LAMMPS reference-engine numbers in this
+page and MLX runtime claims in the MLX benchmark docs.
+
+## Reproducer
+
+Run final GPU/OpenCL measurements from a host terminal or an approved
+outside-sandbox command. Sandboxed sessions can hide GPU devices or trigger
+Metal/OpenCL cleanup errors.
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py environment --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py openmm --dry-run --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py lammps --classify-only --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py run --seconds 30 --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_m5max_reference.py validate --manifest results/m5max-reference/manifest.json --json
+```
+
+Amber20 inputs are external and gitignored. For this run, the official
+`Amber20_Benchmark_Suite.tar.gz` was downloaded and extracted under
+`results/inputs/Amber20_Benchmark_Suite/`.

--- a/site/src/content/docs/benchmarks/openmm-opencl-amber20.md
+++ b/site/src/content/docs/benchmarks/openmm-opencl-amber20.md
@@ -1,0 +1,122 @@
+---
+title: "OpenMM OpenCL — Amber20 Cellulose & STMV on Apple M5 Max"
+---
+
+
+Engine: `openmm-reference`. Large-system measurement of OpenMM's OpenCL
+backend on the M5 Max for the two heavy AMBER 20 benchmark systems.
+
+## Result
+
+| Test | Atoms | M5 Max OpenCL (ns/day) | A100 (ns/day)² | H100 1× (ns/day)² | H100 4× (ns/day)² | B200 (ns/day)² | M5 Max / A100 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Cellulose PME | 408,609 | **55.89** | 131.85 | 216.98 | 342.21 | 276.41 | **42%** |
+| STMV PME | 1,067,095 | **18.14** | 46.05 | 70.16 | 147.09 | 116.91 | **39%** |
+
+² [openmm.org/benchmarks](https://openmm.org/benchmarks), OpenMM 8.4.
+
+## The full M5 Max scaling curve, all benchmarks so far
+
+Combining this report with [`openmm-opencl-dhfr.md`](./openmm-opencl-dhfr.md)
+and [`openmm-opencl-apoa1.md`](./openmm-opencl-apoa1.md):
+
+| System | Atoms | PME? | M5 Max ns/day | M5 Max / A100 |
+|---|---:|:---:|---:|---:|
+| DHFR Implicit | ~2.5k | ❌ | 1762.1 | 91% |
+| DHFR Explicit-RF | 23.6k | ❌ | 1018.4 | 70% |
+| DHFR Explicit-PME | 23.6k | ✅ | 752.5 | 58% |
+| ApoA1 PME | 92.2k | ✅ | 231.1 | 48% |
+| Cellulose PME | 408.6k | ✅ | 55.9 | 42% |
+| STMV PME | 1,067k | ✅ | 18.1 | 39% |
+
+### What this tells us
+
+The M5 Max / A100 ratio on PME-heavy systems **decelerates as system size
+grows**, approaching an asymptote near ~35–40%:
+
+- 23.6k → 92.2k (≈4×): 58% → 48%, a 10-point drop.
+- 92.2k → 408.6k (≈4×): 48% → 42%, a 6-point drop.
+- 408.6k → 1.07M (≈2.6×): 42% → 39%, a 3-point drop.
+
+The ratio is not crashing toward zero. **M5 Max is not memory-pressure-limited
+at STMV (1M atoms)**: unified memory holds the system fine, and the relative
+deficit vs A100 stabilizes rather than blowing up. This is the most
+informative thing this run produced — Apple's unified memory does carry its
+weight at large scale; the gap stays bound by the per-step PME-FFT deficit,
+not by data movement.
+
+For reference, even a single A100 only reaches 46 ns/day on STMV; the OpenMM
+table shows you need 3–4× H100 to make STMV throughput meaningful (130 to
+147 ns/day). M5 Max at 18 ns/day is in the regime where single-GPU NVIDIA is
+also a struggle.
+
+## Provenance
+
+- Engine: OpenMM 8.5.1.dev-f7fa0c2 (vendored at `vendors/openmm/`, run via
+  the upstream stock benchmark script)
+- Platform: OpenCL
+- OpenCL platform name: Apple
+- Device: Apple M5 Max (DeviceIndex 0)
+- Host: `AppCubics-MacBook-Pro.local`, Darwin arm64
+- Date: 2026-05-15
+- Raw output: `results/openmm-opencl-amber20-m5max.json` (gitignored)
+
+## External inputs
+
+These tests require the AMBER 20 Benchmark Suite (not shipped with OpenMM):
+
+| Field | Value |
+|---|---|
+| Source | `https://ambermd.org/Amber20_Benchmark_Suite.tar.gz` |
+| Tarball size | ~75 MB |
+| Extracted size | ~411 MB |
+| Local path | `results/inputs/Amber20_Benchmark_Suite/` (gitignored) |
+| Fetched | 2026-05-15 |
+
+`results/inputs/README.md` records what is in that directory and why. The
+benchmark script handles the download automatically on first run; subsequent
+runs reuse the local copy. See the reproducer below.
+
+## Config
+
+| Parameter | Cellulose | STMV |
+|---|---|---|
+| Force field | AMBER (suite default) | AMBER (suite default) |
+| Integrator | Langevin (NVT) | Langevin (NVT) |
+| Timestep | 4 fs | 4 fs |
+| Constraints | HBonds | HBonds |
+| Hydrogen mass | 1.5 amu | 1.5 amu |
+| PME cutoff | 0.9 nm | 0.9 nm |
+| Precision | single | single |
+| Target wall time | 30 s | 30 s |
+
+Identical to the configuration used at `openmm.org/benchmarks`.
+
+## Reproducer
+
+```bash
+cd results/inputs
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run --project ../.. \
+  python ../../vendors/openmm/examples/benchmarks/benchmark.py \
+    --platform OpenCL \
+    --test amber20-cellulose,amber20-stmv \
+    --seconds 30 \
+    --precision single \
+    --outfile ../openmm-opencl-amber20-m5max.json
+```
+
+The script downloads `Amber20_Benchmark_Suite.tar.gz` into the current
+working directory on first run and extracts it next to itself. By running
+from `results/inputs/`, the download stays inside the gitignored
+`results/` tree rather than polluting the vendored OpenMM source under
+`vendors/`.
+
+## Open questions for follow-up benchmarks
+
+- **`--disable-pme-stream`** on STMV: would directly test whether the
+  PME-stream overlap path is the deficit, or whether the FFT itself is.
+- **Cellulose with mixed precision**: large-system mixed-precision benefits
+  on Apple GPU are unmeasured publicly.
+- **mlx-atomistic at the same scales** — once feasible, an MLX run on a
+  comparable system would land alongside these and tell us where the MLX
+  runtime fits relative to OpenMM's OpenCL ceiling on this hardware.

--- a/site/src/content/docs/benchmarks/openmm-opencl-apoa1.md
+++ b/site/src/content/docs/benchmarks/openmm-opencl-apoa1.md
@@ -1,0 +1,113 @@
+---
+title: "OpenMM OpenCL — ApoA1 on Apple M5 Max"
+---
+
+
+Engine: `openmm-reference`. Not a product runtime path; this is a reference
+ceiling for what OpenMM extracts from the M5 Max via its OpenCL backend.
+
+## Result
+
+| Test | M5 Max OpenCL (ns/day) | M1 Max OpenCL (ns/day)¹ | A100 (ns/day)² | H100 (ns/day)² | B200 (ns/day)² |
+|---|---:|---:|---:|---:|---:|
+| ApoA1 RF | **331.8** | 41.7 | 615.9 | 921.8 | 1000.8 |
+| ApoA1 PME | **231.1** | 31.7 | 479.7 | 742.1 | 875.9 |
+| ApoA1 LJPME | **172.9** | 25.4 | 356.7 | 553.8 | 655.1 |
+
+¹ philipturner, [openmm/openmm#3847](https://github.com/openmm/openmm/issues/3847) (2022, OpenMM dev branch).
+² [openmm.org/benchmarks](https://openmm.org/benchmarks), OpenMM 8.4.
+
+### Derived ratios
+
+- M5 Max vs M1 Max ApoA1 PME: **7.3×** speedup across 4–5 GPU generations.
+- M5 Max vs A100 ApoA1 PME: **48%** of A100 throughput.
+- M5 Max vs H100 ApoA1 PME: **31%** of H100 throughput.
+- Per-watt (rough, ≤80 W vs 400 W for A100): M5 Max ≈ **2.4×** A100 on ApoA1 PME.
+
+## Provenance
+
+- Engine: OpenMM 8.5.1.dev-f7fa0c2 (vendored at `vendors/openmm/`, run from the
+  upstream stock benchmark script)
+- Platform: OpenCL
+- OpenCL platform name: Apple
+- Device: Apple M5 Max (DeviceIndex 0)
+- Host: `AppCubics-MacBook-Pro.local`, Darwin arm64
+- Date: 2026-05-15
+- Raw output: `results/openmm-opencl-apoa1-m5max.json` (gitignored)
+
+## Config
+
+All three tests share the OpenMM public-benchmark config exactly:
+
+| Parameter | Value |
+|---|---|
+| Force field | AMBER14 |
+| Integrator | Langevin (NVT) |
+| Timestep | 4 fs |
+| Constraints | HBonds |
+| Hydrogen mass | 1.5 amu |
+| PME cutoff | 0.9 nm (RF uses 1.0 nm) |
+| Precision | single |
+| Target wall time | 30 s per test |
+
+This matches the configuration on `openmm.org/benchmarks`, so the M5 Max
+column is directly comparable to the NVIDIA columns in that table.
+
+## Reproducer
+
+```bash
+cd vendors/openmm/examples/benchmarks
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run --project ../../../.. \
+  python benchmark.py \
+    --platform OpenCL \
+    --test apoa1rf,apoa1pme,apoa1ljpme \
+    --seconds 30 \
+    --precision single \
+    --outfile ../../../../results/openmm-opencl-apoa1-m5max.json
+```
+
+OpenCL device access on macOS requires running outside the default Claude
+Code sandbox; from a normal terminal session no special permission is
+needed. See `docs/runtime-boundaries.md` for the broader OpenMM-as-reference
+boundary statement.
+
+## Notes worth keeping
+
+- **OpenCL ICD overhead is still present.** philipturner
+  [(openmm/openmm#3924)](https://github.com/openmm/openmm/issues/3924) shows that
+  reimplementing `findBlocksWithInteractions` in native Metal Shading Language —
+  including `simd_prefix_inclusive_sum` and `half`-compressed position buffers —
+  yields **+58% to +73%** over the current OpenCL kernel on Apple GPUs. A
+  hypothetical OpenMM Metal backend would push M5 Max ApoA1 PME toward 300–380
+  ns/day, in the same range as A100.
+- **Apple GPUs have no native FP64.** Single-precision is the only realistic
+  GPU path; double-precision asks fall back to CPU or emulation.
+- **GROMACS does not plan to add Metal.** See
+  [t/gpu-acceleration-on-mac-m1-mini/2938](https://gromacs.bioexcel.eu/t/gpu-acceleration-on-mac-m1-mini/2938).
+  GROMACS on Apple Silicon is OpenCL-only with `GMX_GPU_DISABLE_COMPATIBILITY_CHECK=1`.
+
+## External comparison context
+
+- Same script, same systems, same config as the rows at
+  [openmm.org/benchmarks](https://openmm.org/benchmarks).
+- HECBioSim publishes a parallel benchmark suite at
+  [hecbiosim.ac.uk/access-hpc/hpc-benchmarking](https://www.hecbiosim.ac.uk/access-hpc/hpc-benchmarking)
+  with standardized 21k / 61k / 465k / 1.4M / 3M-atom systems and energy-per-ns
+  figures; their tooling is at [github.com/HECBioSim/hpcbench](https://github.com/HECBioSim/hpcbench).
+- AMBER's source benchmark page is [ambermd.org/GPUPerformance.php](https://ambermd.org/GPUPerformance.php);
+  OpenMM's DHFR/ApoA1/Cellulose/STMV input sets are imported from there.
+
+## Open questions for follow-up benchmarks
+
+- **DHFR (23k atoms)** — same script with `--test rf,pme` exercises the
+  smaller hello-world system. Would let M5 Max land in *every* column of the
+  OpenMM official table, not just ApoA1.
+- **Mixed precision on Apple GPU** — `--precision mixed` to test whether
+  Apple's FP16 path measurably helps; most NVIDIA reference numbers use
+  mixed by default.
+- **STMV (1M atoms)** — large-system scaling on Apple Silicon. Likely the
+  point where unified memory either pays off or hits a wall vs A100 80 GB.
+- **mlx-atomistic on the same system** — once the `mlx_atomistic` runtime
+  can run ApoA1, that result lives at
+  `docs/benchmarks/mlx-atomistic-apoa1.md` and is directly comparable to
+  this file.

--- a/site/src/content/docs/benchmarks/openmm-opencl-dhfr.md
+++ b/site/src/content/docs/benchmarks/openmm-opencl-dhfr.md
@@ -1,0 +1,124 @@
+---
+title: "OpenMM OpenCL — DHFR on Apple M5 Max"
+---
+
+
+Engine: `openmm-reference`. Reference-ceiling measurement of OpenMM's OpenCL
+backend on the M5 Max for the canonical DHFR hello-world system (23k atoms).
+
+## Result
+
+| Test | M5 Max OpenCL (ns/day) | A100 (ns/day)² | H100 (ns/day)² | B200 (ns/day)² | M5 Max / A100 |
+|---|---:|---:|---:|---:|---:|
+| DHFR Implicit (GBSA) | **1762.1** | 1942.2 | 2498.6 | 2268.4 | **91%** |
+| DHFR Explicit-RF | **1018.4** | 1460.6 | 1873.2 | 1802.3 | **70%** |
+| DHFR Explicit-PME | **752.5** | 1286.6 | 1704.5 | 1658.7 | **58%** |
+
+² [openmm.org/benchmarks](https://openmm.org/benchmarks), OpenMM 8.4.
+
+### Cross-system scaling (M5 Max vs A100)
+
+| System | Atoms | M5 Max / A100 (PME) |
+|---|---:|---:|
+| DHFR Implicit (no PME, no water) | 2.5k | 91% |
+| DHFR Explicit-RF (water, no PME) | 23.6k | 70% |
+| DHFR Explicit-PME | 23.6k | 58% |
+| ApoA1 PME ([report](./openmm-opencl-apoa1.md)) | 92.2k | 48% |
+
+The relative gap to A100 **grows with system size and PME usage**, not with
+kernel-launch overhead. M5 Max essentially matches an A100 on DHFR Implicit
+and falls to about half the throughput at ApoA1 PME.
+
+## What this tells us about the M5 Max bottleneck
+
+The expected story for an Apple GPU vs NVIDIA on a small system is that
+launch overhead, threadgroup-memory latency, and lack of warp-level
+primitives would hurt the small-system regime more than the large one.
+The data here points the other direction:
+
+- **Small + no PME (DHFR GBSA): M5 Max ≈ A100.** Pair-list and bonded force
+  kernels on Apple GPU are competitive when they are the only thing running.
+- **Large + PME (ApoA1 PME): M5 Max ≈ 0.5 × A100.** The deficit shows up in
+  proportion to PME workload.
+
+The real M5 Max bottleneck in OpenMM today is the **OpenCL FFT path used by
+PME**, not pair-list dispatch. This is consistent with philipturner's
+finding in [openmm/openmm#3924](https://github.com/openmm/openmm/issues/3924)
+that the largest unrealized speedups on Apple GPUs come from rewriting
+`findBlocksWithInteractions` and prefix-sum primitives in native Metal —
+those gains are on the *non-PME* side. A native Metal FFT (separate from
+the Metal kernel work) is likely needed to close the PME gap.
+
+## Notable side observation
+
+M5 Max DHFR Implicit (1762 ns/day) lands within ~10% of NVIDIA DGX Spark
+(1942 ns/day on the same test). DGX Spark is NVIDIA's personal-workstation
+class part, so this is a near-peer comparison in the segment Apple actually
+competes in.
+
+## Provenance
+
+- Engine: OpenMM 8.5.1.dev-f7fa0c2 (vendored at `vendors/openmm/`, run from
+  the upstream stock benchmark script)
+- Platform: OpenCL
+- OpenCL platform name: Apple
+- Device: Apple M5 Max (DeviceIndex 0)
+- Host: `AppCubics-MacBook-Pro.local`, Darwin arm64
+- Date: 2026-05-15
+- Raw output: `results/openmm-opencl-dhfr-m5max.json` (gitignored)
+
+## Config
+
+All three tests share the OpenMM public-benchmark config exactly:
+
+| Parameter | Value |
+|---|---|
+| Force field | AMBER99SB |
+| Integrator | Langevin (NVT) |
+| Timestep | 4 fs |
+| Constraints | HBonds |
+| Hydrogen mass | 1.5 amu |
+| Cutoff | 0.9 nm (PME) / 1.0 nm (RF) / 2.0 nm (implicit) |
+| Precision | single |
+| Target wall time | 30 s per test |
+
+Identical to the configuration used at `openmm.org/benchmarks`, so the
+M5 Max column is directly comparable to the NVIDIA columns in that table.
+
+## Reproducer
+
+```bash
+cd vendors/openmm/examples/benchmarks
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run --project ../../../.. \
+  python benchmark.py \
+    --platform OpenCL \
+    --test gbsa,rf,pme \
+    --seconds 30 \
+    --precision single \
+    --outfile ../../../../results/openmm-opencl-dhfr-m5max.json
+```
+
+PDB inputs (`5dfr_minimized.pdb`, `5dfr_solv-cube_equil.pdb`) ship with the
+OpenMM source in this directory — no downloads required.
+
+## External comparison context
+
+- Cross-reference with [`openmm-opencl-apoa1.md`](./openmm-opencl-apoa1.md)
+  to see the small-vs-large scaling on this hardware.
+- Same script, same systems, same config as the rows at
+  [openmm.org/benchmarks](https://openmm.org/benchmarks).
+- The DHFR input is the AMBER JAC benchmark, originating from
+  [ambermd.org/GPUPerformance.php](https://ambermd.org/GPUPerformance.php).
+
+## Open questions for follow-up benchmarks
+
+- **STMV (1M atoms)** — the natural other extreme. Would test whether
+  Apple's unified-memory advantage shows up at large scale, or whether the
+  PME-FFT deficit dominates further.
+- **Mixed precision** — `--precision mixed` on DHFR PME to see if FP16
+  intermediate accumulation moves the needle on Apple GPU.
+- **AMOEBA polarizable on DHFR** — `--test amoebagk,amoebapme` exercises a
+  different code path (induced dipoles). M5 Max relative position there is
+  unmeasured publicly.
+- **PME isolation** — toggle `--disable-pme-stream` to measure how much of
+  the M5 Max PME deficit is the stream-overlap path vs the FFT itself.

--- a/site/src/content/docs/benchmarks/performance-audit-baseline.md
+++ b/site/src/content/docs/benchmarks/performance-audit-baseline.md
@@ -1,0 +1,84 @@
+---
+title: "Performance Audit Baseline"
+---
+
+
+Date: 2026-05-22
+
+This report is the committed Slice 6 audit summary for
+`2026-05-22-performance-audit-harness-hardening`. Raw JSON is gitignored under
+`results/performance-audit-harness-hardening/`.
+
+## Baseline Runs
+
+| Benchmark | Engine | Command | Raw output | Status |
+| --- | --- | --- | --- | --- |
+| force-term microbenchmarks | `mlx_atomistic` | `uv run python -m mlx_atomistic.benchmarks.mm_force_terms --evaluations 1 --particles 16 --json` | `results/performance-audit-harness-hardening/mm-force-terms-fast.json` | ok |
+| nonbonded acceleration split | `mlx_atomistic` | `uv run python -m mlx_atomistic.benchmarks.md_acceleration --sizes 16 --evaluations 1 --json` | `results/performance-audit-harness-hardening/md-acceleration-fast.json` | ok |
+| full MD smoke | `mlx_atomistic` | `uv run python -m mlx_atomistic.benchmarks.md_performance --sizes 32 --steps 1 --sample-interval 1 --diagnostic-interval 1 --evaluation-interval 1 --json` | `results/performance-audit-harness-hardening/md-performance-fast.json` | ok |
+| Phase 3 physics smoke | `mlx_atomistic` | `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json` | `results/performance-audit-harness-hardening/phase3-physics-fast.json` | ok |
+| PME missing-fixture blocked smoke | `mlx_atomistic` | `uv run python -m mlx_atomistic.benchmarks.pme_performance --fixture-dir results/missing-pme-fixture --iterations 1 --warmups 0 --json` | `results/performance-audit-harness-hardening/pme-blocked-fast.json` | blocked |
+| OpenMM unavailable-platform smoke | `openmm-reference` | `uv run python scripts/benchmark_openmm_opencl.py --platform DefinitelyMissing --particles 16 --steps 1 --json` | `results/performance-audit-harness-hardening/openmm-blocked-fast.json` | blocked |
+| LAMMPS OpenCL smoke | `lammps-reference` | `uv run python scripts/benchmark_lammps_opencl.py --particles 16 --steps 1 --json` | `results/performance-audit-harness-hardening/lammps-fast.json` | ok |
+
+## Measured Rows
+
+| Row | Metric | Value | Evidence |
+| --- | --- | ---: | --- |
+| full MD synthetic LJ, dense backend | `steps_per_s` | 53.073 | `md-performance-fast.json` |
+| full MD force evaluation | `force_eval_ms_per_step` | 0.221 | `md-performance-fast.json` |
+| nonbonded `mlx_tiled` | `ms_per_eval` | 0.521 | `md-acceleration-fast.json` |
+| nonbonded `mlx_dense` | `ms_per_eval` | 0.855 | `md-acceleration-fast.json` |
+| nonbonded `mlx_pairs` force eval | `ms_per_eval` | 0.864 | `md-acceleration-fast.json` |
+| `mlx_pairs` neighbor build | `neighbor_build_ms_per_eval` | 2.423 | `md-acceleration-fast.json` |
+| `python_neighbor` total eval | `ms_per_eval` | 2.376 | `md-acceleration-fast.json` |
+| Phase 3 replica exchange | `ms_per_eval` | 9.552 | `phase3-physics-fast.json` |
+| GBSA/OBC energy and forces | `ms_per_eval` | 7.791 | `phase3-physics-fast.json` |
+| TIP4P-Ew M-site reconstruction | `ms_per_eval` | 5.526 | `phase3-physics-fast.json` |
+| soft-core lambda grid | `ms_per_eval` | 3.389 | `phase3-physics-fast.json` |
+| virtual-site force redistribution | `ms_per_eval` | 1.125 | `phase3-physics-fast.json` |
+| LAMMPS synthetic OpenCL smoke | `steps_per_s` | 700.076 | `lammps-fast.json` |
+
+The reference-engine rows are context only. The OpenMM row intentionally uses a
+missing platform and proves fail-soft behavior; the LAMMPS row is a tiny
+synthetic smoke run and is not an apples-to-apples production target.
+
+## Ranked Optimization Backlog
+
+1. **Replica-exchange runtime materialization and serial replica execution.**
+   Evidence: `phase3-physics-fast.json` reports
+   `two_replica_temperature_exchange` at `9.552 ms/eval`, the slowest fast row,
+   with `history_materialization_count: 8`.
+   Reproducer: `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json`.
+
+2. **GBSA/OBC force evaluation.**
+   Evidence: `phase3-physics-fast.json` reports
+   `gbsa_obc_energy_forces` at `7.791 ms/eval` for only four atoms, while the
+   surface-area term is `0.903 ms/eval`.
+   Reproducer: same Phase 3 command above.
+
+3. **TIP4P-Ew virtual-site reconstruction and advanced-water overhead.**
+   Evidence: `phase3-physics-fast.json` reports TIP4P-Ew reconstruction at
+   `5.526 ms/eval`; `mm-force-terms-fast.json` reports synchronized
+   `tip4p-ew-reconstruct` at `1.158 ms/eval` and force redistribution at
+   `0.866 ms/eval`.
+   Reproducer: `uv run python -m mlx_atomistic.benchmarks.mm_force_terms --evaluations 1 --particles 16 --json`.
+
+4. **Neighbor-list build and pair-compaction overhead.**
+   Evidence: `md-acceleration-fast.json` reports `mlx_pairs`
+   `neighbor_build_ms_per_eval: 2.423`, larger than its force eval row
+   (`0.864 ms/eval`) and the dense/tiled diagnostic rows at this small size.
+   Reproducer: `uv run python -m mlx_atomistic.benchmarks.md_acceleration --sizes 16 --evaluations 1 --json`.
+
+5. **Full-loop MD synchronization/cadence path.**
+   Evidence: `md-performance-fast.json` reports `53.073 steps/s` for a one-step
+   smoke with `force_eval_ms_per_step: 0.221`; this row should be rerun at
+   opt-in sizes before any custom-kernel work.
+   Reproducer: `uv run python -m mlx_atomistic.benchmarks.md_performance --sizes 32 --steps 1 --sample-interval 1 --diagnostic-interval 1 --evaluation-interval 1 --json`.
+
+## Follow-On Spec Recommendation
+
+The next optimization spec should target **replica-exchange and GBSA/OBC
+Phase 3 overhead first**, then neighbor-list build/compaction. Custom Metal
+kernel work remains deferred until opt-in larger-system runs reproduce these
+rankings beyond fast synthetic probes.

--- a/site/src/content/docs/benchmarks/same-workload-comparison-matrix.md
+++ b/site/src/content/docs/benchmarks/same-workload-comparison-matrix.md
@@ -1,0 +1,63 @@
+---
+title: "Same-Workload Comparison Matrix"
+---
+
+
+Date: 2026-05-23
+
+Scope: `.agent/work/2026-05-23-same-workload-openmm-benchmark-comparison`.
+This matrix defines the first MLX/OpenMM comparison pairs. It is a routing
+artifact for benchmark implementation, not a performance report.
+
+## Rules
+
+- Compare `mlx_atomistic` to OpenMM only when workload, physics, hardware, and
+  metric family match.
+- Keep MLX commands under `src/mlx_atomistic/benchmarks/` module entry points.
+- Keep OpenMM commands under `scripts/`; OpenMM remains a reference/dev
+  surface, not a product runtime dependency.
+- Write raw JSON/CSV under gitignored `results/same-workload-openmm-comparison/`.
+- Mark rows as `comparable`, `diagnostic`, or `blocked`; do not compute a ratio
+  for diagnostic or blocked rows.
+- For the synthetic-LJ scaling ladder, LAMMPS is a first-class third engine
+  (reduced-unit `lj/cut/gpu`, same `fcc_lattice` geometry as MLX). For the
+  semantic smoke pairs below (GBSA/TIP4P/DHFR), LAMMPS remains deferred.
+
+## Pair Matrix
+
+| Pair id | Workload | MLX command | OpenMM command | Metric family | Comparable status | Output paths | Caveat or blocker policy |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `lj-synthetic-loop` | synthetic LJ full-loop / nonbonded smoke | `uv run python -m mlx_atomistic.benchmarks.md_performance --sizes 32 --steps 1 --sample-interval 1 --diagnostic-interval 1 --evaluation-interval 1 --json` | `uv run python scripts/benchmark_openmm_opencl.py --platform OpenCL --particles 32 --steps 1 --warmup-steps 0 --spacing-nm 1.0 --json` | `steps/s`; optionally `ns/day` when timestep and step semantics are aligned | `comparable` when both sides are `ok` and use the same particle/step count; otherwise `blocked` | `results/same-workload-openmm-comparison/mlx-lj-synthetic-loop.json`; `results/same-workload-openmm-comparison/openmm-lj-synthetic-loop.json` | Use only as a tiny controlled smoke row. Do not extrapolate to DHFR, ApoA1, PME, or production throughput. |
+| `gbsa-obc-small` | small GBSA/OBC energy and force evaluation | `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json` | `uv run python scripts/benchmark_openmm_opencl.py --case gbsa-obc-small --platform Reference --particles 4 --steps 1 --json` | `ms/eval` or per-step timing | `comparable` only if OpenMM side evaluates the same OBC-style implicit-solvent physics; `blocked` if the reference script does not yet expose this case | `results/same-workload-openmm-comparison/mlx-gbsa-obc-small.json`; `results/same-workload-openmm-comparison/openmm-gbsa-obc-small.json` | OpenMM reference must report the exact force setup or return `blocked` with the unsupported feature reason. |
+| `tip4p-ew-water` | TIP4P-Ew virtual-site / water row | `uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json` | `uv run python scripts/benchmark_openmm_opencl.py --case tip4p-ew-water --platform Reference --particles 4 --steps 1 --json` | `ms/eval` or per-step timing | `comparable` only if both sides report the same TIP4P-Ew virtual-site or water-workload operation; `diagnostic` if the MLX side measures reconstruction and OpenMM measures full water force evaluation | `results/same-workload-openmm-comparison/mlx-tip4p-ew-water.json`; `results/same-workload-openmm-comparison/openmm-tip4p-ew-water.json` | Do not compare virtual-site reconstruction alone against full OpenMM water dynamics. |
+| `dhfr-implicit` | DHFR implicit GBSA/OBC real-system stretch | `uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-implicit --steps 1 --json` | `uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-implicit --platform Reference --steps 1 --json` | `ns/day` | `comparable` for the one-step MLX/OpenMM Reference smoke row when both sides are `ok` and use `0.004 ps` | `results/same-workload-openmm-comparison/mlx-dhfr-implicit.json`; `results/same-workload-openmm-comparison/openmm-dhfr-implicit.json`; `results/same-workload-openmm-comparison/summary.json` | Use as a narrow runtime/artifact smoke comparison. OpenMM OpenCL DHFR implicit remains context only. |
+| `dhfr-explicit-pme` | DHFR explicit PME real-system stretch | `uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-explicit-pme --steps 1 --json` | `uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-explicit-pme --platform Reference --steps 1 --json` | `ns/day` | `blocked` until MLX has a scientifically valid neutral PME artifact or charged-PME policy | `results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json`; `results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json` | Current local Amber20/JAC PME artifact has `net_charge=-11`; OpenMM OpenCL DHFR PME remains context only. |
+
+## Production Scaling Ladder
+
+The `lj-synthetic-loop` row above is a tiny controlled smoke. The production-scale
+throughput comparison is the synthetic-LJ size ladder (1k/4k/16k/50k) across MLX,
+OpenMM, and LAMMPS, driven by `scripts/run_same_workload_lj_scaling.py` and
+aggregated by `same_workload_compare.build_scaling_summary` (matched per size by
+`(atom_count, step_count)`). Results, method, and caveats:
+`docs/benchmarks/same-workload-lj-scaling-m5max.md`. Raw JSON under gitignored
+`results/same-workload-lj-scaling/`.
+
+```bash
+uv run python scripts/run_same_workload_lj_scaling.py \
+  --sizes 1000,4000,16000,50000 --steps 3000,2000,800,300
+```
+
+## Required Report Behavior
+
+The final comparison report should answer five questions for each row:
+
+1. Did both engines run?
+2. Are the workload and metric actually comparable?
+3. What raw output files support the row?
+4. If comparable, what is the measured ratio?
+5. If not comparable, what exact blocker or caveat prevents comparison?
+
+OpenMM DHFR, ApoA1, Cellulose, and STMV reports may be cited as reference
+context, but they are not direct comparisons until a matching `mlx_atomistic`
+row exists.

--- a/site/src/content/docs/benchmarks/same-workload-dhfr-stretch.md
+++ b/site/src/content/docs/benchmarks/same-workload-dhfr-stretch.md
@@ -1,0 +1,82 @@
+---
+title: "Same-Workload DHFR Stretch Status"
+---
+
+
+Date: 2026-05-23
+
+Engine pair: `mlx_atomistic` vs `openmm-reference`.
+Pair ids: `dhfr-implicit`, `dhfr-explicit-pme`.
+
+These are the real-system DHFR stretch rows for the same-workload comparison
+plan. `dhfr-implicit` now runs as a one-step MLX/OpenMM Reference smoke
+comparison. `dhfr-explicit-pme` remains blocked on the MLX side, so it still
+has no ratio.
+
+## Row Status
+
+| Pair id | Intended system | Physics target | Metric | Status | Raw output |
+| --- | --- | --- | --- | --- | --- |
+| `dhfr-implicit` | DHFR implicit solvent, ~2.5k atoms | implicit GBSA/OBC target | `ns/day` | `comparable` one-step smoke row; ratio in summary | MLX: `results/same-workload-openmm-comparison/mlx-dhfr-implicit.json`; OpenMM Reference: `results/same-workload-openmm-comparison/openmm-dhfr-implicit.json`; summary: `results/same-workload-openmm-comparison/summary.json` |
+| `dhfr-explicit-pme` | DHFR explicit PME, 23.6k atoms | explicit solvent PME target | `ns/day` | `blocked`; no ratio | MLX: `results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json`; OpenMM Reference: `results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json` |
+
+## OpenMM Reference
+
+The reference side is already measured in
+[`openmm-opencl-dhfr.md`](./openmm-opencl-dhfr.md):
+
+| OpenMM system | Size | Result |
+| --- | ---: | ---: |
+| DHFR Implicit GBSA | ~2.5k atoms | 1762.1 ns/day |
+| DHFR Explicit PME | 23.6k atoms | 752.5 ns/day |
+
+The committed OpenMM OpenCL numbers are reference context, not the same thing
+as the one-step OpenMM Reference shape-check rows used by the same-workload
+comparison helper.
+
+## MLX Status
+
+`mlx_atomistic` can resolve the local DHFR inputs. The two rows now differ:
+
+- `dhfr-implicit`: runnable. The prep path derives a DHFR GBSA/OBC artifact
+  from OpenMM `amber99sb.xml` and `amber99_obc.xml`, including `gbsa_radius`,
+  `gbsa_scale`, bonded terms, torsions, constraints, and nonbonded exceptions.
+  The MLX runtime currently reports a one-step `0.004 ps` smoke row.
+- `dhfr-explicit-pme`: blocked before PME runtime because the local Amber20/JAC
+  artifact has `net_charge=-11` and the current MLX PME artifact policy
+  requires neutral systems.
+
+The comparison helper computes a ratio only for `dhfr-implicit`. It keeps
+`dhfr-explicit-pme` blocked and does not compute a ratio for that row.
+
+## Reproducer Boundary
+
+MLX row reproducers:
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-implicit --steps 1 --json > results/same-workload-openmm-comparison/mlx-dhfr-implicit.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-explicit-pme --steps 1 --json > results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json
+```
+
+OpenMM same-workload shape-check reproducers:
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-implicit --platform Reference --steps 1 --json > results/same-workload-openmm-comparison/openmm-dhfr-implicit.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-explicit-pme --platform Reference --steps 1 --json > results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json
+```
+
+OpenMM OpenCL context reproducer:
+
+```bash
+cd vendors/openmm/examples/benchmarks
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run --project ../../../.. \
+  python benchmark.py \
+    --platform OpenCL \
+    --test pme \
+    --seconds 30 \
+    --precision single \
+    --outfile ../../../../results/openmm-opencl-dhfr-m5max.json
+```
+
+The OpenMM Reference commands above are one-step same-workload shape checks.
+They are not the OpenCL performance numbers in the context table.

--- a/site/src/content/docs/benchmarks/same-workload-lj-scaling-m5max.md
+++ b/site/src/content/docs/benchmarks/same-workload-lj-scaling-m5max.md
@@ -1,0 +1,193 @@
+---
+title: "Same-Workload LJ Scaling: MLX vs OpenMM vs LAMMPS (M5 Max)"
+---
+
+
+Date: 2026-06-18 (MLX re-measured after the `mlx_cell_pairs` neighbor-default
+switch, the batched-block integrator, and dropping the per-rebuild pair sort;
+OpenMM and LAMMPS reference rows are carried over unchanged from the 2026-06-17
+run on the same machine — only the MLX runtime changed.)
+
+This is the first **production-scale** same-workload throughput comparison of the
+`mlx_atomistic` runtime against the OpenMM and LAMMPS reference engines on a
+single Apple M5 Max. It exists because every prior committed MLX number was
+smoke-sized (4–32 atoms, 1 step), where fixed overhead dominates and the real
+O(N) force/neighbor costs are invisible. The goal here is an honest baseline, not
+a favorable one.
+
+## What is measured
+
+A pure Lennard-Jones fluid (ε = σ = 1, cutoff 2.5σ) integrated under NVE/Langevin
+at reduced density 0.8, swept across a particle-count ladder and run on each
+engine's GPU path on the same machine. The comparison metric is **`steps_per_s`**
+(integration steps per wall-second). Reduced-unit `ns/day` is intentionally not
+compared across engines because the reduced timestep has no common physical
+meaning.
+
+## Method
+
+| Engine | Path | Command surface | Geometry / units |
+| --- | --- | --- | --- |
+| `mlx_atomistic` | MLX/Metal GPU | `mlx_atomistic.benchmarks.md_performance` | `fcc_lattice`, reduced units, auto backend |
+| OpenMM | OpenCL | `scripts/benchmark_openmm_opencl.py` | synthetic LJ, physical (nm/ps) units |
+| LAMMPS | GPU/OpenCL (`lj/cut/gpu`) | `scripts/benchmark_lammps_opencl.py` | same `fcc_lattice`, reduced (`units lj`) |
+
+- **Identical workload per size.** All engines run the same `(particles, steps)`
+  at each ladder point; the aggregator (`same_workload_compare.build_scaling_summary`)
+  only emits a ratio when particle and step counts match and both engines ran `ok`.
+- **MLX and LAMMPS share geometry.** The LAMMPS script reuses the product's own
+  `fcc_lattice` (same N, box, initial positions) at reduced density 0.8, so the
+  MLX↔LAMMPS comparison is genuinely the same physics (same potential, cutoff,
+  units). OpenMM runs the same particle/step counts in physical units and is a
+  throughput reference, not a bit-identical workload.
+- **MLX runs its own auto-selected backend per size**: dense all-pairs below the
+  neighbor-list threshold (1536 atoms), and the `mlx_cell_pairs` neighbor backend
+  (host-compacted real pairs) above it. This compares MLX at its best per size,
+  not a single fixed path.
+- **Per-size step counts.** Cheap small systems run many steps; expensive large
+  systems run fewer, so each point reaches steady state without an unbounded run.
+  Steps are matched across engines within each size.
+
+### Two measurement corrections made for this comparison
+
+1. **OpenMM async timing.** OpenCL enqueues integration kernels asynchronously, so
+   `integrator.step(n)` can return before the GPU has done the work. The timed
+   region now forces the queue to drain (`context.getState(getEnergy=True)`) so
+   `wall_s` reflects real compute, not just kernel enqueue. Without this, short
+   OpenMM runs reported absurd rates (e.g. ~280k steps/s at 60 steps).
+2. **LAMMPS GPU verification.** The LAMMPS log is parsed to confirm the
+   `lj/cut/gpu` pair build is actually active; if it cannot be confirmed the row
+   is reported as a CPU-only `diagnostic` rather than claimed as OpenCL.
+
+## Honest caveats
+
+- This is a **throughput** comparison (steps/s), not a validation of identical
+  trajectories. Neighbor strategy, thermostat, and integrator details differ
+  across engines.
+- On the Apple GPU, **both LAMMPS and MLX build neighbor lists on the host (CPU)**
+  and run the pair force on the GPU (LAMMPS logs "GPU does not support neighbor
+  lists on device, switching to host"). This is the documented neighbor-build
+  cost, not a defect.
+- MLX uses reduced-unit LJ; OpenMM uses physical units. Only `steps_per_s` is
+  compared, and only where N and step counts match.
+
+## Results
+
+Measured on an Apple M5 Max (128 GB), reduced density 0.8, `dt = 0.002`, per-size
+step counts (3000 / 2000 / 800 / 300). MLX and LAMMPS share the same `fcc_lattice`
+geometry and reduced LJ units; OpenMM runs the same particle/step counts in
+physical units. All four sizes are `comparable` and all MLX runs conserved energy
+(see note below). The MLX rows are the current best per size: above the dense
+threshold (1536 atoms) the neighbor backend is `mlx_cell_pairs` (compacted real
+pairs, unsorted) and the integrator runs the **compiled batched-block fast path**
+(`block_size=16`, `neighbor_skin=1.2`) — `block_size` Langevin substeps per
+compiled block with one host sync per block instead of per step.
+
+| atoms | MLX steps/s | MLX backend | OpenMM steps/s | OpenMM/MLX | LAMMPS steps/s | LAMMPS/MLX |
+| ---: | ---: | --- | ---: | ---: | ---: | ---: |
+| 1000  | 1906.8 | `mlx_dense` | 24024.7 | 12.6× | 4358.1 | 2.3× |
+| 4000  | 2152.6 | `mlx_cell_pairs` + batched | 4819.9 | 2.2× | 2165.1 | 1.0× |
+| 16000 | 663.7  | `mlx_cell_pairs` + batched | 4171.0 | 6.3× | 664.6 | 1.0× |
+| 50000 | 200.9  | `mlx_cell_pairs` + batched | 3193.6 | 15.9× | 234.0 | 1.2× |
+
+`ratio = reference_steps_per_s / mlx_steps_per_s` (> 1 means the reference engine
+runs more steps/s — the MLX gap).
+
+Three compounding MLX changes produced these numbers, all at identical physics:
+
+1. **Neighbor backend `mlx_cell_blocks` → `mlx_cell_pairs`** (compact real pairs
+   instead of ~11× padded candidates): 99.5 / 31.8 / 8.5 → 649 / 180 / 57 steps/s
+   at 4k / 16k / 50k (**~6×**). Locked by
+   `tests/test_neighbors.py::test_default_backend_switch_preserves_lj_physics`.
+2. **Compiled batched-block integrator** (sync once per block, not per step):
+   649 / 180 / 57 → 1354 / 346 / 102 steps/s (**2.2× / 1.9× / 1.8×**). The batched
+   path uses the same seeded threaded PRNG and the same per-step arithmetic, so it
+   reproduces the per-step trajectory to floating-point precision (≈1e-4 energy
+   over the run; differences are summation-order ULPs from a larger skin, the same
+   class of difference as changing the rebuild interval) — locked by
+   `tests/test_nvt.py::test_batched_langevin_matches_per_step`.
+3. **Dropped the per-rebuild pair sort** (`NeighborListManager.sort_pairs` now
+   defaults to `False`): 1354 / 346 / 102 → 2153 / 664 / 201 steps/s at 4k / 16k /
+   50k (**1.6× / 1.9× / 2.0×**). A wall-clock decomposition of a 50k rebuild showed
+   the final `np.lexsort` of ~4.8M pairs was **~77% of the rebuild** (~700 ms) and
+   bought nothing: MLX scatter-add is insensitive to pair order, so the
+   Lennard-Jones energy and forces are unchanged (identical pair sets; residuals
+   are summation-order ULPs), and unsorted lists are still deterministic. Locked by
+   `tests/test_neighbors.py::test_unsorted_pairs_are_physics_neutral_and_default_in_md_loop`.
+   (`cProfile` had mis-attributed the rebuild cost to the Python candidate loop;
+   wall-clock timers found the sort. A vectorized candidate generator was
+   prototyped and discarded — it gave only ~2% once the sort was gone.)
+
+Cumulatively MLX is **21.6× / 20.9× / 23.6×** faster at 4k / 16k / 50k than the
+original `mlx_cell_blocks` baseline.
+
+### Interpretation
+
+- **MLX now matches LAMMPS across the ladder (~1.0–1.2×)** — same reduced-unit LJ
+  physics, both building neighbor lists on the host with the pair force on the GPU
+  — down from ~20–27× at the start, and from ~1.6–2.3× before the pair sort was
+  dropped. At 16k the two are neck-and-neck (663.7 vs 664.6 steps/s). The three
+  levers were structural, not micro-optimization: stop computing masked padded
+  candidates, stop paying a host round-trip every step, and stop sorting a pair
+  list nothing reads in order.
+- **The batched fast path removes the per-step host sync.** With a managed
+  neighbor list the integrator could not be compiled and synced (`mx.eval`) every
+  step. Running `block_size` Langevin substeps as one compiled block — with the
+  neighbor displacement check at block boundaries and a larger skin so rebuilds
+  stay rare — cuts the host round-trips by `block_size`× and lets MLX fuse the
+  step. A fixed-list NVE micro-loop showed the ceiling: per-step sync caps 4k at
+  ~3.2k steps/s, while syncing once per ~50 steps reaches ~9k.
+- **Measure with wall-clock timers, not `cProfile`, for this code.** `cProfile`
+  attributes by call count, so it inflated the per-cell Python candidate loop to
+  ~72% of a 50k rebuild and made the single expensive `np.lexsort` C call look
+  free. Plain `perf_counter` timing reversed that: the sort was ~77%, the loop a
+  few percent. The fix followed the corrected measurement (drop the sort), not the
+  profile (which would have sent us to rewrite the loop for ~2%).
+- **The residual gap to OpenMM is structural, and now splits two ways.** OpenMM
+  throughput is nearly flat (24k → 3.2k steps/s, ~7.5× for a 50× size increase);
+  MLX goes 1907 → 201 (~9.5×). OpenMM keeps the *entire* step on-device (fused tile
+  kernels, neighbor list on device, no host round-trip) and is launch-bound at
+  these sizes — extra atoms are nearly free. MLX still pays two real O(N) costs:
+  the per-step force (now ~3.8 ms/step at 50k, several dispatched kernels per
+  substep vs OpenMM's one fused tile kernel) and the host neighbor rebuild
+  (now ~⅓ of 50k wall, down from ~⅔ before the sort fix).
+- The next closure levers are therefore **force-step kernel fusion** (collapse the
+  per-substep gather → distance → LJ → scatter-add dispatch chain) and an
+  **on-device neighbor rebuild** (`mx.fast.metal_kernel` exists) to remove the
+  remaining host round-trip and flatten MLX's curve toward OpenMM's launch-bound
+  regime.
+
+### Energy-conservation note (why these numbers are trustworthy)
+
+This ladder was first run before a correctness fix and exposed a critical bug:
+MLX MD did **not conserve energy** on a standard LJ fluid — total energy climbed
+every step and diverged to `NaN` within a few thousand steps, which also corrupted
+the throughput numbers (a diverging system changes the per-step work and crashed
+the neighbor backend at 16k/50k). Root cause: `Cell.wrap` round-tripped through
+fractional coordinates, so in float32 it nudged boundary atoms by ~1e-2 each step
+(not an exact lattice translation), doing spurious work. The fix makes `wrap` a
+direct `x - L·floor(x/L)` translation (matching `minimum_image`); NVE now conserves
+energy over long runs and a regression test guards it
+(`tests/test_nve.py::test_simulate_nve_conserves_energy_over_long_run`,
+`tests/test_core.py::test_wrap_is_exact_lattice_translation`). The numbers above are
+post-fix: every MLX run completed with finite, bounded energy drift.
+
+## Reproduce
+
+```bash
+uv run python scripts/run_same_workload_lj_scaling.py \
+  --sizes 1000,4000,16000,50000 --steps 3000,2000,800,300 \
+  --block-size 16 --neighbor-skin 1.2
+```
+
+(`--block-size 1` reproduces the per-step baseline; `--block-size 16
+--neighbor-skin 1.2` is the batched fast path reported above. Both are the same
+physics — the batched path matches the per-step trajectory to floating-point
+precision. The managed neighbor list now defaults to unsorted pairs
+(`NeighborListManager.sort_pairs=False`); pass `sort_pairs=True` to restore
+canonical `(i, j)` ordering at the cost of a per-rebuild `lexsort`.)
+
+Raw per-engine JSON and the aggregated `summary.json` are written under the
+gitignored `results/same-workload-lj-scaling/`. The MLX command stays in the
+`mlx_atomistic.benchmarks` module; OpenMM and LAMMPS commands stay under
+`scripts/`, per the reference-engine boundary.

--- a/site/src/content/docs/benchmarks/same-workload-openmm-comparison.md
+++ b/site/src/content/docs/benchmarks/same-workload-openmm-comparison.md
@@ -1,0 +1,118 @@
+---
+title: "Same-Workload OpenMM Comparison"
+---
+
+
+Date: 2026-05-23
+
+Scope: refreshed controlled `mlx_atomistic` vs `openmm-reference` comparison.
+This report only compares rows where workload and metric match. Rows marked
+`blocked`, `diagnostic`, or `deferred` keep their raw evidence but do not get
+performance ratios.
+
+## Summary
+
+| Pair id | Status | MLX result | OpenMM result | Ratio | Raw output |
+| --- | --- | ---: | ---: | ---: | --- |
+| `lj-synthetic-loop` | `comparable` | 37.8469 steps/s | 727.9128 steps/s | 19.2331 OpenMM/MLX throughput | `results/same-workload-openmm-comparison/summary.json`; `results/same-workload-openmm-comparison/mlx-lj-synthetic-loop.json`; `results/same-workload-openmm-comparison/openmm-lj-synthetic-loop.json` |
+| `gbsa-obc-small` | `comparable` | 3.3352 ms/eval | 0.001458 ms/eval | 0.0004372 OpenMM/MLX latency | `results/same-workload-openmm-comparison/summary.json`; `results/same-workload-openmm-comparison/mlx-phase3-controlled.json`; `results/same-workload-openmm-comparison/openmm-gbsa-obc-small.json` |
+| `tip4p-ew-water` | `comparable` | 6.0068 ms/eval | 0.0003339 ms/eval | 0.00005558 OpenMM/MLX latency | `results/same-workload-openmm-comparison/summary.json`; `results/same-workload-openmm-comparison/mlx-phase3-controlled.json`; `results/same-workload-openmm-comparison/openmm-tip4p-ew-water.json` |
+| `dhfr-implicit` | `comparable` | 0.3095 ns/day | 1.3136 ns/day | 4.2447 OpenMM/MLX throughput | `results/same-workload-openmm-comparison/summary.json`; `results/same-workload-openmm-comparison/mlx-dhfr-implicit.json`; `results/same-workload-openmm-comparison/openmm-dhfr-implicit.json`; [`same-workload-dhfr-stretch.md`](./same-workload-dhfr-stretch.md) |
+| `dhfr-explicit-pme` | `blocked` | blocked: PME artifact must be neutral (`net_charge=-11`) | OpenMM Reference one-step row runs; OpenMM OpenCL context 752.5 ns/day | none | `results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json`; `results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json`; [`same-workload-dhfr-stretch.md`](./same-workload-dhfr-stretch.md) |
+
+## Interpretation
+
+`lj-synthetic-loop` is a tiny controlled MD row: one synthetic LJ step, 32
+atoms, matching atom count, matching step count, and `steps/s` on both sides.
+In that narrow row, the OpenMM OpenCL throughput is 19.2331 times the MLX
+throughput.
+
+That is not a production-MD conclusion. It says the current tiny MLX full-loop
+path has lower throughput than OpenMM on this controlled smoke case. It does
+not say how MLX compares on DHFR, ApoA1, PME, or larger systems.
+
+`gbsa-obc-small` is now a controlled latency row. The MLX row is the
+`obc_pair_accumulation_and_force` case from
+`results/same-workload-openmm-comparison/mlx-phase3-controlled.json`. The
+summary keeps the logical pair id `gbsa-obc-small`; the per-pair
+`results/same-workload-openmm-comparison/mlx-gbsa-obc-small.json` file is a row
+extract that points back to the combined phase3 source. The OpenMM Reference row
+reports `status: "ok"`,
+`fixture: "gbsa_obc_small"`, `ms_per_eval`, and an `obc_force_setup` payload in
+`results/same-workload-openmm-comparison/openmm-gbsa-obc-small.json`. Because
+this is a latency metric, the lower OpenMM/MLX ratio means the OpenMM Reference
+latency is lower for this controlled OBC operation.
+
+`tip4p-ew-water` is also a controlled latency row. The MLX row is the
+`m_site_reconstruction` case from
+`results/same-workload-openmm-comparison/mlx-phase3-controlled.json`. The
+summary keeps the logical pair id `tip4p-ew-water`; the per-pair
+`results/same-workload-openmm-comparison/mlx-tip4p-ew-water.json` file is a row
+extract that points back to the combined phase3 source. The OpenMM Reference row
+reports `status: "ok"`,
+`fixture: "tip4p_ew_water"`, `operation_semantics:
+"virtual_site_reconstruction"`, and `openmm_operation:
+"Context.computeVirtualSites"` in
+`results/same-workload-openmm-comparison/openmm-tip4p-ew-water.json`. Because
+this is a latency metric, the lower OpenMM/MLX ratio means the OpenMM Reference
+latency is lower for this controlled virtual-site reconstruction operation.
+
+`dhfr-implicit` is now a real one-step same-workload smoke row. The MLX side
+loads an OpenMM-derived DHFR GBSA/OBC artifact, builds MLX force terms, and runs
+one bounded NVT step at `0.004 ps`. The OpenMM Reference side runs the matching
+one-step implicit GBSA/OBC row. Because both rows are `ok`, use the ratio as a
+narrow reference comparison for this smoke workload only.
+
+`dhfr-explicit-pme` remains blocked on the MLX side for a concrete artifact
+reason: the Amber20/JAC PME artifact is charged (`net_charge=-11`) and the
+current PME artifact policy requires neutral systems. The old AMBER 10-12
+blocker is no longer the active blocker for this local input. The comparison
+helper correctly suppresses the explicit PME ratio while keeping the OpenMM
+Reference raw row.
+
+No row in this report is currently labeled `diagnostic` or `deferred`. The
+benchmark ladder still uses those labels for rows whose operation semantics,
+metric family, or reference mapping are not yet controlled enough for a ratio.
+
+## Reproducer
+
+Raw controlled outputs:
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.md_performance --sizes 32 --steps 1 --sample-interval 1 --diagnostic-interval 1 --evaluation-interval 1 --json > results/same-workload-openmm-comparison/mlx-lj-synthetic-loop.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_opencl.py --platform OpenCL --particles 32 --steps 1 --warmup-steps 0 --spacing-nm 1.0 --json > results/same-workload-openmm-comparison/openmm-lj-synthetic-loop.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.phase3_physics --evaluations 1 --waters 1 --atoms 4 --replica-steps 1 --json > results/same-workload-openmm-comparison/mlx-phase3-controlled.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_opencl.py --case gbsa-obc-small --platform Reference --particles 4 --steps 1 --json > results/same-workload-openmm-comparison/openmm-gbsa-obc-small.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_opencl.py --case tip4p-ew-water --platform Reference --particles 4 --steps 1 --json > results/same-workload-openmm-comparison/openmm-tip4p-ew-water.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-implicit --steps 1 --json > results/same-workload-openmm-comparison/mlx-dhfr-implicit.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.dhfr --case dhfr-explicit-pme --steps 1 --json > results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-implicit --platform Reference --steps 1 --json > results/same-workload-openmm-comparison/openmm-dhfr-implicit.json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_dhfr.py --case dhfr-explicit-pme --platform Reference --steps 1 --json > results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json
+```
+
+Comparison summary:
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.same_workload_compare --mlx-json results/same-workload-openmm-comparison/mlx-lj-synthetic-loop.json --mlx-json results/same-workload-openmm-comparison/mlx-phase3-controlled.json --mlx-json results/same-workload-openmm-comparison/mlx-dhfr-implicit.json --mlx-json results/same-workload-openmm-comparison/mlx-dhfr-explicit-pme.json --openmm-json results/same-workload-openmm-comparison/openmm-lj-synthetic-loop.json --openmm-json results/same-workload-openmm-comparison/openmm-gbsa-obc-small.json --openmm-json results/same-workload-openmm-comparison/openmm-tip4p-ew-water.json --openmm-json results/same-workload-openmm-comparison/openmm-dhfr-implicit.json --openmm-json results/same-workload-openmm-comparison/openmm-dhfr-explicit-pme.json --out results/same-workload-openmm-comparison/summary.json
+```
+
+These commands require local MLX/Metal access for MLX rows and OpenMM/OpenCL or
+OpenMM Reference availability for OpenMM rows. A sandbox atexit warning from
+MLX/Metal cleanup after the summary command is not a benchmark failure when the
+summary JSON is written with `status: "ok"`.
+
+## Next Optimization Target
+
+The next optimization target should be MLX TIP4P-Ew virtual-site
+reconstruction, followed by GBSA/OBC force evaluation if the TIP4P path does
+not explain the shared latency overhead. This is based on measured comparable
+rows only: `tip4p-ew-water` has the largest MLX latency in the refreshed
+controlled summary, and both `tip4p-ew-water` and `gbsa-obc-small` use
+controlled OpenMM Reference latency rows.
+
+The `lj-synthetic-loop` result also shows a measured tiny full-loop throughput
+gap, so force evaluation, reporting cadence, and synchronization remain valid
+diagnostic follow-ups for that row. `dhfr-implicit` is now runnable, but its
+one-step row should guide runtime-path hardening before it guides broad
+performance optimization claims. `dhfr-explicit-pme` still needs a neutral PME
+artifact policy before it can guide optimization.

--- a/site/src/content/docs/dft/dft-geometry-optimization.md
+++ b/site/src/content/docs/dft/dft-geometry-optimization.md
@@ -1,0 +1,86 @@
+---
+title: "DFT Geometry Optimization"
+---
+
+
+Milestone 5 adds a fixed-cell relaxation workflow for the current DFT stack. It optimizes only ion-center positions and keeps the orthorhombic cell fixed. Forces come from `run_scf(...).forces`, so the workflow is only as physical as the local pseudopotential force model underneath it.
+
+This is a workflow and consistency milestone. It is not a claim that the current DFT layer is chemically validated production DFT.
+
+## Workflow
+
+The public entry point is:
+
+```python
+from mlx_atomistic.dft import GeometryOptimizationConfig, optimize_geometry
+
+result = optimize_geometry(system, config=GeometryOptimizationConfig(max_steps=5))
+```
+
+Each geometry step does:
+
+1. Run SCF at the current ion positions.
+2. Use the current force array `F = -∂E/∂R`.
+3. Propose an ion-position step with an L-BFGS-style inverse-Hessian update.
+4. Fall back to steepest descent if the L-BFGS direction is invalid.
+5. Backtrack the step size until the SCF energy is finite and not higher than the previous accepted geometry.
+6. Wrap accepted ion positions back into the periodic cell.
+7. Reuse the previous SCF density and orbitals as continuation inputs for the next line-search trial.
+
+The optimizer accepts SCF results with status `converged` or `max_iterations`. It rejects SCF failures, nonfinite energies, and exhausted line searches.
+
+## Results
+
+`GeometryOptimizationResult.to_dict()` is JSON-safe and includes:
+
+- final status, final energy, final positions, and final maximum force;
+- per-step energy, energy delta, maximum force, RMS force, force norm, step norm, and accepted step size;
+- per-step SCF status, SCF iteration count, residual, electron count, and timing summary;
+- final SCF summary without dense array payloads.
+
+Valid statuses are:
+
+- `converged`
+- `max_steps`
+- `line_search_failed`
+- `scf_failed`
+- `nonfinite`
+
+## Restart-Like Continuation
+
+Within one `optimize_geometry(...)` run, SCF is continued by passing the previous step's density and orbitals into `run_scf(...)`. This is a practical acceleration and stability feature for local relaxation workflows because adjacent geometries usually have similar densities.
+
+The compressed NPZ helpers save and load the accepted geometry history:
+
+```python
+from mlx_atomistic.dft import save_geometry_optimization, load_geometry_optimization
+
+save_geometry_optimization("relaxation.npz", result, metadata={"system": "gth-h2"})
+record = load_geometry_optimization("relaxation.npz")
+```
+
+The NPZ record stores positions, forces, energies, maximum forces, statuses, JSON metadata, and JSON step history. It does not store enough dense SCF state to resume a calculation by itself yet.
+
+## CLI
+
+Compact built-in demos are available through:
+
+```bash
+uv run python -m mlx_atomistic.dft.optimize --system gth-h2 --steps 5 --json
+```
+
+Supported demo systems:
+
+- `gaussian-dimer`: toy two-center Gaussian local potential.
+- `gth-h2`: two hydrogen ions using parsed GTH local pseudopotentials.
+- `upf-si2`: two silicon ions using parsed UPF local pseudopotentials.
+
+The benchmark entry point compares the same families:
+
+```bash
+uv run python -m mlx_atomistic.benchmarks.dft_geometry --json
+```
+
+## Current Scientific Boundary
+
+This milestone still has no spin polarization, k-points, nonlocal projector application, stress tensor, cell relaxation, or geometry optimizer for production materials workloads. The force path is useful for validating local potential derivatives and workflow mechanics before those larger DFT features are added.

--- a/site/src/content/docs/dft/dft-numerics.md
+++ b/site/src/content/docs/dft/dft-numerics.md
@@ -1,0 +1,113 @@
+---
+title: "DFT Numerics"
+---
+
+
+Milestone 3 makes the DFT layer more numerically inspectable. It is still a
+small Γ-point, spin-unpolarized, local-pseudopotential prototype, but the code
+now has explicit checks for the Kohn-Sham operator, orbital residuals, energy
+decomposition, and total-energy force consistency.
+
+## Kohn-Sham Operator
+
+The Kohn-Sham equation is an eigenproblem for auxiliary one-electron orbitals:
+
+```text
+H_KS[ρ] ψᵢ = εᵢ ψᵢ
+```
+
+For the current prototype:
+
+```text
+H_KS[ρ] = T + V_local + V_H[ρ] + V_xc[ρ]
+```
+
+- `T` is the plane-wave kinetic operator, applied in reciprocal space as
+  `0.5 |G|²`.
+- `V_local` is the toy Gaussian local pseudopotential.
+- `V_H[ρ]` is the Hartree potential from the reciprocal-space Poisson solve.
+- `V_xc[ρ]` is the exchange-correlation potential.
+
+`KohnShamOperator` exposes these pieces separately so tests and notebooks can
+inspect operator action directly instead of treating SCF as a black box.
+
+## Dense Reference Vs Operator Application
+
+For tiny grids, the package can explicitly build the dense Hamiltonian matrix by
+applying `H_KS` to every grid basis vector. That path is intentionally not a
+production solver; it is a reference implementation.
+
+The operator path applies `H_KS` without building the dense matrix. Milestone 3
+compares the two:
+
+```text
+dense_matrix @ ψ  ≈  KohnShamOperator.apply_hamiltonian(ψ)
+```
+
+This is the main guardrail before replacing the tiny dense solver with a real
+iterative eigensolver.
+
+## Orbital Residuals
+
+SCF density residual alone is not enough. A density can stop changing while the
+orbitals are still poor eigenvectors of the current Hamiltonian. The new
+diagnostic computes:
+
+```text
+||Hψᵢ - εᵢψᵢ||
+```
+
+Small residuals mean the orbital is close to an eigenvector of the current
+Kohn-Sham operator. `SCFResult` now records orbital eigenvalues, per-orbital
+residuals, and the maximum orthonormality error.
+
+## Energy Decomposition
+
+The SCF electronic energy is separated from center-center repulsion:
+
+```text
+E_total = E_electronic + E_center-center
+```
+
+`E_electronic` includes kinetic, local, Hartree, and XC terms. The
+center-center term is a toy Coulomb repulsion between Gaussian centers. This is
+not yet a real pseudopotential ion-ion model, but it prevents the total energy
+from hiding an important physical contribution.
+
+## Force Checks
+
+`run_scf(...)` reports center forces for `DFTSystem` calculations. These combine
+the local Gaussian Hellmann-Feynman force with the center-center force.
+
+`scf_total_energy_forces(...)` reruns SCF after displacing each center and
+compares:
+
+```text
+F_A ≈ -[E(R_A + δ) - E(R_A - δ)] / 2δ
+```
+
+This checks consistency between the reported force and the total-energy surface.
+It does not prove production-grade DFT forces because the current model lacks
+real pseudopotentials, Pulay terms for non-plane-wave bases, stress, geometry
+optimization, spin, and k-points.
+
+## Benchmark Evidence
+
+The DFT benchmark reports SCF timing sections. The new operator benchmark adds:
+
+- Kohn-Sham operator construction time.
+- Direct operator application time.
+- Dense Hamiltonian build time.
+- Dense diagonalization time.
+- Prototype subspace solve time.
+- Dense-vs-operator matrix-vector error.
+
+Use:
+
+```bash
+uv run python -m mlx_atomistic.benchmarks.dft_operator --json
+```
+
+The intended decision point is whether the next optimization target should be
+Hamiltonian application, FFT/Hartree work, eigensolver iteration, or a future
+custom Metal kernel.

--- a/site/src/content/docs/dft/dft-production-core.md
+++ b/site/src/content/docs/dft/dft-production-core.md
@@ -1,0 +1,78 @@
+---
+title: "DFT Production-Core Milestone"
+---
+
+
+This milestone consolidates the next DFT phases into one correctness-first release. The library now has working prototype surfaces for nonlocal pseudopotentials, iterative Kohn-Sham solving, spin/occupation diagnostics, k-point and band-path diagnostics, finite-difference stress, dense SCF restart persistence, and reference comparison.
+
+The implementation is still not chemically certified production DFT. It is a production-core infrastructure milestone: the main algorithms exist, have tests, and expose diagnostics, but the numerical models remain intentionally conservative.
+
+## Nonlocal Pseudopotentials
+
+UPF and GTH nonlocal metadata is converted into normalized real-space separable projectors. The operator applies:
+
+```text
+V̂_NL ψ = Σᵢ |βᵢ⟩ Dᵢ ⟨βᵢ|ψ⟩
+```
+
+For UPF, diagonal `PP_DIJ` values are used as projector couplings after Ry-to-Hartree conversion. For GTH, parsed projector coefficients seed the coupling. This gives a Hermitian validation path, but it is not yet a full chemically faithful reproduction of every format convention.
+
+SCF applies nonlocal projectors by default when available. `SCFConfig(apply_nonlocal=False)` keeps the old local-only path available for debugging and comparison.
+
+## Solvers
+
+Dense diagonalization remains the tiny-grid reference. Above the dense cutoff, `auto` SCF selects the Davidson-style path. The current Davidson implementation uses a kinetic preconditioner and residual iteration for larger grids, while still falling back to dense reference on tiny validation grids.
+
+Diagnostics expose residuals, orthonormality error, solver metadata, subspace size, and restart count.
+
+## Spin, Occupations, k-Points, And Bands
+
+The new spin layer is collinear only:
+
+- `unpolarized`: one total density `ρ(r)`.
+- `polarized`: separate `ρ↑(r)` and `ρ↓(r)` diagnostics.
+
+Occupation models include fixed occupations and Fermi-Dirac occupations. k-point abstractions support Γ-point meshes, Monkhorst-Pack-style meshes, and non-SCF band paths. The kinetic operator supports `0.5|G + k|²`, and Γ remains the default.
+
+## Stress, Relaxation, And Restart
+
+Finite-difference stress estimates diagonal orthorhombic stress by changing cell lengths and rerunning SCF. Geometry optimization remains ion-position-first by default, with config fields now prepared for cell and coupled relaxation modes.
+
+Dense SCF restart files store density, orbitals, ion positions, cell lengths, spin metadata, and Γ k-point metadata for small-system continuation workflows.
+
+## Reference Validation
+
+Reference comparison is intentionally static and lightweight. Fixtures are JSON summaries; QE/CP2K are not imported, built, or required in CI. The comparison helper records observed energy, expected energy, error, and pass/fail against a documented tolerance.
+
+## DFT/QM Platform Scope
+
+`get_dft_qm_scope_report()` classifies local DFT/QM capability against CP2K and
+Quantum ESPRESSO reference families without changing the runtime dependency
+boundary.
+
+| Feature | Local Status | Reference Family |
+| --- | --- | --- |
+| Plane-wave SCF core | proof-level | CP2K Quickstep, QE PWscf |
+| UPF/GTH pseudopotentials and nonlocal projectors | proof-level | QE UPF, CP2K GTH |
+| Geometry relaxation and finite-difference stress | proof-level | CP2K MOTION/GEO_OPT, QE relax |
+| Static reference comparison | supported | static CP2K/QE fixture summaries |
+| QM/MM force-environment orchestration | deferred | CP2K FORCE_EVAL/QMMM |
+| PH/EPW/NEB/TDDFT/MPI/offload suite breadth | deferred | QE and CP2K production suites |
+| Importing, wrapping, building, or running CP2K/QE | anti-goal | external executables |
+
+`dft_qm_scope_readiness_report()` returns a shared readiness payload for these
+features. Deferred, anti-goal, and unknown features report blockers before any
+production-suite claim can be emitted.
+
+## Hot-Path Recommendation
+
+The first future custom Metal kernel should target **Hamiltonian application**, specifically the combined kinetic + local + nonlocal application path used by Davidson and band calculations.
+
+Reason:
+
+- Dense diagonalization is a reference path and should not be optimized first.
+- SCF and band workloads repeatedly apply `Hψ`.
+- Nonlocal projector application adds many grid reductions and scatter-like projector accumulations.
+- A fused Metal path can reduce Python-loop overhead before deeper eigensolver work.
+
+Second-tier targets are projector construction/interpolation and orthonormalization. FFT/Hartree should be measured carefully before replacing MLX/Accelerate-backed paths.

--- a/site/src/content/docs/dft/dft-pseudopotentials.md
+++ b/site/src/content/docs/dft/dft-pseudopotentials.md
@@ -1,0 +1,79 @@
+---
+title: "DFT Pseudopotentials"
+---
+
+
+Milestone 4 adds a real ion-model layer while keeping the DFT engine small and
+inspectable. The code now supports parsed UPF and GTH pseudopotential inputs for
+local-potential SCF calculations.
+
+## What Is Implemented
+
+- `PseudopotentialData` stores parsed local potential data, valence charge, and
+  nonlocal metadata.
+- `Ion` and `IonCollection` place parsed pseudopotentials at periodic ion
+  centers.
+- `LocalPseudopotentialField` builds `V_local(r)` on a real-space DFT grid.
+- `DFTSystem` accepts `IonCollection` and defaults the electron count to the
+  sum of valence charges for neutral systems.
+- `run_scf(...)` records pseudopotential diagnostics:
+  `pseudopotential_format`, `ion_count`, `valence_electron_count`,
+  `nonlocal_available`, and `nonlocal_applied`.
+
+## UPF
+
+`read_upf(path)` reads UPF v2-style XML files from Quantum ESPRESSO-style
+sources. The current path uses:
+
+- `PP_HEADER` for element and valence charge.
+- `PP_MESH/PP_R` for radial samples.
+- `PP_LOCAL` for the local potential.
+- `PP_BETA.*` tags for nonlocal projector metadata.
+
+The local UPF potential is interpolated onto the periodic real-space grid. UPF
+nonlocal projectors are parsed and stored, but not applied to orbitals yet.
+
+## GTH
+
+`read_gth(path, element=..., name=...)` reads both single GTH files and CP2K
+database entries. The local GTH potential is evaluated analytically:
+
+```text
+V_local(r) = -Z_ion erf(r / √2 r_loc) / r
+             + exp[-0.5(r/r_loc)²] Σᵢ cᵢ(r/r_loc)²ⁱ
+```
+
+The derivative of this local form is used for fixed-density ion-force checks.
+GTH nonlocal channel metadata is parsed and stored, but nonlocal application is
+still intentionally disabled.
+
+## Forces
+
+For ion-backed systems, reported forces include:
+
+```text
+F_total = F_local electron-ion + F_center-center
+```
+
+The force validation in this milestone checks fixed-density local forces and
+SCF total-energy finite differences. This is a consistency check for the current
+local-potential model, not a claim of production DFT force accuracy.
+
+## Current Limits
+
+- No nonlocal projector application yet.
+- No spin, k-points, stress tensor, geometry optimizer, or real production
+  pseudopotential validation.
+- Vendor checkouts remain reference material only; the package does not import
+  Quantum ESPRESSO or CP2K code.
+
+## Benchmark
+
+Run:
+
+```bash
+uv run python -m mlx_atomistic.benchmarks.dft_pseudopotential --json
+```
+
+The benchmark compares compact Gaussian, UPF-local, and GTH-local SCF cases and
+reports timing plus pseudopotential diagnostics.

--- a/site/src/content/docs/dft/dft-scf-core.md
+++ b/site/src/content/docs/dft/dft-scf-core.md
@@ -1,0 +1,56 @@
+---
+title: "DFT SCF Core"
+---
+
+
+The DFT layer now has a more explicit SCF core while staying intentionally
+small: spin-unpolarized, Γ-point, orthorhombic cells, and local Gaussian
+pseudopotentials only.
+
+## Exchange-Correlation
+
+DFT does not solve directly for the full many-electron wavefunction. In the
+Kohn-Sham construction, auxiliary orbitals generate the density `ρ(r)`, and the
+unknown many-electron physics is approximated by an exchange-correlation
+functional.
+
+This milestone exposes that as a small API:
+
+- `DiracExchange`
+- `LDACorrelationPZ81`
+- `LDAExchangeCorrelation`
+
+Each functional returns an energy density, total energy, and potential `v_xc`.
+The default SCF path now uses LDA exchange plus PZ81 correlation.
+
+## SCF Mixing
+
+SCF iteration repeatedly maps an input density to a new output density. Directly
+replacing the old density is often unstable, so the code now has two mixers:
+
+- `LinearMixer`: conservative and predictable.
+- `PulayDIISMixer`: uses residual history to accelerate convergence.
+
+`SCFResult` records density residual, potential residual, energy delta,
+convergence status, failure reason, timing totals, and mixer metadata.
+
+## Restartable State
+
+`run_scf(...)` accepts `initial_density` and `initial_orbitals`. This is enough
+for continuation workflows and future geometry steps. A restart density is
+renormalized to the requested electron count so continuation does not silently
+change the number of electrons.
+
+## Forces
+
+`local_pseudopotential_forces(...)` computes Hellmann-Feynman-style forces on
+Gaussian centers from a converged or fixed density. These are diagnostic forces
+for the toy local pseudopotential model, not production DFT forces and not yet a
+geometry optimizer.
+
+## Performance Evidence
+
+The DFT benchmark now reports per-case timings for Hartree solves, XC
+evaluation, kinetic application, mixer cost, force evaluation, total SCF time,
+and a compact FFT probe. This makes the next optimization decision evidence
+based instead of speculative.

--- a/site/src/content/docs/foundations/dft-foundations.md
+++ b/site/src/content/docs/foundations/dft-foundations.md
@@ -1,0 +1,63 @@
+---
+title: "DFT Foundations"
+---
+
+
+This first DFT slice is a small spin-unpolarized Γ-point plane-wave prototype.
+It is meant to make the numerical building blocks inspectable before we try to
+make them chemically broad or highly optimized.
+
+## What It Models
+
+The prototype works with one total electron density `ρ(r)`.
+For closed-shell systems, each spatial orbital is doubly occupied:
+
+```text
+ρ(r) = 2Σᵢ |ψᵢ(r)|²
+```
+
+Odd or fractional electron counts are allowed for toy examples, but the code
+does not yet model separate `ρ↑(r)` and `ρ↓(r)` spin densities.
+
+## Units
+
+DFT internals use atomic units:
+
+```text
+ℏ = 1
+m_e = 1
+e = 1
+4πε₀ = 1
+```
+
+Coordinates and cell lengths are in bohr, energies are in hartree, and the
+electron density integrates to electron count over the cell.
+
+## Numerical Pieces
+
+- `RealSpaceGrid` stores an orthorhombic periodic grid.
+- `ReciprocalGrid` stores FFT-compatible `G` vectors and `|G|²`.
+- `normalize_orbitals(...)` enforces `∫ |ψᵢ(r)|² dr = 1`.
+- `density_from_orbitals(...)` builds `ρ(r)` from occupied orbitals.
+- `LocalGaussianPseudopotential` provides a toy local external potential.
+- `hartree_potential(...)` solves the periodic Poisson equation in reciprocal
+  space, with the `G = 0` term set to zero.
+- `DiracExchange`, `LDACorrelationPZ81`, and `LDAExchangeCorrelation` expose the
+  first exchange-correlation layer.
+- `run_scf(...)` iterates density, effective potential, and orbitals with
+  linear or Pulay DIIS density mixing.
+
+Programmatic toy systems are available as `toy_one_electron_dft_example()` and
+`toy_closed_shell_dft_example()` from `mlx_atomistic.examples`.
+
+## Current Limits
+
+This is not production DFT. It intentionally excludes k-points, spin
+polarization, real pseudopotential formats, correlation functionals, forces,
+geometry optimization, and custom Metal kernels.
+
+The current value is correctness and observability: density normalization,
+energy decomposition, SCF residuals, FFT behavior, local Gaussian force checks,
+and small benchmark evidence. Future DFT milestones can add real
+pseudopotentials, spin, k-points, forces suitable for geometry updates, and then
+custom Metal kernels once the hot paths are measured.

--- a/site/src/content/docs/foundations/runtime-boundaries.md
+++ b/site/src/content/docs/foundations/runtime-boundaries.md
@@ -1,0 +1,85 @@
+---
+title: "Runtime Boundaries"
+---
+
+
+`mlx_atomistic` is the primary trajectory generator and product runtime for this
+repo. The project can use external engines for reference runs and validation,
+but project-owned trajectories should come from the MLX implementation unless a
+future spec explicitly changes that boundary.
+
+## Core Runtime
+
+- `src/mlx_atomistic/` contains the MLX/Metal simulation library: force terms,
+  neighbor-list/runtime paths, integrators, reports, and benchmarks.
+- Core package dependencies stay lean: MLX, NumPy, and SciPy are the runtime
+  surface in `project.dependencies`.
+- `src/mlx_atomistic/prep/` prepares and validates inputs for MLX-ready artifacts.
+  It may use chemistry tooling, but it should not turn OpenMM or LAMMPS into the
+  main runtime path.
+
+## Platform Boundary
+
+`mlx_atomistic.runtime.get_platform_boundary_report()` describes the local
+mini-platform boundary without importing reference engines. The report names the
+product runtime, active MLX runtime information, reference-engine policy, and
+local concept groups for runtime/backend, system/artifact, protocol, readiness,
+validation, and DFT/QM scope.
+
+## Reference Engines
+
+- OpenMM is a reference and preview engine. In the current `uv` environment it
+  resolves from the PyPI `openmm==8.5.1` macOS arm64 wheel and exposes
+  `Reference`, `CPU`, and `OpenCL` platforms. We do not build OpenMM locally for
+  this project.
+- LAMMPS is a reference engine for GPU/OpenCL semantics and neighbor-list
+  behavior. It is configured as a `uv` local build from the upstream PyPI source
+  package with `PKG_GPU=ON`, `GPU_API=opencl`, and `GPU_PREC=single`.
+- GROMACS is a reference for biomolecular MD staging, PME/nonbonded performance
+  shape, preprocessing boundaries, and trajectory-analysis conventions.
+- CP2K and Quantum ESPRESSO are references for DFT/QM suite boundaries and force
+  environment discipline, not product runtime engines for this package.
+- OpenMM and LAMMPS remain outside `project.dependencies`; reference engines
+  belong to dev/reference workflows unless a future spec explicitly changes
+  that boundary.
+
+## Vendor Checkouts
+
+`vendors/` contains local reference source trees only. These trees are not
+Python package inputs, are not imported by `mlx_atomistic`, and are not built by
+`uv sync`. Use them for architecture study, algorithm references, and validation
+planning.
+
+## Notebook And Artifact Labels
+
+Notebook data and generated reports should make the engine explicit:
+
+- `mlx_atomistic`: product runtime output.
+- `openmm-reference`: OpenMM preview or validation output.
+- `lammps-reference`: LAMMPS reference or validation output.
+- `gromacs-reference`: GROMACS reference or validation output.
+- `cp2k-reference` / `qe-reference`: electronic-structure reference outputs.
+
+Generated trajectories and heavyweight science artifacts should stay local and
+ignored unless a later spec explicitly approves committing a small fixture.
+
+## Platform Evidence
+
+Runtime proof paths now carry compact platform metadata:
+
+- prepared MLX trajectories and checkpoints record `platform_boundary` and
+  `platform_readiness`;
+- OpenMM parity reports record `platform_evidence` and label OpenMM as
+  reference-only validation;
+- the Phase 3 GPCRmd 729 fixture probe records OpenMM reference evidence,
+  MLX prep/load/readiness evidence, and a blocker matrix without turning OpenMM
+  or `vendors/` into runtime dependencies;
+- MD performance payloads record `platform_evidence` for finite-output proof
+  cases;
+- DFT/QM scope is reported by `get_dft_qm_scope_report()` and
+  `dft_qm_scope_readiness_report()`.
+
+The current large-fixture production-readiness probe is blocked at MLX runtime
+topology/nonbonded provisioning, not at fixture selection or strict artifact
+loading. It should be read as a bounded blocker report, not as a production MD
+certification.

--- a/site/src/content/docs/foundations/testing.md
+++ b/site/src/content/docs/foundations/testing.md
@@ -1,0 +1,59 @@
+---
+title: "Testing"
+---
+
+
+The suite is tiered so the everyday lane is fast and deterministic, while heavier
+or dependency-bound tests run on demand.
+
+## Tiers (pytest markers)
+
+- *(unmarked)* — fast unit tests: pure functions and tiny synthesized systems
+  (2–10 atoms, 1–5 steps). The default lane; runs in seconds.
+- `slow` — long-running physics / SCF / benchmark tests (>~1s).
+- `integration` — multi-component end-to-end flows. A label, not a speed gate:
+  fast integration tests still run in the fast lane; slow ones also carry `slow`.
+- `reference` — require an external reference engine (OpenMM / LAMMPS). Guarded
+  with `pytest.importorskip`, so they skip cleanly when the engine is absent.
+- `data` — require a heavy, gitignored dataset (e.g. notebook OpenMM run reports).
+  Skip-guarded when the data is absent.
+
+Markers are registered with `--strict-markers`, so a typo'd marker fails fast.
+
+## Commands
+
+Fast lane — parallel, what CI runs on every push/PR (no reference engines, so it
+never builds LAMMPS):
+
+```bash
+uv run --group test python -m pytest -n auto -m "not slow and not reference and not data"
+```
+
+Full suite + coverage — what CI runs nightly / on demand (builds LAMMPS, runs
+every tier, gates coverage):
+
+```bash
+uv run --group dev python -m pytest --cov=mlx_atomistic --cov-report=term-missing --cov-fail-under=80
+```
+
+Run a single tier, e.g. just the slow tests:
+
+```bash
+uv run --group dev python -m pytest -m slow
+```
+
+## Dependency groups
+
+- `test` — pytest, pytest-cov, pytest-xdist, ruff. Light; no reference engines,
+  so the fast CI lane never has to build LAMMPS.
+- `reference` — OpenMM (PyPI wheel) and LAMMPS (built from source with
+  GPU/OpenCL).
+- `dev` — `test` + `reference` (the full local/CI environment).
+
+## Conventions
+
+- Prove physics on tiny synthesized systems; never mock the numerics.
+- Mock or guard only external boundaries: reference engines, file I/O, downloads.
+- Keep heavy/gitignored datasets out of the fast lane; tag such tests `data`.
+- Write outputs under `tmp_path`, never a fixed shared path — this keeps tests
+  parallel-safe under `-n auto`.

--- a/site/src/content/docs/foundations/units.md
+++ b/site/src/content/docs/foundations/units.md
@@ -1,0 +1,120 @@
+---
+title: "Units and MD Diagnostics"
+---
+
+
+`mlx-atomistic` uses explicit internal unit systems instead of SI in the numerical kernels.
+
+## Molecular Dynamics
+
+Low-level MD kernels use Lennard-Jones reduced units. Inputs passed directly to
+those kernels are dimensionless unless a caller explicitly converts them before
+calling the API:
+
+```text
+σ = 1
+ε = 1
+m = 1
+k_B = 1
+```
+
+Derived units:
+
+```text
+length      = σ
+energy      = ε
+mass        = m
+time        = τ = σ sqrt(m / ε)
+force       = ε / σ
+temperature = ε / k_B
+velocity    = σ / τ
+```
+
+Typical example values such as `dt = 0.005`, `temperature = 1.0`, `density = 0.8`,
+and `cutoff = 2.5` are reduced-unit values.
+
+The code exposes this convention as `mlx_atomistic.units.LJ_REDUCED_UNITS`.
+For material-specific reduced-unit experiments, create a `LennardJonesReducedUnits`
+instance with explicit `sigma`, `epsilon`, `mass`, and `boltzmann` values, then
+convert external values at the API boundary.
+
+Prepared-system artifacts are the physical-unit path. Their metadata records
+coordinate, mass, charge, energy, time, and temperature units, and the artifact
+gate converts accepted AMBER, CHARMM, and GROMACS subsets into runtime force
+terms that preserve that declared unit contract.
+
+## NVE Output Contract
+
+`simulate_nve()` separates trajectory storage from diagnostics:
+
+- `sample_interval` controls sparse trajectory frames only.
+- `sampled_positions`, `sampled_velocities`, `sampled_steps`, and `sampled_time`
+  are stored at step `0`, every sampled step, and the final step.
+- `potential_energy`, `kinetic_energy`, `total_energy`, `temperature`,
+  `pair_count`, and `rebuild_count` are dense per-step diagnostics with length
+  `steps + 1`.
+- `potential_energy_by_term` stores dense per-term potential-energy series when
+  multiple force terms are composed.
+
+This lets long runs keep a small trajectory while still retaining enough scalar
+diagnostics to judge integrator health.
+
+For NVE, the first correctness check is total-energy drift:
+
+```text
+E(t) = U(t) + K(t)
+ΔE(t) = E(t) - E(0)
+```
+
+`NVEResult.energy_drift` and `NVEResult.max_energy_drift` expose those values.
+Small nonzero drift is expected from finite `dt` and floating-point arithmetic.
+For a stable NVE smoke test, `max(|ΔE|)` should remain small over short runs and
+should improve when `dt` is reduced.
+
+## NVT and Langevin Dynamics
+
+`simulate_nvt()` uses a Langevin thermostat with BAOAB integration. It keeps the
+same sparse trajectory and dense diagnostics contract as `simulate_nve()`, but
+adds `target_temperature` and `temperature_error`.
+
+The v1 thermostat parameters are:
+
+```text
+T = target reduced temperature
+γ = friction in τ⁻¹
+```
+
+`γ = 0` disables stochastic thermostatting, so the NVT integrator reduces to the
+same force/position/velocity updates as NVE. With `γ > 0`, random kicks exchange
+energy with an implicit heat bath. That means total energy is not conserved in
+NVT; use temperature statistics rather than `ΔE(t)` as the primary health check.
+
+Seeded NVT runs use local MLX PRNG keys, so the same seed should reproduce the
+same trajectory without changing global random state.
+
+## Diagnostic Summaries
+
+`mlx_atomistic.diagnostics.summarize_md_result()` converts an MD result into a
+small dictionary of Python scalars for notebooks and CLI output. It reports
+initial/final/mean temperature, total-energy drift, and neighbor-list pair/rebuild
+counts when those fields are present. It also reports per-term potential-energy
+summaries when energy decomposition is available. For NVT results it reports
+target temperature and final/mean temperature error.
+
+When distance constraints are active, NVE/NVT results also include dense
+`constraint_max_error` diagnostics in the same reduced length unit as positions.
+
+## DFT
+
+The DFT prototype uses atomic units internally:
+
+```text
+ℏ = 1
+m_e = 1
+e = 1
+4πε₀ = 1
+```
+
+The current Γ-point plane-wave prototype keeps examples explicit about units.
+User-facing conversion helpers can be added once the DFT API grows beyond toy
+systems.

--- a/site/src/content/docs/mm/md-acceleration.md
+++ b/site/src/content/docs/mm/md-acceleration.md
@@ -1,0 +1,124 @@
+---
+title: "MLX-First MD Acceleration"
+---
+
+
+This milestone keeps Python as the user-facing API but moves the MD nonbonded
+hot path toward MLX array execution. The current priority is to measure how far
+dense and tiled MLX pair evaluation can go on Apple Silicon before introducing
+custom Metal kernels.
+
+## Backends
+
+- `mlx_dense` evaluates all pair interactions with dense MLX arrays. This is a
+  serious baseline on M-series machines with large unified memory.
+- `mlx_tiled` evaluates row blocks against all particles, reducing peak memory
+  while keeping the pair math in MLX.
+- `mlx_pairs` evaluates an explicit pair list with MLX gather/scatter. This is
+  the path used with prebuilt neighbor lists.
+- `mlx_dense_pairs` is a small-system neighbor-list backend selected by the
+  neighbor manager's `auto` policy. It evaluates the dense periodic distance
+  mask in MLX, then records explicit CPU `argwhere` compaction metadata because
+  this MLX runtime does not expose dynamic `argwhere`/`nonzero` pair emission.
+- `mlx_cell_pairs` is the large-system neighbor-list backend selected by the
+  neighbor manager's `auto` policy above the dense-pair atom limit. It keeps the
+  periodic cell/bin search space bounded, batches neighboring-cell candidates
+  into MLX distance-filter chunks, and emits compact pairs through CPU
+  compaction.
+- `python_neighbor` means the Python/NumPy cell-list builder is included in the
+  benchmark before MLX pair evaluation.
+- `auto` uses dense MLX when no pair list is supplied and the dense memory
+  estimate fits the configured budget; otherwise it falls back to tiled MLX.
+  For neighbor-list managers, `auto` selects `mlx_dense_pairs` for supported
+  small systems and `mlx_cell_pairs` above the small-system limit.
+
+## Current Hot-Path Recommendation
+
+Do not write a custom Metal kernel first. The first decision point should come
+from `python -m mlx_atomistic.benchmarks.md_acceleration --json`.
+
+The likely candidates are:
+
+- dense/tiled pair evaluation, if MLX force accumulation dominates runtime;
+- neighbor-list construction, if `python_neighbor` is much slower than
+  `mlx_pairs`;
+- DFT projector or solver work, if MD dense/tiled already scales well enough.
+
+For the current code shape, the most suspicious path is still neighbor-list
+construction: it uses Python dictionaries, Python sets, and NumPy loops. Dense
+MLX all-pairs should be measured first because the target machine has enough
+memory for thousands of particles.
+
+For GPCRmd-scale periodic systems, dense all-pairs is not viable. The current
+large-system route uses `mlx_cell_pairs`: CPU-side periodic binning bounds the
+candidate space, MLX evaluates batched neighboring-cell distance filters, and
+the backend emits compact pairs for the existing MLX pair force path. A
+92,001-atom GPCRmd 729 short-range proof run under
+`/tmp/mlx-atomistic-gpcrmd-729-mlx-cell-pairs` selected
+`nonbonded_runtime.backend=mlx_cell_pairs` with no fallback. It tested
+`candidate_count=390934237` local candidates, emitted `pair_count=48933140`,
+and recorded `elapsed_wall_seconds=23.05953904206399`,
+`neighbor_rebuild_wall_seconds=1.3890800829976797`,
+`force_evaluation_wall_seconds=11.277963876025751`, `skin=2.5`, and one
+rebuild. Direct rebuild microbenchmarks on 512-8192 particle FCC systems showed
+the batched `mlx_cell_pairs` builder matching `periodic_cell_list` pairs and
+running about 2.5-3x faster than the CPU builder. The under-5-second GPCRmd
+stretch target remains blocked by force-evaluation cost, import/orchestration
+overhead, and remaining CPU dynamic compaction.
+
+A native pair emitter would benefit more than the GPCRmd notebook. It would
+accelerate any cutoff-based periodic run that currently pays CPU-side cost for
+compact neighbor-pair construction, including solvated proteins,
+protein-ligand systems, water boxes, membranes, coarse-grained systems, and
+benchmarks that use explicit pair lists. The difficult part is dynamic pair-list
+emission: MLX can evaluate dense distance masks and pair math well, but the
+runtime does not currently expose a NumPy-style one-argument `where(mask)` or
+`nonzero(mask)` compaction API for emitting variable-length `(i, j)` pairs.
+`mlx_cell_pairs` is the current pragmatic hybrid: bounded cell candidates and
+MLX distance filtering, with dynamic compaction still CPU-side.
+
+For the active solvated ligand-receptor notebook system, the near-term GPU
+occupancy lever is independent replica batching. The system is only a few
+hundred atoms, so one trajectory does not expose much work to the GPU. Use the
+prep APIs to advance multiple physically independent velocity seeds in one MLX
+loop:
+
+```python
+from mlx_atomistic.prep.replicas import run_ligand_receptor_replicas
+
+run_ligand_receptor_replicas(
+    "notebooks/ligand-receptor-motion/data/mlx-real-md/example-200ps-r4",
+    replicas=4,
+    selected_replica=0,
+    steps=200000,
+    dt=0.001,
+    sample_interval=100,
+)
+```
+
+For repeatable profiling across durations and replica counts:
+
+```python
+from mlx_atomistic.prep.replicas import profile_ligand_receptor_performance
+
+profile_ligand_receptor_performance(
+    "notebooks/ligand-receptor-motion/data/perf/replica-profile",
+    durations_ps=[5, 50, 200],
+    replica_counts=[1, 4, 8, 16],
+    dt=0.001,
+    sample_interval=100,
+)
+```
+
+The profile reports wall time, per-replica and aggregate steps/s, aggregate
+ps/s, GPU-visible atoms, dense pair slots, force-evaluation cost, constraint
+projection cost, diagnostic cost, max constraint error, and artifact size.
+
+## Interpreting The Benchmark
+
+The benchmark reports `ms_per_eval`, `neighbor_rebuild_ms_per_eval`,
+`force_eval_ms_per_eval`, an estimated dense memory footprint,
+`ns_per_day_at_dt_0_002`, and force/energy deltas relative to dense MLX. The
+`ns_per_day` number is only a throughput-style indicator because the MD engine
+uses reduced internal units. Use the separated rebuild and force timings when
+deciding whether the current bottleneck is pair construction or pair evaluation.

--- a/site/src/content/docs/mm/molecular-mechanics.md
+++ b/site/src/content/docs/mm/molecular-mechanics.md
@@ -1,0 +1,94 @@
+---
+title: "Molecular Mechanics Core"
+---
+
+
+The MD engine now supports a programmatic molecular mechanics surface. It is not
+a complete AMBER/CHARMM feature clone yet, but it is no longer limited to an LJ
+fluid demo.
+
+## Topology
+
+`Topology` stores validated atom connectivity:
+
+```text
+bonds      shape (n_bonds, 2)
+angles     shape (n_angles, 3)
+dihedrals  shape (n_dihedrals, 4)
+impropers  shape (n_impropers, 4)
+exclusions shape (n_exclusions, 2)
+charges    shape (n_atoms,)
+```
+
+`Topology.from_sequences(...)` is the intended v1 construction helper. Bonded
+pairs are excluded from nonbonded interactions by default. Dihedral endpoints are
+used as default 1-4 pairs for optional LJ/Coulomb scaling.
+
+## Force Terms
+
+Supported terms:
+
+- `LennardJonesPotential`
+- `CoulombPotential`
+- `NonbondedPotential`
+- `HarmonicBondPotential`
+- `HarmonicAnglePotential`
+- `PeriodicDihedralPotential`
+- `ImproperDihedralPotential`
+- `RBDihedralPotential`
+- `PositionalRestraintPotential`
+
+All terms implement `energy_forces(positions, cell=None, pairs=None)` and can be
+passed together to `simulate_nve()` or `simulate_nvt()`.
+
+## Nonbonded Rules
+
+LJ and Coulomb support topology-aware nonbonded pairs:
+
+- bonded-pair exclusions
+- explicit exclusions and nonbonded exception overrides
+- optional 1-4 scaling / overrides
+- direct cutoff support
+- orthorhombic periodic minimum-image behavior
+
+`PMEConfig` supports PME assignment orders `2`, `4`, and `5`. Prepared artifacts
+must carry explicit PME arrays/metadata before the runtime PME path is accepted;
+unsupported or partial PME requests still fail closed.
+
+`NonbondedPotential` is the production-oriented direct pair path. It combines
+mixed LJ and direct Coulomb terms, supports explicit nonbonded exceptions and
+independent LJ/Coulomb 1-4 scaling, and reports component energies as
+`nonbonded.lj` and `nonbonded.coulomb` in MD diagnostics.
+
+## Force-Field Imports
+
+The optional prep layer exposes native accepted-subset importers:
+
+```python
+from mlx_atomistic.prep import (
+    import_amber_prmtop,
+    import_charmm_psf,
+    import_gromacs_top_gro,
+)
+```
+
+These importers produce prepared-system artifacts for AMBER `prmtop`/`inpcrd`,
+CHARMM PSF/parameter, and GROMACS `.top`/`.gro` inputs. The production artifact
+gate remains fail-closed for unsupported terms such as virtual sites, advanced
+water models, polarizable terms, or incomplete PME metadata.
+
+## Energy Decomposition
+
+NVE and NVT results expose:
+
+```text
+potential_energy
+potential_energy_by_term
+```
+
+`potential_energy` is the total potential energy. `potential_energy_by_term` maps
+term names such as `bond`, `angle`, `dihedral`, `coulomb`, and `lj` to dense
+per-step energy series.
+
+The diagnostic helper `summarize_md_result()` includes final and mean term-energy
+summaries for notebook and benchmark output.

--- a/site/src/content/docs/mm/production-md.md
+++ b/site/src/content/docs/mm/production-md.md
@@ -1,0 +1,168 @@
+---
+title: "Production MLX MD Boundary"
+---
+
+
+`mlx_atomistic` keeps the simulation engine lightweight. Core installs only MLX,
+NumPy, and SciPy. Optional extras may parse chemistry/topology files or visualize
+results, but `mlx_atomistic` owns trajectory generation.
+
+## Dependency Extras
+
+- `mlx-atomistic`: core MLX engine and reduced/physical-unit kernels.
+- `mlx-atomistic[prep]`: topology/parameter import plus ligand chemistry/file
+  parsing helpers. These tools do not run MD.
+- `mlx-atomistic[viz]`: notebook visualization and trajectory analysis.
+
+Raw PDB/mmCIF coordinates are accepted for visualization and selection, not as
+general production MD input. Bundled examples are explicit exceptions:
+`mlx_atomistic.prep` includes versioned internal templates for specific systems so
+notebooks can build runnable MLX artifacts without an external simulator or
+user-supplied topology files.
+
+## Production Artifact Contract
+
+A production artifact must include:
+
+- explicit physical units for coordinates, mass, charge, energy, time, and
+  temperature;
+- topology arrays for bonds, angles, dihedrals, optional impropers, constraints,
+  and nonbonded exceptions;
+- per-atom LJ parameters and charges;
+- force-field provenance and a compatibility report;
+- no unsupported required terms.
+
+`mlx_atomistic.artifacts.load_prepared_mlx_artifact(..., require_production=True)`
+fails closed for reduced-unit demo artifacts, unsupported terms, missing arrays,
+unsupported or incomplete PME/barostat requests, virtual sites,
+Drude/polarizable terms, and other terms the MLX engine cannot yet represent
+faithfully. PME and first-path NPT support are proof-level surfaces: accepted
+artifacts must provide explicit configuration and readiness metadata, and
+unsupported production cases remain blockers.
+
+## Phase 3 GPCRmd Fixture Probe
+
+The active production-readiness probe uses
+`gpcrmd-729-beta1-5f8u-cyanopindolol`, a local GPCRmd 729 cache with `92001`
+atoms, CHARMM36, TIP3P water, sodium/chloride ions, and a POPC membrane.
+
+The probe result is blocked, not a production-MD pass:
+
+- OpenMM reference evidence is available as reference-only CHARMM/PME data.
+- MLX preparation, strict artifact loading, and readiness checks now pass for
+  the fixture.
+- Bounded MLX execution blocks at `topology_terms`: lazy topology needs a
+  runtime nonbonded pair provider, and full dense pair materialization was not
+  requested.
+- Because the run blocks before production frames, energy parity, trajectory
+  output, checkpoint, and restart behavior are not claimed.
+
+This is one bounded fixture probe and is not broad production MD certification.
+
+## Archived ATP-Receptor Workflow
+
+The old ATP/P2X4 notebook has moved to
+`notebooks/archive/atp-pocket-mlx-demo/`. It remains useful as historical
+reference for the internal 4DW1 pocket artifact, but it is no longer the active
+macromolecule visualization workflow. For that archived example:
+
+1. build the prepared artifact with `prepare_p2x4_atp(..., backend="production_mlx")`
+   and `save_prepared_system(...)` if the artifact is missing or stale;
+2. validate the generated artifact with `require_production=True`;
+3. run MLX minimization, restrained NVT warmup, and production NVT if
+   `trajectory.npz` is missing or stale;
+4. animate and analyze only the saved MLX coordinates with one preloaded Plotly
+   trajectory player, visible controls, a translucent frame-0 ATP overlay, and
+   ATP center-of-mass motion relative to the receptor pocket.
+
+Expected Python API flow:
+
+```python
+from pathlib import Path
+
+from mlx_atomistic.prep.io import save_prepared_system
+from mlx_atomistic.prep.prepare import prepare_p2x4_atp
+from mlx_atomistic.prep.runner import run_mlx
+
+prepared_dir = Path("notebooks/archive/atp-pocket-mlx-demo/data/prepared/4dw1-atp")
+prepared = prepare_p2x4_atp(
+    pdb_path=Path("notebooks/archive/atp-pocket-mlx-demo/data/4dw1_atp_bound_p2x4.pdb"),
+    backend="production_mlx",
+)
+save_prepared_system(prepared, prepared_dir)
+run_mlx(
+    prepared_dir,
+    require_production=True,
+    steps=5000,
+    sample_interval=25,
+    dt=0.002,
+    temperature=300,
+    friction=10,
+    restraint_k=5,
+    minimize_steps=50,
+    equilibration_steps=100,
+)
+```
+
+General user systems still need real topology/parameter import first:
+
+```python
+from mlx_atomistic.prep import (
+    import_amber_prmtop,
+    import_charmm_psf,
+    import_gromacs_top_gro,
+)
+```
+
+Accepted imports can carry RB torsions and PME assignment-order metadata into
+the strict artifact gate. PME assignment orders `2`, `4`, and `5` are accepted
+when the artifact includes complete PME configuration arrays; unsupported
+force-field terms still produce blockers rather than partial production runs.
+
+The internal 4DW1 force field is fixed-topology classical MD: no ATP hydrolysis,
+bond breaking, ligand docking/search, membrane, solvent, PME, or NPT.
+
+## T4L / Benzene Forced-SMD Method Demo
+
+The active macromolecular notebook is now
+`notebooks/ligand-receptor-motion/01-ligand-receptor-translational-motion.ipynb`.
+Its primary realistic path uses a public GLP-1R / Exendin-4 trajectory. The MLX
+section builds a small soluble T4 lysozyme L99A / benzene artifact from PDB
+`4W52` and runs forced steered MD:
+
+```python
+from pathlib import Path
+
+from mlx_atomistic.prep.io import save_prepared_system
+from mlx_atomistic.prep.runner import run_steered_mlx
+from mlx_atomistic.prep.t4l_benzene import prepare_t4l_benzene
+
+prepared_dir = Path("notebooks/ligand-receptor-motion/data/prepared/t4l-benzene-smd")
+save_prepared_system(prepare_t4l_benzene(), prepared_dir)
+run_steered_mlx(prepared_dir, steps=25000, dt=0.001, sample_interval=50)
+```
+
+The T4L artifact is labeled `mlx_internal_t4l_benzene_forced_smd_demo_v2`. It
+includes explicit hydrogens, topology arrays, simple internal parameters,
+constraints, nonbonded exceptions, receptor/ligand masks, and steering
+provenance. It is appropriate for demonstrating MLX-generated ligand translation
+under a moving COM restraint. It is not a validated CHARMM/AMBER production force
+field, does not represent natural diffusion, and does not infer a real benzene
+egress route. The steering direction is a documented heuristic radial vector
+from pocket-center to ligand-center.
+
+The same notebook keeps the public GLP-1R / Exendin-4 trajectory as a labeled
+`public_md` comparison. That comparison is analysis input only.
+
+## Remaining Production Gaps
+
+A GLP-1R / Exendin-4 production simulation generated by `mlx_atomistic` still
+requires full membrane/solvent/ion setup, mature production PME/NPT validation,
+validated CHARMM/AMBER force-field parity, and enhanced sampling beyond simple
+SMD. Current PME and NPT paths are bounded proof surfaces, not evidence for a
+complete membrane-production workflow.
+
+For the GPCRmd 729 production-readiness probe, the next implementation blocker
+is runtime nonbonded pair provisioning for lazy topology at GPCRmd scale. Until
+that blocker is closed and re-run evidence is recorded, production-MD readiness
+remains blocked for the selected large fixture.

--- a/site/src/content/docs/mm/real-mm-core.md
+++ b/site/src/content/docs/mm/real-mm-core.md
@@ -1,0 +1,105 @@
+---
+title: "Real Molecular Mechanics Core"
+---
+
+
+This milestone adds the first system-level molecular mechanics layer. The engine
+can now represent typed systems, assign force-field parameters, run a combined
+LJ+Coulomb nonbonded path, apply pair-distance constraints, and save/load simple
+structures and trajectories.
+
+## Systems And Parameters
+
+`MMSystem` stores the molecular state:
+
+```text
+symbols, atom_names, atom_types
+masses, charges
+positions, velocities
+topology, optional cell
+```
+
+`ForceField` assigns parameters from atom types:
+
+- `AtomType`
+- `NonbondedParameter`
+- `BondParameter`
+- `AngleParameter`
+- `DihedralParameter`
+
+Bond parameters match atom-type pairs without order sensitivity. Angle and
+dihedral parameters match forward or reverse type tuples. Missing parameters
+raise errors with atom indices and type tuples so mistakes are visible.
+
+## Production Nonbonded Path
+
+`NonbondedPotential` combines Lennard-Jones and direct Coulomb terms in one pair
+loop. It supports:
+
+- per-atom `σ`, `ε`, and charge
+- Lorentz-Berthelot mixing
+- topology exclusions
+- independent LJ and Coulomb 1-4 scaling
+- cutoff and minimum-image behavior
+- optional LJ and Coulomb energy shifts
+
+NVE/NVT diagnostics record component terms as:
+
+```text
+nonbonded.lj
+nonbonded.coulomb
+```
+
+This gives a realistic target for the future custom Metal pair kernel.
+
+## Constraints
+
+`DistanceConstraints` supports fixed pair distances. The current implementation
+uses iterative position projection and velocity projection:
+
+- position correction after position updates
+- velocity correction after force/velocity updates
+- dense `constraint_max_error` diagnostics for every step
+
+This is intentionally limited to pair-distance constraints. It is enough for
+water-like toy systems and for measuring constraint overhead.
+
+## I/O
+
+The I/O layer is deliberately small:
+
+- `read_xyz(...)`
+- `write_xyz(...)`
+- `save_npz_trajectory(...)`
+- `load_npz_trajectory(...)`
+- `restart_state_from_trajectory(...)`
+
+XYZ is for quick structure interchange. NPZ is the native trajectory format and
+stores sampled frames, scalar diagnostics, energy decomposition, optional cell,
+symbols, and JSON metadata.
+
+## Examples
+
+Programmatic examples now include:
+
+- water-like constrained molecule
+- butane-like torsion system
+- small ionic cluster
+- mixed typed LJ fluid
+
+The notebook `notebooks/workflows/01-md-molecular-mechanics.ipynb` demonstrates
+the active MM workflow: system construction, force-field assignment,
+constraints, trajectory diagnostics, and energy decomposition.
+
+## Remaining Boundaries
+
+Still out of scope:
+
+- unrestricted PME/Ewald production coverage beyond the accepted artifact gate
+- mature production NPT/barostat certification
+- unrestricted AMBER/CHARMM/GROMACS parsing beyond the accepted native subsets
+- DFT
+- custom Metal kernels
+
+The next optimization decision should be based on benchmark evidence from the
+combined nonbonded and constraint paths.

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -1,0 +1,50 @@
+---
+title: Overview
+description: Apple Silicon-native atomistic simulation with MLX and Metal.
+---
+
+mlx-atomistic is an Apple Silicon-native atomistic simulation runtime built on
+MLX and Metal. It targets Python 3.13 through `uv` and uses MLX for local GPU
+execution on Apple Silicon.
+
+## What it is
+
+`mlx_atomistic` is the primary trajectory generator and product runtime in this
+repo. OpenMM, LAMMPS, and the source trees under `vendors/` are reference or
+validation surfaces; they do not replace the MLX runtime path.
+
+## Two scales, one runtime
+
+- **Density Functional Theory** — spin-unpolarized Γ-point plane-wave Kohn–Sham
+  SCF, LDA + PBE GGA (autodiff-derived potential), pseudopotentials (GTH / UPF),
+  forces, stress, and geometry optimization.
+- **Molecular Mechanics** — Lennard-Jones, Coulomb, harmonic bonds/angles,
+  periodic + Ryckaert–Bellemans torsions, bounded PME, NVE and Langevin NVT.
+
+## First milestones
+
+Lightweight DFT building blocks, validation notebooks, and visualization
+utilities rather than a heavy production DFT engine. Small, validated examples
+before broader chemistry coverage.
+
+## Setup
+
+```bash
+uv venv --python 3.13
+uv sync --extra notebook --extra prep --extra viz --group dev
+uv run python -m ipykernel install --user --name mlx-atomistic --display-name "mlx-atomistic"
+uv run jupyter lab
+```
+
+If `uv` cannot use the home cache in a sandboxed run, use a writable cache:
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv sync --extra notebook --extra prep --extra viz --group dev
+```
+
+## Where to go next
+
+- [Foundations](/mlx-atomistic/foundations/) — units, runtime boundaries, testing
+- [DFT](/mlx-atomistic/dft/) — SCF core, pseudopotentials, numerics
+- [Molecular Mechanics](/mlx-atomistic/mm/) — topology, force fields, production MD
+- [Benchmarks](/mlx-atomistic/benchmarks/) — validation and performance results

--- a/site/src/content/docs/project/validation-and-performance.md
+++ b/site/src/content/docs/project/validation-and-performance.md
@@ -1,0 +1,118 @@
+---
+title: "Validation And Performance"
+---
+
+
+This milestone turns the MD/MM code from "it runs" into "we can measure whether
+it is correct, stable, and worth optimizing." The key idea is simple: before
+writing custom Metal kernels, we need repeatable force checks, stability runs,
+and benchmark rows that identify the hot path.
+
+## Force Validation
+
+`mlx_atomistic.validation` compares each force term against central
+finite-difference forces:
+
+```python
+from mlx_atomistic.validation import run_force_validation_suite
+
+results = run_force_validation_suite(seed=7, cases_per_term=1)
+```
+
+Each `ForceValidationResult` reports:
+
+- maximum absolute force error
+- RMS force error
+- atom and coordinate of the worst error
+- seed, tolerance, and pass/fail status
+
+The command-line gauntlet emits JSON or CSV:
+
+```bash
+uv run python -m mlx_atomistic.benchmarks.validation_gauntlet --json
+uv run python -m mlx_atomistic.benchmarks.validation_gauntlet --csv validation.csv
+```
+
+The default suite is intentionally small for development. Increase
+`--cases-per-term` before trusting a larger code change.
+
+## Stability Diagnostics
+
+The stability benchmark runs:
+
+- bonded-chain NVE at multiple `dt` values
+- LJ-liquid NVE
+- LJ-liquid Langevin NVT
+
+It records energy drift, relative drift, mean/final temperature, pair counts,
+neighbor-list rebuilds, and nonfinite diagnostics:
+
+```bash
+uv run python -m mlx_atomistic.benchmarks.stability --json
+uv run python -m mlx_atomistic.benchmarks.stability --sizes 128,512,2048 --csv stability.csv
+```
+
+`8192` particles is supported as an opt-in size, but it should not be part of
+routine development checks.
+
+## Performance Harnesses
+
+The LJ MD benchmark now supports CSV:
+
+```bash
+uv run python -m mlx_atomistic.benchmarks.lj_md --sizes 128,512,2048 --steps 20 --json
+uv run python -m mlx_atomistic.benchmarks.lj_md --sizes 128,512,2048 --steps 20 --csv lj.csv
+```
+
+The MM force-term benchmark separates the current hot-path candidates:
+
+- bonded autodiff terms
+- neighbor-list construction
+- LJ pair-list evaluation
+- direct cutoff Coulomb evaluation
+- combined mixed LJ+Coulomb nonbonded evaluation
+- distance-constraint projection
+
+```bash
+uv run python -m mlx_atomistic.benchmarks.mm_force_terms --particles 128 --evaluations 20 --json
+```
+
+Use these rows to decide where a custom Metal kernel belongs. At this stage the
+right answer should come from timing data, not intuition.
+
+## Development Gate
+
+For normal development:
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run ruff check src tests
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run pytest
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.validation_gauntlet --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m mlx_atomistic.benchmarks.stability --sizes 16 --steps 2 --bonded-steps 2 --dt-values 0.001 --json
+```
+
+For serious local performance work on Apple Silicon, run the larger benchmark
+matrix outside the fast test loop and keep the JSON/CSV artifacts for comparison.
+
+## OpenMM/OpenCL Reference
+
+OpenMM is not a product runtime dependency, but it is useful as a reference
+ceiling for local GPU/OpenCL throughput. The standalone showcase script keeps
+that comparison under `scripts/`:
+
+```bash
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_opencl.py --json
+UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python scripts/benchmark_openmm_opencl.py --particles 4096 --steps 1000 --platform OpenCL --csv openmm-opencl.csv
+```
+
+The script emits OpenMM version, available platforms, selected platform
+properties, steps/s, ns/day, and final energy/finite-state diagnostics.
+
+## Benchmark Reports
+
+Per-run benchmark write-ups live under [`docs/benchmarks/`](./benchmarks/),
+indexed by `docs/benchmarks/README.md`. Each report records hardware,
+engine version, config, the reproducer command, and external reference
+numbers (e.g. `openmm.org/benchmarks`, HECBioSim) so a future result can be
+compared without re-deriving context. Raw JSON output is written to the
+gitignored `results/` directory.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,0 +1,693 @@
+---
+const features = [
+  {
+    title: "Apple Silicon native",
+    desc: "MLX arrays and Metal kernels run the GPU on your machine. No CUDA, no server.",
+    span: "wide",
+    icon: "chip",
+  },
+  {
+    title: "Plane-wave DFT",
+    desc: "Kohn–Sham SCF, LDA + PBE GGA via autodiff, Γ-point and k-mesh, Davidson diagonalization.",
+    span: "tall",
+    icon: "wave",
+  },
+  {
+    title: "Molecular mechanics",
+    desc: "LJ, Coulomb, harmonic bonds/angles, periodic + RB torsions, bounded PME, Langevin NVT.",
+    span: "std",
+    icon: "bond",
+  },
+  {
+    title: "Pseudopotentials",
+    desc: "GTH and UPF readers, local + nonlocal projectors, analytic + finite-difference forces.",
+    span: "std",
+    icon: "grid",
+  },
+  {
+    title: "Python 3.13 + uv",
+    desc: "Reproducible environments, fast sync, Jupyter-first exploration.",
+    span: "std",
+    icon: "python",
+  },
+  {
+    title: "Validated",
+    desc: "OpenMM and LAMMPS reference surfaces keep the MLX runtime honest.",
+    span: "wide",
+    icon: "check",
+  },
+];
+
+const stats = [
+  { value: "LDA + PBE", label: "XC functionals" },
+  { value: "NVE / NVT", label: "Integrators" },
+  { value: "PME", label: "Long-range electrostatics" },
+  { value: "Jupyter", label: "First-class viz" },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>mlx-atomistic — Apple Silicon atomistic simulation</title>
+    <meta
+      name="description"
+      content="Apple Silicon-native atomistic simulation: MLX + Metal DFT and MD runtime."
+    />
+    <meta name="theme-color" content="#0a0b0c" />
+    <meta property="og:title" content="mlx-atomistic" />
+    <meta
+      property="og:description"
+      content="Apple Silicon-native atomistic simulation: MLX + Metal DFT and MD runtime."
+    />
+    <meta property="og:type" content="website" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <script is:inline>
+      const stored = localStorage.getItem("starlight-theme");
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const theme = stored ?? (prefersDark ? "dark" : "light");
+      document.documentElement.dataset.theme = theme;
+    </script>
+  </head>
+  <body>
+    <!-- Floating navigation -->
+    <nav class="float-nav" aria-label="Primary">
+      <a class="float-nav__brand" href="/">
+        <svg width="22" height="22" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+          <circle cx="32" cy="32" r="6" fill="currentColor" />
+          <ellipse cx="32" cy="32" rx="26" ry="11" stroke="currentColor" stroke-width="2.5" opacity="0.85" />
+          <ellipse cx="32" cy="32" rx="26" ry="11" transform="rotate(60 32 32)" stroke="currentColor" stroke-width="2.5" opacity="0.55" />
+          <ellipse cx="32" cy="32" rx="26" ry="11" transform="rotate(120 32 32)" stroke="currentColor" stroke-width="2.5" opacity="0.35" />
+        </svg>
+        <span>mlx-atomistic</span>
+      </a>
+      <div class="float-nav__links">
+        <a href="/mlx-atomistic/foundations/">Foundations</a>
+        <a href="/mlx-atomistic/dft/">DFT</a>
+        <a href="/mlx-atomistic/mm/">MD</a>
+        <a href="/mlx-atomistic/benchmarks/">Benchmarks</a>
+      </div>
+      <div class="float-nav__actions">
+        <button id="theme-toggle" class="icon-btn" aria-label="Toggle theme">
+          <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+          <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+        </button>
+        <a class="icon-btn" href="https://github.com/appautomaton/mlx-atomistic" aria-label="GitHub">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.9 10.9c.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5z"/></svg>
+        </a>
+      </div>
+    </nav>
+
+    <main>
+      <!-- Hero -->
+      <section class="hero">
+        <div class="hero__glow" aria-hidden="true"></div>
+        <div class="hero__grid-bg" aria-hidden="true"></div>
+        <div class="hero__inner">
+          <span class="badge">Apple Silicon · MLX · Metal</span>
+          <h1>
+            Atomistic simulation,<br />
+            <span class="gradient-text">native to your Mac.</span>
+          </h1>
+          <p class="lead">
+            An Apple Silicon-native MD + DFT runtime built on MLX and Metal —
+            the product, not a wrapper.
+          </p>
+          <div class="cta-row">
+            <a class="btn btn--primary" href="/mlx-atomistic/foundations/">
+              Get started
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+            </a>
+            <a class="btn btn--ghost" href="https://github.com/appautomaton/mlx-atomistic">
+              View on GitHub
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Bento grid -->
+      <section class="bento" aria-label="Features">
+        <h2 class="section-title">One runtime, two scales.</h2>
+        <div class="bento__grid">
+          {
+            features.map((f) => (
+              <article class={`card card--${f.span}`}>
+                <div class="card__icon" data-icon={f.icon} aria-hidden="true">
+                  <span />
+                </div>
+                <h3>{f.title}</h3>
+                <p>{f.desc}</p>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+
+      <!-- Stats -->
+      <section class="stats" aria-label="Capabilities">
+        {
+          stats.map((s) => (
+            <div class="stat">
+              <div class="stat__value">{s.value}</div>
+              <div class="stat__label">{s.label}</div>
+            </div>
+          ))
+        }
+      </section>
+
+      <!-- Quick start -->
+      <section class="quickstart" aria-label="Quick start">
+        <h2 class="section-title">Quick start</h2>
+        <div class="code-block">
+          <div class="code-block__bar">
+            <span class="dot dot--red" />
+            <span class="dot dot--amber" />
+            <span class="dot dot--green" />
+            <span class="code-block__label">shell</span>
+          </div>
+          <pre><code><span class="c-prompt">$</span> uv venv --python 3.13
+<span class="c-prompt">$</span> uv sync --extra notebook --group dev
+<span class="c-prompt">$</span> uv run jupyter lab
+
+<span class="c-comment"># run a DFT SCF benchmark</span>
+<span class="c-prompt">$</span> uv run python -m mlx_atomistic.benchmarks.dft_scf \
+    --sizes 8,16,24,32 --iterations 5 --mixer both --json</code></pre>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer__inner">
+        <span>mlx-atomistic · Apple Silicon atomistic simulation</span>
+        <div class="footer__links">
+          <a href="/mlx-atomistic/project/">Docs</a>
+          <a href="https://github.com/appautomaton/mlx-atomistic">GitHub</a>
+        </div>
+      </div>
+    </footer>
+
+    <script is:inline>
+      const toggle = document.getElementById("theme-toggle");
+      toggle?.addEventListener("click", () => {
+        const cur = document.documentElement.dataset.theme || "dark";
+        const next = cur === "dark" ? "light" : "dark";
+        document.documentElement.dataset.theme = next;
+        localStorage.setItem("starlight-theme", next);
+      });
+    </script>
+  </body>
+</html>
+
+<style is:global>
+  :root {
+    --accent: #06b6d4;
+    --accent-bright: #22d3ee;
+    --accent-deep: #0891b2;
+    --gradient-accent: linear-gradient(135deg, #22d3ee 0%, #7c3aed 100%);
+    --bg: #0a0b0c;
+    --bg-elev: #121317;
+    --border: rgba(255, 255, 255, 0.08);
+    --text: #e4e4e7;
+    --text-muted: #a1a1aa;
+    --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  }
+
+  [data-theme="light"] {
+    --bg: #fafafa;
+    --bg-elev: #ffffff;
+    --border: rgba(0, 0, 0, 0.08);
+    --text: #18181b;
+    --text-muted: #52525b;
+  }
+
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    font-family: var(--font-sans);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  /* ---------- Floating nav ---------- */
+  .float-nav {
+    position: fixed;
+    top: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 0.5rem 0.75rem 0.5rem 1rem;
+    background: color-mix(in srgb, var(--bg) 72%, transparent);
+    backdrop-filter: blur(16px) saturate(180%);
+    -webkit-backdrop-filter: blur(16px) saturate(180%);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.28);
+    transition: top 0.3s ease;
+  }
+
+  .float-nav__brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    color: var(--accent-bright);
+  }
+
+  .float-nav__links {
+    display: flex;
+    gap: 1.25rem;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+  }
+
+  .float-nav__links a {
+    transition: color 0.15s ease;
+  }
+
+  .float-nav__links a:hover {
+    color: var(--text);
+  }
+
+  .float-nav__actions {
+    display: flex;
+    gap: 0.375rem;
+  }
+
+  .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    background: transparent;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .icon-btn:hover {
+    color: var(--text);
+    background: var(--border);
+  }
+
+  .icon-sun {
+    display: none;
+  }
+  [data-theme="light"] .icon-sun {
+    display: block;
+  }
+  [data-theme="light"] .icon-moon {
+    display: none;
+  }
+
+  /* ---------- Hero ---------- */
+  .hero {
+    position: relative;
+    min-height: 100svh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 8rem 1.5rem 6rem;
+    overflow: hidden;
+  }
+
+  .hero__glow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 900px;
+    height: 900px;
+    transform: translate(-50%, -50%);
+    background: radial-gradient(
+      circle,
+      rgba(34, 211, 238, 0.18) 0%,
+      rgba(124, 58, 237, 0.08) 35%,
+      transparent 65%
+    );
+    pointer-events: none;
+    filter: blur(20px);
+  }
+
+  .hero__grid-bg {
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(var(--border) 1px, transparent 1px),
+      linear-gradient(90deg, var(--border) 1px, transparent 1px);
+    background-size: 64px 64px;
+    mask-image: radial-gradient(ellipse at center, black 30%, transparent 70%);
+    -webkit-mask-image: radial-gradient(ellipse at center, black 30%, transparent 70%);
+    pointer-events: none;
+  }
+
+  .hero__inner {
+    position: relative;
+    max-width: 820px;
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 0.375rem 0.875rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--accent-bright);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+    border-radius: 999px;
+    margin-bottom: 1.75rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.5rem, 7vw, 4.5rem);
+    font-weight: 700;
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+    margin-bottom: 1.5rem;
+  }
+
+  .gradient-text {
+    background: var(--gradient-accent);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .lead {
+    font-size: clamp(1.0625rem, 2.2vw, 1.375rem);
+    color: var(--text-muted);
+    max-width: 620px;
+    margin: 0 auto 2.5rem;
+  }
+
+  .cta-row {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    transition: all 0.18s ease;
+  }
+
+  .btn--primary {
+    background: var(--accent);
+    color: #0a0b0c;
+    border-color: var(--accent);
+  }
+  [data-theme="light"] .btn--primary {
+    color: #ffffff;
+  }
+  .btn--primary:hover {
+    background: var(--accent-bright);
+    box-shadow: 0 0 32px color-mix(in srgb, var(--accent) 40%, transparent);
+    transform: translateY(-1px);
+  }
+
+  .btn--ghost:hover {
+    background: var(--border);
+    transform: translateY(-1px);
+  }
+
+  /* ---------- Bento grid ---------- */
+  .bento {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+  }
+
+  .section-title {
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin-bottom: 2rem;
+    text-align: center;
+  }
+
+  .bento__grid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 1rem;
+  }
+
+  .card {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 1.5rem;
+    transition: all 0.2s ease;
+  }
+
+  .card:hover {
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+    transform: translateY(-2px);
+  }
+
+  .card--wide {
+    grid-column: span 4;
+  }
+  .card--tall {
+    grid-column: span 2;
+    grid-row: span 2;
+  }
+  .card--std {
+    grid-column: span 2;
+  }
+
+  .card__icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--accent) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 1rem;
+  }
+
+  .card__icon span {
+    width: 14px;
+    height: 14px;
+    border-radius: 4px;
+    background: var(--accent-bright);
+  }
+
+  .card h3 {
+    font-size: 1.0625rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  .card p {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+
+  /* ---------- Stats ---------- */
+  .stats {
+    max-width: 1120px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    padding: 2rem 1.5rem 4rem;
+  }
+
+  .stat {
+    text-align: center;
+    padding: 1.5rem 1rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .stat__value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--accent-bright);
+    letter-spacing: -0.01em;
+  }
+
+  .stat__label {
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+  }
+
+  /* ---------- Quick start ---------- */
+  .quickstart {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 6rem;
+  }
+
+  .code-block {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    overflow: hidden;
+  }
+
+  .code-block__bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .dot {
+    width: 11px;
+    height: 11px;
+    border-radius: 999px;
+  }
+  .dot--red {
+    background: #f87171;
+  }
+  .dot--amber {
+    background: #fbbf24;
+  }
+  .dot--green {
+    background: #34d399;
+  }
+
+  .code-block__label {
+    margin-left: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .code-block pre {
+    padding: 1.25rem 1.5rem;
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.7;
+    color: var(--text);
+  }
+
+  .c-prompt {
+    color: var(--accent-bright);
+    user-select: none;
+  }
+  .c-comment {
+    color: var(--text-muted);
+  }
+
+  /* ---------- Footer ---------- */
+  .footer {
+    border-top: 1px solid var(--border);
+    padding: 2rem 1.5rem;
+  }
+
+  .footer__inner {
+    max-width: 1120px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+  }
+
+  .footer__links {
+    display: flex;
+    gap: 1.25rem;
+  }
+
+  .footer__links a:hover {
+    color: var(--text);
+  }
+
+  /* ---------- Mobile-first responsive ---------- */
+  @media (max-width: 860px) {
+    .bento__grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .card--wide,
+    .card--tall,
+    .card--std {
+      grid-column: span 2;
+      grid-row: auto;
+    }
+    .stats {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .float-nav__links {
+      display: none;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .hero {
+      padding-top: 6rem;
+    }
+    .bento__grid {
+      grid-template-columns: 1fr;
+    }
+    .card--wide,
+    .card--tall,
+    .card--std {
+      grid-column: span 1;
+    }
+    .stats {
+      grid-template-columns: 1fr;
+    }
+    .cta-row .btn {
+      flex: 1;
+      justify-content: center;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    * {
+      transition: none !important;
+      animation: none !important;
+    }
+  }
+</style>

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,0 +1,117 @@
+/* mlx-atomistic — 2026 palette: near-black dark, cyan accent, surgical gradients. */
+
+:root {
+  --accent: #06b6d4;
+  --accent-bright: #22d3ee;
+  --accent-deep: #0891b2;
+  --gradient-accent: linear-gradient(135deg, #22d3ee 0%, #7c3aed 100%);
+
+  --font-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-mono:
+    "JetBrains Mono", "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas,
+    monospace;
+}
+
+/* ---------- Dark theme (primary, 2026 dev-tool default) ---------- */
+:root,
+[data-theme="dark"] {
+  --sl-color-bg: #0a0b0c;
+  --sl-color-bg-nav: #0a0b0c;
+  --sl-color-bg-sidebar: #0d0e10;
+  --sl-color-bg-inline-code: #15171b;
+  --sl-color-bg-input: #15171b;
+  --sl-color-bg-row: #121317;
+  --sl-color-bg-row-hover: #181a1f;
+
+  --sl-color-white: #fafafa;
+  --sl-color-gray-1: #e4e4e7;
+  --sl-color-gray-2: #a1a1aa;
+  --sl-color-gray-3: #71717a;
+  --sl-color-gray-4: #52525b;
+  --sl-color-gray-5: #3f3f46;
+  --sl-color-gray-6: #27272a;
+  --sl-color-gray-7: #18181b;
+
+  --sl-color-black: #0a0b0c;
+  --sl-color-accent: #22d3ee;
+  --sl-color-accent-text: #0a0b0c;
+  --sl-color-accent-low: rgba(34, 211, 238, 0.12);
+  --sl-color-accent-high: rgba(34, 211, 238, 0.28);
+
+  --sl-color-healing-1: #34d399;
+  --sl-color-healing-2: #059669;
+  --sl-color-admonition-tip: #22d3ee;
+  --sl-color-admonition-note: #71717a;
+  --sl-color-admonition-caution: #fbbf24;
+  --sl-color-admonition-danger: #f87171;
+
+  --sl-font: var(--font-sans);
+  --sl-font-mono: var(--font-mono);
+}
+
+/* ---------- Light theme (scientific, airy) ---------- */
+[data-theme="light"] {
+  --sl-color-bg: #fafafa;
+  --sl-color-bg-nav: #ffffff;
+  --sl-color-bg-sidebar: #ffffff;
+  --sl-color-bg-inline-code: #f4f4f5;
+  --sl-color-bg-input: #ffffff;
+  --sl-color-bg-row: #ffffff;
+  --sl-color-bg-row-hover: #f4f4f5;
+
+  --sl-color-white: #18181b;
+  --sl-color-gray-1: #18181b;
+  --sl-color-gray-2: #3f3f46;
+  --sl-color-gray-3: #52525b;
+  --sl-color-gray-4: #71717a;
+  --sl-color-gray-5: #a1a1aa;
+  --sl-color-gray-6: #d4d4d8;
+  --sl-color-gray-7: #e4e4e7;
+
+  --sl-color-black: #ffffff;
+  --sl-color-accent: #0891b2;
+  --sl-color-accent-text: #ffffff;
+  --sl-color-accent-low: rgba(8, 145, 178, 0.08);
+  --sl-color-accent-high: rgba(8, 145, 178, 0.22);
+
+  --sl-color-healing-1: #059669;
+  --sl-color-healing-2: #047857;
+  --sl-color-admonition-tip: #0891b2;
+  --sl-color-admonition-note: #52525b;
+  --sl-color-admonition-caution: #d97706;
+  --sl-color-admonition-danger: #dc2626;
+}
+
+/* Refined type scale for a scientific feel */
+:root {
+  --sl-text-xs: 0.75rem;
+  --sl-text-sm: 0.875rem;
+  --sl-text-base: 0.9375rem;
+  --sl-text-lg: 1.0625rem;
+  --sl-text-xl: 1.25rem;
+  --sl-text-2xl: 1.5rem;
+  --sl-text-3xl: 2rem;
+  --sl-text-4xl: 2.5rem;
+  --sl-text-5xl: 3.25rem;
+}
+
+/* Border over shadow (2026 aesthetic) */
+.starlight-sidebar,
+.sl-card,
+.card {
+  border: 1px solid var(--sl-color-gray-7);
+  box-shadow: none;
+}
+
+/* Accent link underline */
+.sl-link {
+  text-decoration-color: var(--sl-color-accent);
+}
+
+/* Code blocks: subtle border, no heavy shadow */
+:where(.expressive-code pre) {
+  border: 1px solid var(--sl-color-gray-7);
+  border-radius: 12px;
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary

Adds a 2026-aesthetic GitHub Pages site for mlx-atomistic using **Astro + Starlight**.

## What's included

### Landing page ()
- **Floating pill navigation** — backdrop-blur dock at top center with logo, section links, theme toggle, GitHub
- **Hero** — gradient-text headline, radial glow + masked grid backdrop, two CTAs
- **Bento grid** — six feature cards (Apple Silicon native, plane-wave DFT, MM, pseudopotentials, Python 3.13 + uv, validated) with varying spans
- **Stats row** + **quick-start code block**
- Mobile-first responsive (bento collapses 6→2→1 cols, nav links hide on mobile)

### 2026 design system ()
- Dark-dominant palette: near-black  bg, zinc grays
- Single saturated accent: cyan  (with cyan→violet surgical gradient on hero text only)
- Border-over-shadow aesthetic (2026 trend)
- Day/night toggle (synced with Starlight's  key)
- Inter + JetBrains Mono typography

### Docs (27 pages migrated from )
-  — DFT foundations, units, runtime boundaries, testing
-  — molecular mechanics, production MD, real MM core, MD acceleration
-  — SCF core, pseudopotentials, numerics, geometry optimization, production core
-  — all benchmark result docs
-  — validation and performance
- Pagefind full-text search built in
- Sidebar autogeneration via Starlight 0.40 syntax

### Deploy ()
- Builds on push to  when  changes
- Deploys to GitHub Pages via official  action
-  + , Node 22

## Local preview

```bash
cd site && npm install && npm run dev   # http://localhost:4321/mlx-atomistic/
```

## Verification

- `npm run build` succeeds: **30 pages built**, Pagefind search index + sitemap generated
- Landing page verified in build output (float-nav, bento grid, hero present)
- Docs verified across all sidebar groups

## After merge

Enable GitHub Pages in repo Settings → Pages → Source: **GitHub Actions**. Site will be live at https://appautomaton.github.io/mlx-atomistic/