### PR TITLE
feat(site): retheme brand to Spectral Teal + living atom logo

### DIFF
--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,20 +1,20 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" rx="14" fill="#6c5ce7"/>
-  <g stroke="#fff" stroke-width="2" opacity="0.4">
-    <line x1="32" y1="32" x2="44" y2="32"/>
-    <line x1="32" y1="32" x2="38" y2="21.6"/>
-    <line x1="32" y1="32" x2="26" y2="21.6"/>
-    <line x1="32" y1="32" x2="20" y2="32"/>
-    <line x1="32" y1="32" x2="26" y2="42.4"/>
-    <line x1="32" y1="32" x2="38" y2="42.4"/>
+  <rect width="64" height="64" rx="14" fill="#0c8c7e"/>
+  <g stroke="#fff" stroke-width="2.4" opacity="0.4">
+    <line x1="32" y1="32" x2="50" y2="32"/>
+    <line x1="32" y1="32" x2="41" y2="16.4"/>
+    <line x1="32" y1="32" x2="23" y2="16.4"/>
+    <line x1="32" y1="32" x2="14" y2="32"/>
+    <line x1="32" y1="32" x2="23" y2="47.6"/>
+    <line x1="32" y1="32" x2="41" y2="47.6"/>
   </g>
   <g fill="#fff">
-    <circle cx="44" cy="32" r="3.2" opacity="0.85"/>
-    <circle cx="38" cy="21.6" r="3.2" opacity="0.85"/>
-    <circle cx="26" cy="21.6" r="3.2" opacity="0.85"/>
-    <circle cx="20" cy="32" r="3.2" opacity="0.85"/>
-    <circle cx="26" cy="42.4" r="3.2" opacity="0.85"/>
-    <circle cx="38" cy="42.4" r="3.2" opacity="0.85"/>
-    <circle cx="32" cy="32" r="4.6"/>
+    <circle cx="50" cy="32" r="4.8" opacity="0.9"/>
+    <circle cx="41" cy="16.4" r="4.8" opacity="0.9"/>
+    <circle cx="23" cy="16.4" r="4.8" opacity="0.9"/>
+    <circle cx="14" cy="32" r="4.8" opacity="0.9"/>
+    <circle cx="23" cy="47.6" r="4.8" opacity="0.9"/>
+    <circle cx="41" cy="47.6" r="4.8" opacity="0.9"/>
+    <circle cx="32" cy="32" r="6.9"/>
   </g>
 </svg>

--- a/site/src/assets/logo.svg
+++ b/site/src/assets/logo.svg
@@ -1,19 +1,37 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g stroke="#7468e8" stroke-width="2.4" opacity="0.3">
-    <line x1="32" y1="32" x2="47" y2="32"/>
-    <line x1="32" y1="32" x2="39.5" y2="19"/>
-    <line x1="32" y1="32" x2="24.5" y2="19"/>
-    <line x1="32" y1="32" x2="17" y2="32"/>
-    <line x1="32" y1="32" x2="24.5" y2="45"/>
-    <line x1="32" y1="32" x2="39.5" y2="45"/>
-  </g>
-  <g fill="#7468e8">
-    <circle cx="47" cy="32" r="4" opacity="0.7"/>
-    <circle cx="39.5" cy="19" r="4" opacity="0.7"/>
-    <circle cx="24.5" cy="19" r="4" opacity="0.7"/>
-    <circle cx="17" cy="32" r="4" opacity="0.7"/>
-    <circle cx="24.5" cy="45" r="4" opacity="0.7"/>
-    <circle cx="39.5" cy="45" r="4" opacity="0.7"/>
-    <circle cx="32" cy="32" r="5.5"/>
+  <style>
+    .orbit { transform-box: fill-box; transform-origin: center; animation: spin 22s linear infinite; }
+    .sat, .cen { transform-box: fill-box; transform-origin: center; }
+    .sat { animation: jitA 1.7s ease-in-out infinite; }
+    .s1 { animation-name: jitB; animation-duration: 1.5s; animation-delay: -0.3s; }
+    .s2 { animation-name: jitC; animation-duration: 1.9s; animation-delay: -0.7s; }
+    .s3 { animation-duration: 1.6s; animation-delay: -1.1s; }
+    .s4 { animation-name: jitB; animation-duration: 2s; animation-delay: -0.5s; }
+    .s5 { animation-name: jitC; animation-duration: 1.55s; animation-delay: -0.9s; }
+    .cen { animation: jitA 2.6s ease-in-out infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes jitA { 0%,100% { transform: translate(0,0); } 30% { transform: translate(0.7px,-0.6px); } 60% { transform: translate(-0.5px,0.6px); } }
+    @keyframes jitB { 0%,100% { transform: translate(0,0); } 35% { transform: translate(-0.7px,-0.4px); } 70% { transform: translate(0.5px,0.6px); } }
+    @keyframes jitC { 0%,100% { transform: translate(0,0); } 40% { transform: translate(0.4px,0.7px); } 75% { transform: translate(0.6px,-0.4px); } }
+    @media (prefers-reduced-motion: reduce) { .orbit, .sat, .cen { animation: none; } }
+  </style>
+  <g class="orbit">
+    <g stroke="#0c8c7e" stroke-width="2.4" opacity="0.34">
+      <line x1="32" y1="32" x2="47" y2="32"/>
+      <line x1="32" y1="32" x2="39.5" y2="19"/>
+      <line x1="32" y1="32" x2="24.5" y2="19"/>
+      <line x1="32" y1="32" x2="17" y2="32"/>
+      <line x1="32" y1="32" x2="24.5" y2="45"/>
+      <line x1="32" y1="32" x2="39.5" y2="45"/>
+    </g>
+    <g fill="#0c8c7e">
+      <circle class="sat s0" cx="47" cy="32" r="4" opacity="0.85"/>
+      <circle class="sat s1" cx="39.5" cy="19" r="4" opacity="0.85"/>
+      <circle class="sat s2" cx="24.5" cy="19" r="4" opacity="0.85"/>
+      <circle class="sat s3" cx="17" cy="32" r="4" opacity="0.85"/>
+      <circle class="sat s4" cx="24.5" cy="45" r="4" opacity="0.85"/>
+      <circle class="sat s5" cx="39.5" cy="45" r="4" opacity="0.85"/>
+      <circle class="cen" cx="32" cy="32" r="5.5"/>
+    </g>
   </g>
 </svg>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -120,15 +120,17 @@ const stats = [
   <body>
     <nav class="nav" aria-label="Primary">
       <a class="nav__brand" href="/mlx-atomistic/">
-        <svg width="25" height="25" viewBox="0 0 64 64" fill="none" aria-hidden="true">
-          <g stroke="currentColor" stroke-width="2.4" opacity="0.3">
-            <line x1="32" y1="32" x2="47" y2="32" /><line x1="32" y1="32" x2="39.5" y2="19" /><line x1="32" y1="32" x2="24.5" y2="19" />
-            <line x1="32" y1="32" x2="17" y2="32" /><line x1="32" y1="32" x2="24.5" y2="45" /><line x1="32" y1="32" x2="39.5" y2="45" />
-          </g>
-          <g fill="currentColor">
-            <circle cx="47" cy="32" r="4" opacity="0.7" /><circle cx="39.5" cy="19" r="4" opacity="0.7" /><circle cx="24.5" cy="19" r="4" opacity="0.7" />
-            <circle cx="17" cy="32" r="4" opacity="0.7" /><circle cx="24.5" cy="45" r="4" opacity="0.7" /><circle cx="39.5" cy="45" r="4" opacity="0.7" />
-            <circle cx="32" cy="32" r="5.5" />
+        <svg class="brand-atom" width="25" height="25" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+          <g class="brand-atom__orbit">
+            <g stroke="currentColor" stroke-width="2.4" opacity="0.34">
+              <line x1="32" y1="32" x2="47" y2="32" /><line x1="32" y1="32" x2="39.5" y2="19" /><line x1="32" y1="32" x2="24.5" y2="19" />
+              <line x1="32" y1="32" x2="17" y2="32" /><line x1="32" y1="32" x2="24.5" y2="45" /><line x1="32" y1="32" x2="39.5" y2="45" />
+            </g>
+            <g fill="currentColor">
+              <circle class="sat s0" cx="47" cy="32" r="4" opacity="0.85" /><circle class="sat s1" cx="39.5" cy="19" r="4" opacity="0.85" /><circle class="sat s2" cx="24.5" cy="19" r="4" opacity="0.85" />
+              <circle class="sat s3" cx="17" cy="32" r="4" opacity="0.85" /><circle class="sat s4" cx="24.5" cy="45" r="4" opacity="0.85" /><circle class="sat s5" cx="39.5" cy="45" r="4" opacity="0.85" />
+              <circle class="cen" cx="32" cy="32" r="5.5" />
+            </g>
           </g>
         </svg>
         <span>mlx-atomistic</span>
@@ -459,8 +461,8 @@ const stats = [
     --ink: #1d1d1f;
     --ink-2: #6e6e73;
     --ink-3: #86868b;
-    --blue: #6c5ce7;
-    --blue-hover: #5a4bd4;
+    --accent: #0c8c7e;
+    --accent-hover: #0a6f63;
     --on-accent: #ffffff;
     --border: #d2d2d7;
     --border-soft: rgba(0, 0, 0, 0.08);
@@ -483,9 +485,9 @@ const stats = [
     --ink: #f5f5f7;
     --ink-2: #a1a1a6;
     --ink-3: #86868b;
-    --blue: #b7abff;
-    --blue-hover: #c9c0ff;
-    --on-accent: #14122b;
+    --accent: #4fd8c6;
+    --accent-hover: #7fe6d8;
+    --on-accent: #06231e;
     --border: #2a2a2c;
     --border-soft: rgba(255, 255, 255, 0.1);
     --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.4);
@@ -549,7 +551,43 @@ const stats = [
     font-size: 0.95rem;
     letter-spacing: -0.02em;
   }
-  .nav__brand svg { color: var(--blue); }
+  .nav__brand svg { color: var(--accent); }
+
+  /* Living brand mark: the shell slow-spins while each satellite jitters on an
+     offset phase — atoms in an MD run are never still. Hover heats it up. */
+  .brand-atom .sat,
+  .brand-atom .cen { transform-box: fill-box; transform-origin: center; }
+  .brand-atom__orbit {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: brand-spin 22s linear infinite;
+  }
+  .brand-atom .sat { animation: brand-jitA 1.7s ease-in-out infinite; }
+  .brand-atom .s1 { animation-name: brand-jitB; animation-duration: 1.5s; animation-delay: -0.3s; }
+  .brand-atom .s2 { animation-name: brand-jitC; animation-duration: 1.9s; animation-delay: -0.7s; }
+  .brand-atom .s3 { animation-duration: 1.6s; animation-delay: -1.1s; }
+  .brand-atom .s4 { animation-name: brand-jitB; animation-duration: 2s; animation-delay: -0.5s; }
+  .brand-atom .s5 { animation-name: brand-jitC; animation-duration: 1.55s; animation-delay: -0.9s; }
+  .brand-atom .cen { animation: brand-jitA 2.6s ease-in-out infinite; }
+  .brand-atom { transition: filter 0.45s ease; }
+
+  .nav__brand:hover .brand-atom .sat { animation-duration: 0.5s; }
+  .nav__brand:hover .brand-atom .cen { animation: brand-pulse 1.05s ease-in-out infinite; }
+  .nav__brand:hover .brand-atom {
+    filter: drop-shadow(0 0 6px color-mix(in srgb, var(--accent) 55%, transparent));
+  }
+
+  @keyframes brand-spin { to { transform: rotate(360deg); } }
+  @keyframes brand-jitA { 0%, 100% { transform: translate(0, 0); } 30% { transform: translate(0.7px, -0.6px); } 60% { transform: translate(-0.5px, 0.6px); } }
+  @keyframes brand-jitB { 0%, 100% { transform: translate(0, 0); } 35% { transform: translate(-0.7px, -0.4px); } 70% { transform: translate(0.5px, 0.6px); } }
+  @keyframes brand-jitC { 0%, 100% { transform: translate(0, 0); } 40% { transform: translate(0.4px, 0.7px); } 75% { transform: translate(0.6px, -0.4px); } }
+  @keyframes brand-pulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.16); } }
+
+  @media (prefers-reduced-motion: reduce) {
+    .brand-atom .sat,
+    .brand-atom .cen,
+    .brand-atom__orbit { animation: none !important; }
+  }
 
   .nav__links {
     display: flex;
@@ -601,7 +639,7 @@ const stats = [
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.01em;
-    color: var(--blue);
+    color: var(--accent);
     margin-bottom: 1.1rem;
   }
 
@@ -612,7 +650,7 @@ const stats = [
     letter-spacing: -0.035em;
     margin-bottom: 1.4rem;
   }
-  .accent { color: var(--blue); }
+  .accent { color: var(--accent); }
 
   .lead {
     font-size: clamp(1.1rem, 2vw, 1.4rem);
@@ -643,16 +681,16 @@ const stats = [
   }
   .btn--primary {
     padding: 0.7rem 1.5rem;
-    background: var(--blue);
+    background: var(--accent);
     color: var(--on-accent);
     border-radius: 980px;
   }
   .btn--primary:hover {
-    background: var(--blue-hover);
+    background: var(--accent-hover);
     transform: scale(1.02);
   }
   .btn--link {
-    color: var(--blue);
+    color: var(--accent);
   }
   .btn--link svg { transition: transform 0.18s ease; }
   .btn--link:hover svg { transform: translateX(3px); }
@@ -744,7 +782,7 @@ const stats = [
   }
   .lattice .die-inner {
     fill: none;
-    stroke: color-mix(in srgb, var(--blue) 26%, transparent);
+    stroke: color-mix(in srgb, var(--accent) 26%, transparent);
     stroke-width: 1.5;
   }
   .lattice .pins line {
@@ -758,8 +796,8 @@ const stats = [
   .lattice .atom-b { stop-color: #aebbd0; }
   [data-theme="dark"] .lattice .atom-a { stop-color: #50535c; }
   [data-theme="dark"] .lattice .atom-b { stop-color: #1b1c22; }
-  .lattice .atomA-a { stop-color: #cdc4ff; }
-  .lattice .atomA-b { stop-color: var(--blue); }
+  .lattice .atomA-a { stop-color: #a7efe4; }
+  .lattice .atomA-b { stop-color: var(--accent); }
   .lattice .atoms circle {
     filter: drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.18));
   }
@@ -780,9 +818,9 @@ const stats = [
     letter-spacing: -0.01em;
     padding: 0.2rem 0.65rem;
     border-radius: 999px;
-    color: var(--blue);
-    background: color-mix(in srgb, var(--blue) 12%, transparent);
-    border: 1px solid color-mix(in srgb, var(--blue) 28%, transparent);
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
     transition: color 0.25s ease, background 0.25s ease, border-color 0.25s ease;
   }
   .hero__readout .phase[data-phase="molten"] {
@@ -802,7 +840,7 @@ const stats = [
     height: 100%;
     width: 6%;
     border-radius: 999px;
-    background: linear-gradient(90deg, var(--blue), #ff8a3d);
+    background: linear-gradient(90deg, var(--accent), #ff8a3d);
     transition: width 0.18s linear;
   }
   .hero__hint {
@@ -874,8 +912,8 @@ const stats = [
     align-items: center;
     justify-content: center;
     border-radius: 13px;
-    color: var(--blue);
-    background: color-mix(in srgb, var(--blue) 10%, transparent);
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
     margin-bottom: 1.1rem;
   }
   .card__icon svg { width: 24px; height: 24px; }
@@ -963,7 +1001,7 @@ const stats = [
     line-height: 1.75;
     color: var(--ink);
   }
-  .c-prompt { color: var(--blue); user-select: none; }
+  .c-prompt { color: var(--accent); user-select: none; }
   .c-comment { color: var(--ink-3); }
 
   /* ---------- Footer ---------- */

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -34,10 +34,10 @@
   --sl-color-gray-7: #f0f0f3;
   --sl-color-black: #ffffff;
 
-  --sl-color-accent: #6c5ce7;
-  --sl-color-accent-low: rgba(108, 92, 231, 0.1);
-  --sl-color-accent-high: #5343c9;
-  --sl-color-text-accent: #5a4bd4;
+  --sl-color-accent: #0c8c7e;
+  --sl-color-accent-low: rgba(12, 140, 126, 0.1);
+  --sl-color-accent-high: #0a6f63;
+  --sl-color-text-accent: #0a6f63;
   --sl-color-text-invert: #ffffff;
 
   --sl-color-hairline: #d2d2d7;
@@ -62,11 +62,11 @@
   --sl-color-gray-7: #161617;
   --sl-color-black: #000000;
 
-  --sl-color-accent: #b7abff;
-  --sl-color-accent-low: rgba(183, 171, 255, 0.14);
-  --sl-color-accent-high: #cfc6ff;
-  --sl-color-text-accent: #b7abff;
-  --sl-color-text-invert: #14122b;
+  --sl-color-accent: #4fd8c6;
+  --sl-color-accent-low: rgba(79, 216, 198, 0.14);
+  --sl-color-accent-high: #7fe6d8;
+  --sl-color-text-accent: #5fe0cf;
+  --sl-color-text-invert: #06231e;
 
   --sl-color-hairline: #2a2a2c;
   --sl-color-hairline-light: #1c1c1e;


### PR DESCRIPTION
## What & why

The landing/docs accent was `#6c5ce7` — the generic indigo-violet shared by most dev-tool and AI landing pages, so it read as templated. This reties the whole identity to **Spectral Teal**, drawn from the product's own world (Metal / GPU compute), and gives the atom mark a molecular-dynamics motion language.

## Changes
- **Landing (`index.astro`)**: rename accent token `--blue` → `--accent`/`--accent-hover` (the name no longer lies), teal values for light (`#0c8c7e`) and dark (`#4fd8c6`), retuned `--on-accent` + hero center-atom highlight. Nav mark now slow-spins the shell while each satellite thermal-jitters on an offset phase, and **heats up on hover** (faster jitter + glowing core).
- **Docs (`custom.css`)**: Starlight `--sl-color-accent`/`-high`/`-low`/`--sl-color-text-accent` retuned to teal for both themes, AA-legible.
- **`favicon.svg`**: recolor teal + scale the atom ~1.45× (r12 → r18) so it fills the tile instead of floating.
- **`logo.svg`**: recolor teal + embed spin/jitter animation inside the SVG (Starlight serves it as `<img>`).

## Notes
- All motion respects `prefers-reduced-motion`.
- Recolor flows entirely through existing design tokens — no scattered hexes.
- The one intentional warm accent (molten-state ember) is preserved.
- `npm run build` passes (84 pages); light + dark verified via headless screenshots.