### PR TITLE
dft: mark bulk-silicon plane-wave SCF verified

### DIFF
--- a/docs/dft-production-core.md
+++ b/docs/dft-production-core.md
@@ -58,13 +58,18 @@ boundary.
 
 | Feature | Local Status | Reference Family |
 | --- | --- | --- |
-| Plane-wave SCF core | proof-level | CP2K Quickstep, QE PWscf |
+| Plane-wave SCF core | verified (bulk-Si EOS) | CP2K Quickstep, QE PWscf |
 | UPF/GTH pseudopotentials and nonlocal projectors | proof-level | QE UPF, CP2K GTH |
 | Geometry relaxation and finite-difference stress | proof-level | CP2K MOTION/GEO_OPT, QE relax |
 | Static reference comparison | supported | static CP2K/QE fixture summaries |
 | QM/MM force-environment orchestration | deferred | CP2K FORCE_EVAL/QMMM |
 | PH/EPW/NEB/TDDFT/MPI/offload suite breadth | deferred | QE and CP2K production suites |
 | Importing, wrapping, building, or running CP2K/QE | anti-goal | external executables |
+
+Plane-wave SCF core is `verified` only for the bulk-silicon PBE equation of state
+against an all-electron (FLEUR/WIEN2k) reference (Lejaeghere Δ factor
+1.942 meV/atom); broader chemistry stays proof-level, and the separate
+MLX-versus-QE PWscf cross-engine parity is still diagnostic, not closed.
 
 `dft_qm_scope_readiness_report()` returns a shared readiness payload for these
 features. Deferred, anti-goal, and unknown features report blockers before any

--- a/site/src/content/docs/benchmarks/mlx-dft-silicon-m5max.md
+++ b/site/src/content/docs/benchmarks/mlx-dft-silicon-m5max.md
@@ -205,6 +205,14 @@ The persisted report therefore says **scientifically verified baseline,
 cutoff-converged, and 8³ spot-check passed**. Artifacts are under
 `results/mlx-dft-science/eos-admission/`.
 
+The verified claim is an all-electron equation-of-state agreement, not a
+same-code cross-engine parity. A separate MLX-versus-Quantum-ESPRESSO PWscf
+plane-wave parity run exists but remains **diagnostic, not admitted**: its
+comparison is blocked on `case_not_comparable:strain_minus`,
+`case_not_comparable:volume_scan`, and
+`diagnostic_profile_not_admitted_for_qe_parity`. That cross-engine closure is
+deferred and is not part of this verified result.
+
 ## Bounded development evidence
 
 These rows are intentionally not comparable to the complete production result.

--- a/site/src/content/docs/dft/dft-production-core.md
+++ b/site/src/content/docs/dft/dft-production-core.md
@@ -61,13 +61,18 @@ boundary.
 
 | Feature | Local Status | Reference Family |
 | --- | --- | --- |
-| Plane-wave SCF core | proof-level | CP2K Quickstep, QE PWscf |
+| Plane-wave SCF core | verified (bulk-Si EOS) | CP2K Quickstep, QE PWscf |
 | UPF/GTH pseudopotentials and nonlocal projectors | proof-level | QE UPF, CP2K GTH |
 | Geometry relaxation and finite-difference stress | proof-level | CP2K MOTION/GEO_OPT, QE relax |
 | Static reference comparison | supported | static CP2K/QE fixture summaries |
 | QM/MM force-environment orchestration | deferred | CP2K FORCE_EVAL/QMMM |
 | PH/EPW/NEB/TDDFT/MPI/offload suite breadth | deferred | QE and CP2K production suites |
 | Importing, wrapping, building, or running CP2K/QE | anti-goal | external executables |
+
+Plane-wave SCF core is `verified` only for the bulk-silicon PBE equation of state
+against an all-electron (FLEUR/WIEN2k) reference (Lejaeghere Δ factor
+1.942 meV/atom); broader chemistry stays proof-level, and the separate
+MLX-versus-QE PWscf cross-engine parity is still diagnostic, not closed.
 
 `dft_qm_scope_readiness_report()` returns a shared readiness payload for these
 features. Deferred, anti-goal, and unknown features report blockers before any

--- a/src/mlx_atomistic/dft/references.py
+++ b/src/mlx_atomistic/dft/references.py
@@ -132,12 +132,16 @@ def get_dft_qm_scope_report() -> DFTQMScopeReport:
         entries=(
             DFTQMScopeEntry(
                 feature="plane_wave_scf",
-                status="proof-level",
+                status="verified",
                 local_surface=("DFTSystem", "run_scf", "KohnShamOperator", "SCFResult"),
                 reference_families=("CP2K Quickstep", "Quantum ESPRESSO PWscf"),
                 rationale=(
-                    "Local SCF, LDA, Hartree, kinetic, and pseudopotential paths are "
-                    "tested on tiny grids but are not chemically certified production DFT."
+                    "Bulk-silicon PBE plane-wave SCF is scientifically verified against "
+                    "the all-electron (FLEUR/WIEN2k) PBE equation of state at Lejaeghere "
+                    "delta factor 1.942 meV/atom (verified tier). This certifies the "
+                    "silicon EOS workload only; broader chemistry stays proof-level, and "
+                    "the separate MLX-versus-QE PWscf cross-engine parity remains "
+                    "diagnostic, not closed."
                 ),
             ),
             DFTQMScopeEntry(

--- a/tests/test_dft_production_core.py
+++ b/tests/test_dft_production_core.py
@@ -269,7 +269,16 @@ def test_dft_qm_scope_report_classifies_cp2k_qe_boundaries():
     assert payload["product_runtime"] == "mlx_atomistic"
     assert "cp2k" in payload["reference_policy"]
     assert "quantum_espresso" in payload["reference_policy"]
-    assert entries["plane_wave_scf"]["status"] == "proof-level"
+    assert entries["plane_wave_scf"]["status"] == "verified"
+    # Verified is scoped to the bulk-silicon PBE EOS workload only; the rationale
+    # must say so and must not claim general/production DFT or a closed QE parity.
+    pwscf_rationale = entries["plane_wave_scf"]["rationale"]
+    assert "silicon" in pwscf_rationale.lower()
+    assert "all-electron" in pwscf_rationale
+    assert "diagnostic" in pwscf_rationale
+    # Regression guard: only plane_wave_scf moved off proof-level.
+    assert entries["pseudopotentials"]["status"] == "proof-level"
+    assert entries["geometry_and_stress"]["status"] == "proof-level"
     assert entries["static_reference_comparison"]["status"] == "supported"
     assert entries["qmmm_orchestration"]["status"] == "deferred"
     assert entries["external_runtime_execution"]["status"] == "anti-goal"
@@ -279,7 +288,7 @@ def test_dft_qm_scope_report_classifies_cp2k_qe_boundaries():
 
     ready = dft_qm_scope_readiness_report("pwscf").to_dict()
     assert ready["name"] == "dft_qm_scope"
-    assert ready["status"] == "proof-level"
+    assert ready["status"] == "verified"
     assert ready["blockers"] == []
 
     deferred = dft_qm_scope_readiness_report("qmmm").to_dict()


### PR DESCRIPTION
## What changed

- Promote the plane-wave SCF capability from proof-level to verified for the
  narrowly supported bulk-silicon PBE EOS scope.
- Record the measured 1.942 meV/atom delta and preserve broader chemistry,
  pseudopotential, geometry, and QE cross-engine parity limitations.
- Update production-core tests and both documentation surfaces so code and
  published status cannot drift.

## Claim boundary

This does not claim general DFT verification. It records the existing
bulk-silicon all-electron EOS validation only; QE PWscf parity remains
diagnostic/deferred.

## Verification

- Production-core and periodic DFT tests passed
- Ruff passed
- API documentation generation completed (57 pages)
- `git diff --check` passed

No production runtime behavior changed.
