### PR TITLE
test: demote DFT performance-governance tests behind an opt-in perf marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ markers = [
   "reference: requires an external reference engine (openmm/lammps); run with --run-reference",
   "data: requires a heavy/gitignored dataset; run with --run-data",
   "gpu: requires a Metal GPU; skipped if unavailable",
+  "perf: exercises DFT performance and formal-evidence governance; run with --run-perf",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,15 +34,23 @@ def pytest_addoption(parser):
         default=False,
         help="run tests that require a Metal GPU",
     )
+    parser.addoption(
+        "--run-perf",
+        action="store_true",
+        default=False,
+        help="run DFT performance and formal-evidence governance tests",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
     skip_data = pytest.mark.skip(reason="requires --run-data")
     skip_reference = pytest.mark.skip(reason="requires --run-reference")
     skip_gpu = pytest.mark.skip(reason="requires --run-gpu")
+    skip_perf = pytest.mark.skip(reason="requires --run-perf")
     run_data = config.getoption("--run-data")
     run_reference = config.getoption("--run-reference")
     run_gpu = config.getoption("--run-gpu")
+    run_perf = config.getoption("--run-perf")
     for item in items:
         if not run_data and item.get_closest_marker("data"):
             item.add_marker(skip_data)
@@ -50,3 +58,5 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_reference)
         if not run_gpu and item.get_closest_marker("gpu"):
             item.add_marker(skip_gpu)
+        if not run_perf and item.get_closest_marker("perf"):
+            item.add_marker(skip_perf)

--- a/tests/test_dft_runtime_harness.py
+++ b/tests/test_dft_runtime_harness.py
@@ -821,6 +821,7 @@ def test_report_loader_rejects_laundered_raw_host_normalization(
         runtime_core._load_report(destination)
 
 
+@pytest.mark.perf
 def test_baseline_seal_requires_bound_report_and_generation_envelope(tmp_path):
     valid, _fingerprint = _fake_baseline_seal(
         tmp_path / "valid-seal",
@@ -883,6 +884,7 @@ def test_baseline_seal_requires_bound_report_and_generation_envelope(tmp_path):
         inspect_artifact(artifact=wrong_binding, require_admitted=True)
 
 
+@pytest.mark.perf
 @pytest.mark.parametrize("audit", ({"passed": False}, None, "invalid"))
 def test_baseline_seal_rejects_failed_or_malformed_diff_audit(tmp_path, audit):
     artifact, _fingerprint = _fake_baseline_seal(
@@ -896,6 +898,7 @@ def test_baseline_seal_rejects_failed_or_malformed_diff_audit(tmp_path, audit):
         runtime_core._load_seal(artifact)
 
 
+@pytest.mark.perf
 def test_baseline_seal_creation_and_comparison_are_mutually_exclusive(tmp_path):
     with pytest.raises(ValueError, match="cannot also consume"):
         run_fixed_density(
@@ -911,6 +914,7 @@ def test_baseline_seal_creation_and_comparison_are_mutually_exclusive(tmp_path):
         )
 
 
+@pytest.mark.perf
 def test_baseline_diff_audit_fails_closed_for_git_and_structure_drift(
     tmp_path, monkeypatch
 ):
@@ -1664,6 +1668,7 @@ def test_cli_publishes_structured_failure_for_operational_setup_error(
     assert "host inspection unavailable" in capsys.readouterr().err
 
 
+@pytest.mark.perf
 @pytest.mark.parametrize("source", ["AC Power", "Battery Power"])
 @pytest.mark.parametrize("mode_key", ["lowpowermode", "powermode"])
 def test_host_admission_accepts_either_source_at_active_low_power(source, mode_key):
@@ -1693,6 +1698,7 @@ def test_host_admission_accepts_either_source_at_active_low_power(source, mode_k
     assert "SECRET" not in json.dumps(provenance)
 
 
+@pytest.mark.perf
 def test_host_admission_selects_only_current_profile_and_fails_closed():
     calls = []
     battery = collect_host_provenance(
@@ -1725,6 +1731,7 @@ def test_host_admission_selects_only_current_profile_and_fails_closed():
         parse_power_profiles("AC Power:\n powermode nope\n")
 
 
+@pytest.mark.perf
 def test_host_admission_rejects_missing_or_conflicting_power_mode_keys():
     missing = {
         "chip": TARGET_CHIP,
@@ -1748,6 +1755,7 @@ def test_host_admission_rejects_missing_or_conflicting_power_mode_keys():
     )["blockers"]
 
 
+@pytest.mark.perf
 @pytest.mark.parametrize(
     ("field", "forged"),
     (
@@ -1794,6 +1802,7 @@ def test_host_power_mode_declared_normalization_mismatch_blocks_formal_admission
     assert "formal_target_host_low_power_mismatch" in formal["blockers"]
 
 
+@pytest.mark.perf
 def test_host_power_mode_uses_only_active_source_and_alias_is_not_identity():
     legacy_calls = []
     current_calls = []
@@ -1840,6 +1849,7 @@ def test_host_power_mode_uses_only_active_source_and_alias_is_not_identity():
         assert legacy_protocol[field] == value
 
 
+@pytest.mark.perf
 @pytest.mark.parametrize(
     "custom",
     (
@@ -1861,6 +1871,7 @@ def test_host_power_mode_conflict_from_pmset_fails_closed(custom):
     )["admitted"] is False
 
 
+@pytest.mark.perf
 @pytest.mark.parametrize(
     ("custom", "expected_blocker"),
     (
@@ -1881,6 +1892,7 @@ def test_host_power_mode_missing_or_non_low_fails_closed(custom, expected_blocke
     )["blockers"]
 
 
+@pytest.mark.perf
 def test_host_power_mode_equal_dual_aliases_are_unambiguous():
     outputs = _host_outputs()
     outputs[("pmset", "-g", "custom")]["stdout"] = (
@@ -1896,6 +1908,7 @@ def test_host_power_mode_equal_dual_aliases_are_unambiguous():
     )["admitted"] is True
 
 
+@pytest.mark.perf
 def test_host_power_mode_malformed_current_key_is_unparsed():
     outputs = _host_outputs()
     outputs[("pmset", "-g", "custom")]["stdout"] = "AC Power:\n powermode nope\n"
@@ -1909,6 +1922,7 @@ def test_host_power_mode_malformed_current_key_is_unparsed():
     )["admitted"] is False
 
 
+@pytest.mark.perf
 def test_compare_allows_runtime_drift_but_rejects_power_source_mismatch(
     tmp_path, monkeypatch
 ):
@@ -2100,6 +2114,7 @@ def test_compare_allows_runtime_drift_but_rejects_power_source_mismatch(
     assert "power_source_mismatch" in mismatch["admission"]["blockers"]
 
 
+@pytest.mark.perf
 def test_fixed_density_seal_records_dual_sources_and_frozen_work_profile(
     tmp_path, monkeypatch
 ):
@@ -2889,6 +2904,7 @@ def test_supervised_progress_callback_failure_still_kills_process_group(tmp_path
         assert heartbeat.read_text() == stopped_value
 
 
+@pytest.mark.perf
 def test_full_scf_publication_deadline_is_part_of_formal_admission(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Wave 2 of the test-suite declutter. Pulls the DFT performance / formal-evidence governance tests out of the required CI gate via a new opt-in `perf` marker (mirrors the existing `gpu`/`reference`/`data` `--run-*` idiom). Accuracy, numerics, and data-integrity coverage stays in the gate.

Additive only: +27 lines across pyproject.toml, tests/conftest.py, tests/test_dft_runtime_harness.py. No `src/` and no test logic changed, so protocol/runtime fingerprints are unaffected.

**Demoted (16 functions / 29 cases)** — baseline seals, git/diff provenance audit, host chip + power/Low-Power admission (9), runtime-comparison policy, frozen performance seal, full-SCF publication deadline.

**Kept in gate** — from-scratch accuracy oracle, numerical-failure handling, atomic-publication/tamper safety, loader identity rejection, observer/memory/complex128-LAPACK numerics, process-timeout safety. The compare-seal eigenvalue-parity test is kept (its real invariant is numerical correctness).

Run the demoted set on demand with `--run-perf`. Rationale: pre-v0.1, science before optimization — a formal performance baseline is premature, so it should not gate every PR.