### PR TITLE
Tune production neighbor skin

### DIFF
--- a/src/mlx_atomistic/prep/runner.py
+++ b/src/mlx_atomistic/prep/runner.py
@@ -75,7 +75,10 @@ TRAJECTORY_NAME = "trajectory.npz"
 STEERED_TRAJECTORY_NAME = "steered_trajectory.npz"
 GPCRMD_RUN_REPORT_NAME = "gpcrmd_mlx_run_report.json"
 PRESSURE_DIAGNOSTIC_ATOM_LIMIT = 50_000
-GPCRMD_NEIGHBOR_SKIN = 2.5
+# Full 750-step JAC PME scaling on M5 Max (2026-07-31): 5.5 A reduced
+# 23k/47k/94k runtime by 18.6-27.0% over 2.5 A after Metal prefix compaction.
+# The 94k process tree peaked at 10.26 GB with a stable memory plateau.
+GPCRMD_NEIGHBOR_SKIN = 5.5
 GPCRMD_NEIGHBOR_WORKERS = max(1, min(8, os.cpu_count() or 1))
 
 


### PR DESCRIPTION
## What changed

- raise the production GPCRmd Verlet skin from 2.5 Å to 5.5 Å
- record the measured three-size runtime and memory rationale beside the policy constant

## Why

Neighbor rebuilds remain the dominant cost after deterministic Metal compaction. The larger skin builds a wider reusable pair inventory but allows substantially more MD steps between rebuilds. This is a production-runner policy only; the generic `NeighborListManager` default and scientific force cutoff are unchanged.

## Performance

Corrected 750-step JAC PME workload on M5 Max, including the parent Metal-compaction PR:

| Atoms | 2.5 Å skin | 5.5 Å skin | Additional reduction |
|---:|---:|---:|---:|
| 23,558 | 15.570 s | 12.669 s | 18.6% |
| 47,116 | 28.105 s | 20.511 s | 27.0% |
| 94,232 | 54.793 s | 40.499 s | 26.1% |

Relative to the corrected pre-optimization baseline, the combined reduction is 30.4%, 36.2%, and 33.9% respectively. The 94k process-tree peak was 10.26 GB under the 40 GB ceiling, and its memory plateau passed.

## Correctness and tradeoff

- the force cutoff remains 9 Å; the additional Verlet pairs are filtered by the same force kernel
- all runs remained finite at approximately 281–283 K
- maximum constraint error remained below 1.9e-5 Å
- candidate and compact-pair inventories were reported for every run
- the accepted tradeoff is more pair/cache memory in exchange for fewer expensive rebuilds

## Validation

- focused prep and production-artifact tests: green
- Ruff: green
- `git diff --check`: clean

## Dependency

This is a stacked policy PR based on `agent/optimize-neighbor-compaction` (#21), which is itself based on the corrected Langevin/RATTLE dynamics in #20.

