### PR TITLE
feat(site): morph the nav on scroll — narrower pill + wordmark condense

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -134,7 +134,10 @@ const stats = [
             </g>
           </g>
         </svg>
-        <span>mlx-atomistic</span>
+        <span class="brand-word">
+          <span class="brand-word__full">mlx-atomistic</span>
+          <span class="brand-word__short" aria-hidden="true">atomistic</span>
+        </span>
       </a>
       <div class="nav__links">
         <a href="/mlx-atomistic/overview/">Overview</a>
@@ -557,13 +560,15 @@ const stats = [
     border: 1px solid var(--border-soft);
     border-radius: 18px;
     box-shadow: var(--shadow-card);
-    transition: padding 0.28s ease, background 0.28s ease,
+    transition: width 0.32s ease, padding 0.28s ease, background 0.28s ease,
       box-shadow 0.28s ease, border-color 0.28s ease;
   }
-  /* Condensed state after scrolling past the top — the pill tightens, its glass
-     turns more opaque and its shadow deepens. Toggled by an IntersectionObserver
-     sentinel (see the inline script), so there is no per-frame scroll handler. */
+  /* Condensed state after scrolling past the top — the pill narrows and tightens,
+     its glass turns more opaque and its shadow deepens, and the wordmark morphs
+     to its short form. Toggled by an IntersectionObserver sentinel (see the
+     inline script), so there is no per-frame scroll handler. */
   .nav.is-scrolled {
+    width: min(860px, calc(100% - 2rem));
     padding-top: 0.42rem;
     padding-bottom: 0.42rem;
     background: var(--glass-strong);
@@ -604,6 +609,26 @@ const stats = [
   }
   .nav.is-scrolled .brand-atom { width: 26px; height: 26px; }
 
+  /* Wordmark morph: the full name collapses and the short form expands in place,
+     so the brand — and with it the pill — pulls in as you scroll. */
+  .brand-word {
+    display: inline-flex;
+    align-items: baseline;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .brand-word__full,
+  .brand-word__short {
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    transition: max-width 0.3s ease, opacity 0.24s ease;
+  }
+  .brand-word__full { max-width: 10em; opacity: 1; }
+  .brand-word__short { max-width: 0; opacity: 0; }
+  .nav.is-scrolled .brand-word__full { max-width: 0; opacity: 0; }
+  .nav.is-scrolled .brand-word__short { max-width: 8em; opacity: 1; }
+
   .nav__brand:hover .brand-atom .sat { animation-duration: 0.5s; }
   .nav__brand:hover .brand-atom .cen { animation: brand-pulse 1.05s ease-in-out infinite; }
   .nav__brand:hover .brand-atom {
@@ -620,6 +645,10 @@ const stats = [
     .brand-atom .sat,
     .brand-atom .cen,
     .brand-atom__orbit { animation: none !important; }
+    .nav,
+    .brand-atom,
+    .brand-word__full,
+    .brand-word__short { transition: none !important; }
   }
 
   .nav__links {


### PR DESCRIPTION
Extends the condense-on-scroll gesture (#4) so the nav reads more dynamic, per request.

## What
- **Horizontal narrowing**: the floating pill eases from its full max-width down to `min(860px, 100% - 2rem)` when `.is-scrolled` is set, staying centered.
- **Wordmark morph**: `mlx-atomistic` collapses (`max-width → 0`) while a short **`atomistic`** form expands in its place — so the brand, and the pill, pull in as you scroll.

Both ride the same easing as the existing padding / logo-shrink / glass / shadow condense, so it's one coordinated move, not several twitches.

## Naming note
Kept the wordmark **all-lowercase `mlx-atomistic`** (matches the PyPI package + import; the idiom for this class of tool). MLX gets its uppercase due in the eyebrow (`APPLE SILICON · MLX · METAL`). The condensed short form is lowercase `atomistic` to match — trivial to swap to a monogram if preferred.

## A11y & verification
- Short form is `aria-hidden`; the full name stays the accessible label.
- `prefers-reduced-motion` disables the nav/wordmark transitions (state still changes, instantly).
- Verified end-to-end via **CDP real-scroll**: `width 1080 → 860`, class toggles to `nav is-scrolled`, short wordmark expands to `136px`. Build passes (84 pages).