### PR TITLE
Compact neighbor pairs deterministically on Metal

### DIFF
--- a/src/mlx_atomistic/metal_kernels.py
+++ b/src/mlx_atomistic/metal_kernels.py
@@ -83,6 +83,7 @@ _pme_order5_spread_kernel_singleton = None
 _pme_order5_interpolate_kernel_singleton = None
 _aligned_topology_lj_scales_kernel_singleton = None
 _neighbor_pair_cutoff_mask_kernel_singleton = None
+_neighbor_pair_ordered_scatter_kernel_singleton = None
 
 # The float32 erf/expm1 implementation below is adapted from MLX's Metal
 # kernels:
@@ -842,6 +843,18 @@ _NEIGHBOR_PAIR_CUTOFF_MASK_SOURCE = r"""
     close[t] = dx * dx + dy * dy + dz * dz < params[0];
 """
 
+_NEIGHBOR_PAIR_ORDERED_SCATTER_SOURCE = r"""
+    uint t = thread_position_in_grid.x;
+    if (t >= (uint)counts[0] || !close[t]) {
+        return;
+    }
+    uint out = (uint)(prefix[t] - 1);
+    int i = pairs_i[t];
+    int j = pairs_j[t];
+    accepted_i[out] = min(i, j);
+    accepted_j[out] = max(i, j);
+"""
+
 
 def _lj_force_kernel():
     """Return the cached fused-LJ Metal kernel, building it on first call."""
@@ -1083,6 +1096,26 @@ def _neighbor_pair_cutoff_mask_kernel():
     return _neighbor_pair_cutoff_mask_kernel_singleton
 
 
+def _neighbor_pair_ordered_scatter_kernel():
+    """Return the cached deterministic neighbor-compaction Metal kernel."""
+
+    global _neighbor_pair_ordered_scatter_kernel_singleton
+    if _neighbor_pair_ordered_scatter_kernel_singleton is None:
+        _neighbor_pair_ordered_scatter_kernel_singleton = mx.fast.metal_kernel(
+            name="neighbor_pair_ordered_scatter",
+            input_names=[
+                "pairs_i",
+                "pairs_j",
+                "close",
+                "prefix",
+                "counts",
+            ],
+            output_names=["accepted_i", "accepted_j"],
+            source=_NEIGHBOR_PAIR_ORDERED_SCATTER_SOURCE,
+        )
+    return _neighbor_pair_ordered_scatter_kernel_singleton
+
+
 def neighbor_pair_cutoff_mask(
     positions: mx.array,
     pairs_i: mx.array,
@@ -1145,6 +1178,64 @@ def neighbor_pair_cutoff_mask(
         threadgroup=(threads, 1, 1),
     )
     return close
+
+
+def neighbor_pair_ordered_scatter(
+    pairs_i: mx.array,
+    pairs_j: mx.array,
+    close: mx.array,
+    prefix: mx.array,
+) -> tuple[mx.array, mx.array]:
+    """Scatter accepted neighbor candidates by their stable prefix positions.
+
+    Args:
+        pairs_i: Left atom indices with shape ``(n_pairs,)``.
+        pairs_j: Right atom indices with shape ``(n_pairs,)``.
+        close: Boolean cutoff mask with shape ``(n_pairs,)``.
+        prefix: Inclusive integer prefix sum of ``close``.
+
+    Returns:
+        Candidate-sized left and right output buffers whose leading accepted
+        entries preserve the input candidate order.
+
+    Raises:
+        ValueError: If the inputs are not matching one-dimensional arrays.
+    """
+
+    pairs_i = as_mx_array(pairs_i, dtype=mx.int32)
+    pairs_j = as_mx_array(pairs_j, dtype=mx.int32)
+    close = as_mx_array(close, dtype=mx.bool_)
+    prefix = as_mx_array(prefix, dtype=mx.int32)
+    if pairs_i.ndim != 1:
+        msg = "pairs_i must be one-dimensional"
+        raise ValueError(msg)
+    if pairs_j.shape != pairs_i.shape or close.shape != pairs_i.shape:
+        msg = "pairs_i, pairs_j, and close must have matching shapes"
+        raise ValueError(msg)
+    if prefix.shape != pairs_i.shape:
+        msg = "prefix must match the candidate-pair shape"
+        raise ValueError(msg)
+
+    pair_count = int(pairs_i.shape[0])
+    if pair_count == 0:
+        empty = mx.zeros((0,), dtype=mx.int32)
+        return empty, empty
+    threads = min(256, pair_count)
+    accepted_i, accepted_j = _neighbor_pair_ordered_scatter_kernel()(
+        inputs=[
+            pairs_i,
+            pairs_j,
+            close,
+            prefix,
+            mx.array([pair_count], dtype=mx.int32),
+        ],
+        output_shapes=[(pair_count,), (pair_count,)],
+        output_dtypes=[mx.int32, mx.int32],
+        grid=(pair_count, 1, 1),
+        threadgroup=(threads, 1, 1),
+        init_value=0,
+    )
+    return accepted_i, accepted_j
 
 
 def aligned_topology_lj_scales(

--- a/src/mlx_atomistic/neighbors.py
+++ b/src/mlx_atomistic/neighbors.py
@@ -17,7 +17,10 @@ from mlx_atomistic.cell_list import (
     estimate_pair_list_bytes,
 )
 from mlx_atomistic.core import Cell, as_mx_array
-from mlx_atomistic.metal_kernels import neighbor_pair_cutoff_mask
+from mlx_atomistic.metal_kernels import (
+    neighbor_pair_cutoff_mask,
+    neighbor_pair_ordered_scatter,
+)
 
 NeighborBackend = Literal[
     "auto",
@@ -42,9 +45,9 @@ DEFAULT_MLX_CELL_BLOCK_SIZE = 256
 # M5 Max (4k/16k/50k LJ, 2026-06-18): compacting candidates to real pairs
 # ("mlx_cell_pairs") beats the fixed-shape padded-block path ("mlx_cell_blocks")
 # by 5.9-7.1x in a managed loop (incl. rebuild) at identical physics (dE=0).
-# Host compaction scales near-linearly (50k build ~0.34s) and does not OOM, so
-# there is no scaling reason to prefer padded blocks. Blocks remain available as
-# an explicit backend for the future on-device fused path.
+# Compact real-pair lists avoid evaluating the much larger padded candidate
+# inventory. Metal uses deterministic prefix-scan compaction while CPU retains
+# the NumPy fallback. Blocks remain available as an explicit backend.
 DEFAULT_LARGE_SYSTEM_NEIGHBOR_BACKEND: NeighborBackend = "mlx_cell_pairs"
 _BOOL_BYTES = np.dtype(np.bool_).itemsize
 _FLOAT_BYTES = np.dtype(np.float32).itemsize
@@ -951,7 +954,11 @@ def _build_mlx_cell_pair_list(
         representation_kind="pairs",
         candidate_count=candidate_count,
         estimated_candidate_bytes=peak_candidate_count * (3 * _FLOAT_BYTES + _BOOL_BYTES),
-        compaction_backend="cpu_argwhere",
+        compaction_backend=(
+            "metal_prefix_scan"
+            if "gpu" in str(mx.default_device()).lower()
+            else "cpu_argwhere"
+        ),
         fallback_reason=None,
     )
     return NeighborList(
@@ -1001,6 +1008,26 @@ def _mlx_filter_index_pairs_within_radius(
             cell.lengths,
             search_radius=search_radius,
         )
+        prefix = mx.cumsum(close.astype(mx.int32))
+        mx.eval(prefix)
+        selected_count = int(np.asarray(prefix[-1]))
+        if selected_count == 0:
+            return np.empty((0, 2), dtype=np.int32)
+        accepted_i, accepted_j = neighbor_pair_ordered_scatter(
+            left_mx,
+            right_mx,
+            close,
+            prefix,
+        )
+        compact = mx.stack(
+            (
+                accepted_i[:selected_count],
+                accepted_j[:selected_count],
+            ),
+            axis=1,
+        )
+        mx.eval(compact)
+        return np.asarray(compact).astype(np.int32, copy=False)
     else:
         displacement = positions_mx[left_mx] - positions_mx[right_mx]
         displacement = cell.minimum_image(displacement)

--- a/tests/test_fused_lj_kernel.py
+++ b/tests/test_fused_lj_kernel.py
@@ -27,6 +27,7 @@ from mlx_atomistic.metal_kernels import (
     fused_parameterized_pme_direct_components,
     fused_parameterized_pme_direct_force_only,
     neighbor_pair_cutoff_mask,
+    neighbor_pair_ordered_scatter,
 )
 from mlx_atomistic.neighbors import NeighborListManager, build_neighbor_list
 from mlx_atomistic.pme import PMEConfig
@@ -119,6 +120,30 @@ def test_neighbor_cutoff_mask_matches_mlx_and_preserves_compact_pair_order():
     assert not bool(np.asarray(fused_mask)[0])
     assert not bool(np.asarray(fused_mask)[1])
 
+    prefix = mx.cumsum(fused_mask.astype(mx.int32))
+    mx.eval(prefix)
+    accepted_count = int(np.asarray(prefix[-1]))
+    accepted_i, accepted_j = neighbor_pair_ordered_scatter(
+        pairs_i,
+        pairs_j,
+        fused_mask,
+        prefix,
+    )
+    compact = mx.stack(
+        (accepted_i[:accepted_count], accepted_j[:accepted_count]),
+        axis=1,
+    )
+    mx.eval(compact)
+    mask_np = np.asarray(expected_mask)
+    expected_pairs = np.stack(
+        (
+            np.asarray(pairs_i)[mask_np],
+            np.asarray(pairs_j)[mask_np],
+        ),
+        axis=1,
+    )
+    assert np.array_equal(np.asarray(compact), expected_pairs)
+
     first = build_neighbor_list(
         positions_np,
         cell,
@@ -148,6 +173,7 @@ def test_neighbor_cutoff_mask_matches_mlx_and_preserves_compact_pair_order():
     } == {
         tuple(pair) for pair in np.asarray(oracle.pairs).tolist()
     }
+    assert first.compaction_backend == "metal_prefix_scan"
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## What changed

- compact Metal neighbor candidates with a deterministic prefix scan and ordered scatter
- transfer only the compact accepted pair inventory back to the host instead of the full cutoff mask
- report `metal_prefix_scan` as the active GPU compaction backend
- add a real-Metal regression that locks cutoff membership and input pair order

## Why

Large-system profiling showed neighbor-list updates consuming 88–96% of trajectory wall time. The previous Metal path computed the cutoff mask on-device, copied the full mask to the CPU, and used NumPy `argwhere` plus host indexing to compact it. The new path keeps selection and ordered scatter on Metal while preserving the exact deterministic pair order.

An unordered atomic implementation was faster in isolation but was rejected because identical rebuilds produced different pair order. The independently measured Verlet-skin policy is deliberately excluded from this change and published as a separate stacked PR.

## Performance

Corrected 750-step JAC PME workload on M5 Max, 4 fs, 9 Å cutoff, 2.5 Å skin:

| Atoms | Before | After | Reduction |
|---:|---:|---:|---:|
| 23,558 | 18.213 s | 15.570 s | 14.5% |
| 47,116 | 32.132 s | 28.105 s | 12.5% |
| 94,232 | 61.274 s | 54.793 s | 10.6% |

The isolated 23k rebuild median improved from 174.01 ms to 142.24 ms. The 94k process-tree peak was 6.09 GB, below the 40 GB ceiling, and its memory plateau passed.

## Validation

- exact compact pair inventory and deterministic order preserved
- real-Metal GPU kernel suite: 9 passed
- focused CPU neighbor/production tests: 149 passed
- required CPU `not slow` lane: green
- Ruff across `src`, `tests`, and `scripts`: green
- API documentation generation: 57 pages
- `git diff --check`: clean

## Dependency

This is a stacked performance PR based on `agent/fix-langevin-rattle-dynamics` so all timings use the corrected Langevin/RATTLE dynamics from #20.
