### PR TITLE
Accelerate Metal neighbor-list construction

### DIFF
--- a/docs/md-acceleration.md
+++ b/docs/md-acceleration.md
@@ -18,10 +18,12 @@ custom Metal kernels.
   mask in MLX, then records explicit CPU `argwhere` compaction metadata because
   this MLX runtime does not expose dynamic `argwhere`/`nonzero` pair emission.
 - `mlx_cell_pairs` is the large-system neighbor-list backend selected by the
-  neighbor manager's `auto` policy above the dense-pair atom limit. It keeps the
-  periodic cell/bin search space bounded, batches neighboring-cell candidates
-  into MLX distance-filter chunks, and emits compact pairs through CPU
-  compaction.
+  neighbor manager's `auto` policy above the dense-pair atom limit. On Metal it
+  bins and stably orders atoms in MLX, prunes a fine cell grid by bounding-box
+  distance, emits bounded candidate batches with a custom Metal kernel, and
+  compacts exact pairs by prefix scan. Only small cell-occupancy and task
+  metadata reaches the CPU; coordinates and compact pairs remain in MLX. The
+  CPU backend retains the established NumPy cell-list implementation.
 - `mlx_cell_blocks` keeps the periodic cell/bin candidate search in a
   fixed-shape block representation. It remains available for fixed-shape
   consumers and historical benchmark reproduction.
@@ -35,8 +37,11 @@ custom Metal kernels.
 
 ## Current Hot-Path Recommendation
 
-Do not write a custom Metal kernel first. The first decision point should come
-from `python -m mlx_atomistic.benchmarks.md_acceleration --json`.
+Measure with `python -m mlx_atomistic.benchmarks.md_acceleration --json` before
+changing a force path. The large-system neighbor emitter is now Metal-native,
+so the next scaling decision is whether to replace the explicit global pair
+array with a spatial tile representation consumed directly by the force
+kernel.
 
 The likely candidates are:
 
@@ -45,15 +50,11 @@ The likely candidates are:
   `mlx_pairs`;
 - DFT projector or solver work, if MD dense/tiled already scales well enough.
 
-For the current code shape, the most suspicious path is still neighbor-list
-construction: it uses Python dictionaries, Python sets, and NumPy loops. Dense
-MLX all-pairs should be measured first because the target machine has enough
-memory for thousands of particles.
-
 For GPCRmd-scale periodic systems, dense all-pairs is not viable. The current
-large-system route uses `mlx_cell_pairs`: CPU-side periodic binning bounds the
-candidate space, MLX evaluates batched neighboring-cell distance filters, and
-the backend emits compact pairs for the existing MLX pair force path. A
+large-system route uses `mlx_cell_pairs`. The historical implementation used
+CPU-side periodic bins and candidate arrays; the current Metal route uses a
+fine device-resident grid and an AABB-pruned canonical half-stencil, then emits
+and compacts candidates on Metal for the existing MLX pair force path. A
 92,001-atom GPCRmd 729 short-range proof run under
 `/tmp/mlx-atomistic-gpcrmd-729-mlx-cell-pairs` selected
 `nonbonded_runtime.backend=mlx_cell_pairs` with no fallback. It tested
@@ -61,22 +62,31 @@ the backend emits compact pairs for the existing MLX pair force path. A
 and recorded `elapsed_wall_seconds=23.05953904206399`,
 `neighbor_rebuild_wall_seconds=1.3890800829976797`,
 `force_evaluation_wall_seconds=11.277963876025751`, `skin=2.5`, and one
-rebuild. Direct rebuild microbenchmarks on 512-8192 particle FCC systems showed
-the batched `mlx_cell_pairs` builder matching `periodic_cell_list` pairs and
-running about 2.5-3x faster than the CPU builder. The under-5-second GPCRmd
-stretch target remains blocked by force-evaluation cost, import/orchestration
-overhead, and remaining CPU dynamic compaction.
+rebuild. Those figures describe the historical hybrid implementation. The
+under-5-second GPCRmd stretch target remains blocked by force evaluation,
+per-step synchronization, and the cost of rebuilding and consuming a global
+explicit pair array. Dynamic compaction is no longer a CPU bottleneck on Metal.
 
-A native pair emitter would benefit more than the GPCRmd notebook. It would
-accelerate any cutoff-based periodic run that currently pays CPU-side cost for
-compact neighbor-pair construction, including solvated proteins,
-protein-ligand systems, water boxes, membranes, coarse-grained systems, and
-benchmarks that use explicit pair lists. The difficult part is dynamic pair-list
-emission: MLX can evaluate dense distance masks and pair math well, but the
-runtime does not currently expose a NumPy-style one-argument `where(mask)` or
-`nonzero(mask)` compaction API for emitting variable-length `(i, j)` pairs.
-`mlx_cell_pairs` is the current pragmatic hybrid: bounded cell candidates and
-MLX distance filtering, with dynamic compaction still CPU-side.
+### Spatial Metal neighbor result
+
+The retained 2026-07-31 JAC fixed-cell PME ladder used the same 9 A cutoff,
+5.5 A skin, ten warmup steps, and 750 measured steps as its immediate control.
+These are one-time engineering measurements on an M5 Max, not a CI gate.
+
+| Atoms | Prior MLX | Spatial MLX | Time reduction | OpenMM | OpenMM / MLX | Peak process memory |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 23,558 | 12.6688 s | 8.7643 s | 30.8% | 0.6810 s | 12.9x | 1.76 GB |
+| 47,116 | 20.5108 s | 13.9166 s | 32.1% | 1.0945 s | 12.7x | 2.76 GB |
+| 94,232 | 40.4986 s | 24.3424 s | 39.9% | 1.6861 s | 14.4x | 4.80 GB |
+
+At 94,232 atoms the current 25x25x12 grid emits 184.1 million candidates,
+down 60.7% from 468.3 million, and retains about 60.5 million exact pairs. All
+three runs were finite, passed the existing constraint behavior, stayed below
+40 GB, and had passing late-memory plateaus. The result is a substantial
+retained gain but does not meet the one-order-of-magnitude OpenMM stretch
+target. The next large-system lever is spatial tiles or cell-pair tasks that
+feed the direct-space force kernel without materializing and repeatedly
+scanning the full explicit pair array.
 
 A fresh synthetic orthorhombic parity ladder now validates this route at
 1k/4k/16k/50k/92,001 atoms against the tiled all-pairs MLX oracle. At 92,001

--- a/site/src/content/docs/mm/md-acceleration.md
+++ b/site/src/content/docs/mm/md-acceleration.md
@@ -21,10 +21,12 @@ custom Metal kernels.
   mask in MLX, then records explicit CPU `argwhere` compaction metadata because
   this MLX runtime does not expose dynamic `argwhere`/`nonzero` pair emission.
 - `mlx_cell_pairs` is the large-system neighbor-list backend selected by the
-  neighbor manager's `auto` policy above the dense-pair atom limit. It keeps the
-  periodic cell/bin search space bounded, batches neighboring-cell candidates
-  into MLX distance-filter chunks, and emits compact pairs through CPU
-  compaction.
+  neighbor manager's `auto` policy above the dense-pair atom limit. On Metal it
+  bins and stably orders atoms in MLX, prunes a fine cell grid by bounding-box
+  distance, emits bounded candidate batches with a custom Metal kernel, and
+  compacts exact pairs by prefix scan. Only small cell-occupancy and task
+  metadata reaches the CPU; coordinates and compact pairs remain in MLX. The
+  CPU backend retains the established NumPy cell-list implementation.
 - `mlx_cell_blocks` keeps the periodic cell/bin candidate search in a
   fixed-shape block representation. It remains available for fixed-shape
   consumers and historical benchmark reproduction.
@@ -38,8 +40,11 @@ custom Metal kernels.
 
 ## Current Hot-Path Recommendation
 
-Do not write a custom Metal kernel first. The first decision point should come
-from `python -m mlx_atomistic.benchmarks.md_acceleration --json`.
+Measure with `python -m mlx_atomistic.benchmarks.md_acceleration --json` before
+changing a force path. The large-system neighbor emitter is now Metal-native,
+so the next scaling decision is whether to replace the explicit global pair
+array with a spatial tile representation consumed directly by the force
+kernel.
 
 The likely candidates are:
 
@@ -48,15 +53,11 @@ The likely candidates are:
   `mlx_pairs`;
 - DFT projector or solver work, if MD dense/tiled already scales well enough.
 
-For the current code shape, the most suspicious path is still neighbor-list
-construction: it uses Python dictionaries, Python sets, and NumPy loops. Dense
-MLX all-pairs should be measured first because the target machine has enough
-memory for thousands of particles.
-
 For GPCRmd-scale periodic systems, dense all-pairs is not viable. The current
-large-system route uses `mlx_cell_pairs`: CPU-side periodic binning bounds the
-candidate space, MLX evaluates batched neighboring-cell distance filters, and
-the backend emits compact pairs for the existing MLX pair force path. A
+large-system route uses `mlx_cell_pairs`. The historical implementation used
+CPU-side periodic bins and candidate arrays; the current Metal route uses a
+fine device-resident grid and an AABB-pruned canonical half-stencil, then emits
+and compacts candidates on Metal for the existing MLX pair force path. A
 92,001-atom GPCRmd 729 short-range proof run under
 `/tmp/mlx-atomistic-gpcrmd-729-mlx-cell-pairs` selected
 `nonbonded_runtime.backend=mlx_cell_pairs` with no fallback. It tested
@@ -64,22 +65,31 @@ the backend emits compact pairs for the existing MLX pair force path. A
 and recorded `elapsed_wall_seconds=23.05953904206399`,
 `neighbor_rebuild_wall_seconds=1.3890800829976797`,
 `force_evaluation_wall_seconds=11.277963876025751`, `skin=2.5`, and one
-rebuild. Direct rebuild microbenchmarks on 512-8192 particle FCC systems showed
-the batched `mlx_cell_pairs` builder matching `periodic_cell_list` pairs and
-running about 2.5-3x faster than the CPU builder. The under-5-second GPCRmd
-stretch target remains blocked by force-evaluation cost, import/orchestration
-overhead, and remaining CPU dynamic compaction.
+rebuild. Those figures describe the historical hybrid implementation. The
+under-5-second GPCRmd stretch target remains blocked by force evaluation,
+per-step synchronization, and the cost of rebuilding and consuming a global
+explicit pair array. Dynamic compaction is no longer a CPU bottleneck on Metal.
 
-A native pair emitter would benefit more than the GPCRmd notebook. It would
-accelerate any cutoff-based periodic run that currently pays CPU-side cost for
-compact neighbor-pair construction, including solvated proteins,
-protein-ligand systems, water boxes, membranes, coarse-grained systems, and
-benchmarks that use explicit pair lists. The difficult part is dynamic pair-list
-emission: MLX can evaluate dense distance masks and pair math well, but the
-runtime does not currently expose a NumPy-style one-argument `where(mask)` or
-`nonzero(mask)` compaction API for emitting variable-length `(i, j)` pairs.
-`mlx_cell_pairs` is the current pragmatic hybrid: bounded cell candidates and
-MLX distance filtering, with dynamic compaction still CPU-side.
+### Spatial Metal neighbor result
+
+The retained 2026-07-31 JAC fixed-cell PME ladder used the same 9 A cutoff,
+5.5 A skin, ten warmup steps, and 750 measured steps as its immediate control.
+These are one-time engineering measurements on an M5 Max, not a CI gate.
+
+| Atoms | Prior MLX | Spatial MLX | Time reduction | OpenMM | OpenMM / MLX | Peak process memory |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 23,558 | 12.6688 s | 8.7643 s | 30.8% | 0.6810 s | 12.9x | 1.76 GB |
+| 47,116 | 20.5108 s | 13.9166 s | 32.1% | 1.0945 s | 12.7x | 2.76 GB |
+| 94,232 | 40.4986 s | 24.3424 s | 39.9% | 1.6861 s | 14.4x | 4.80 GB |
+
+At 94,232 atoms the current 25x25x12 grid emits 184.1 million candidates,
+down 60.7% from 468.3 million, and retains about 60.5 million exact pairs. All
+three runs were finite, passed the existing constraint behavior, stayed below
+40 GB, and had passing late-memory plateaus. The result is a substantial
+retained gain but does not meet the one-order-of-magnitude OpenMM stretch
+target. The next large-system lever is spatial tiles or cell-pair tasks that
+feed the direct-space force kernel without materializing and repeatedly
+scanning the full explicit pair array.
 
 A fresh synthetic orthorhombic parity ladder now validates this route at
 1k/4k/16k/50k/92,001 atoms against the tiled all-pairs MLX oracle. At 92,001

--- a/src/mlx_atomistic/metal_kernels.py
+++ b/src/mlx_atomistic/metal_kernels.py
@@ -82,6 +82,7 @@ _pme_cutoff_correction_virial_kernel_singleton = None
 _pme_order5_spread_kernel_singleton = None
 _pme_order5_interpolate_kernel_singleton = None
 _aligned_topology_lj_scales_kernel_singleton = None
+_neighbor_cell_pair_candidates_kernel_singleton = None
 _neighbor_pair_cutoff_mask_kernel_singleton = None
 _neighbor_pair_ordered_scatter_kernel_singleton = None
 
@@ -843,6 +844,42 @@ _NEIGHBOR_PAIR_CUTOFF_MASK_SOURCE = r"""
     close[t] = dx * dx + dy * dy + dz * dz < params[0];
 """
 
+_NEIGHBOR_CELL_PAIR_CANDIDATES_SOURCE = r"""
+    uint task = thread_position_in_grid.x;
+    if (task >= (uint)counts[0]) {
+        return;
+    }
+
+    int left_cell = cell_pairs[2 * task + 0];
+    int right_cell = cell_pairs[2 * task + 1];
+    int left_start = cell_starts[left_cell];
+    int right_start = cell_starts[right_cell];
+    int left_count = cell_counts[left_cell];
+    int right_count = cell_counts[right_cell];
+    int output = task_offsets[task];
+
+    if (left_cell == right_cell) {
+        for (int left = 0; left < left_count; left++) {
+            int atom_i = sorted_atoms[left_start + left];
+            for (int right = left + 1; right < right_count; right++) {
+                pairs_i[output] = atom_i;
+                pairs_j[output] = sorted_atoms[right_start + right];
+                output++;
+            }
+        }
+        return;
+    }
+
+    for (int left = 0; left < left_count; left++) {
+        int atom_i = sorted_atoms[left_start + left];
+        for (int right = 0; right < right_count; right++) {
+            pairs_i[output] = atom_i;
+            pairs_j[output] = sorted_atoms[right_start + right];
+            output++;
+        }
+    }
+"""
+
 _NEIGHBOR_PAIR_ORDERED_SCATTER_SOURCE = r"""
     uint t = thread_position_in_grid.x;
     if (t >= (uint)counts[0] || !close[t]) {
@@ -1096,6 +1133,27 @@ def _neighbor_pair_cutoff_mask_kernel():
     return _neighbor_pair_cutoff_mask_kernel_singleton
 
 
+def _neighbor_cell_pair_candidates_kernel():
+    """Return the cached spatial neighbor-candidate Metal kernel."""
+
+    global _neighbor_cell_pair_candidates_kernel_singleton
+    if _neighbor_cell_pair_candidates_kernel_singleton is None:
+        _neighbor_cell_pair_candidates_kernel_singleton = mx.fast.metal_kernel(
+            name="neighbor_cell_pair_candidates",
+            input_names=[
+                "sorted_atoms",
+                "cell_starts",
+                "cell_counts",
+                "cell_pairs",
+                "task_offsets",
+                "counts",
+            ],
+            output_names=["pairs_i", "pairs_j"],
+            source=_NEIGHBOR_CELL_PAIR_CANDIDATES_SOURCE,
+        )
+    return _neighbor_cell_pair_candidates_kernel_singleton
+
+
 def _neighbor_pair_ordered_scatter_kernel():
     """Return the cached deterministic neighbor-compaction Metal kernel."""
 
@@ -1180,6 +1238,76 @@ def neighbor_pair_cutoff_mask(
     return close
 
 
+def _neighbor_cell_pair_candidates(
+    sorted_atoms: mx.array,
+    cell_starts: mx.array,
+    cell_counts: mx.array,
+    cell_pairs: mx.array,
+    task_offsets: mx.array,
+    *,
+    candidate_count: int,
+) -> tuple[mx.array, mx.array]:
+    """Emit atom-pair candidates for occupied spatial-cell tasks on Metal.
+
+    Args:
+        sorted_atoms: Atom indices grouped by cell with shape ``(n_atoms,)``.
+        cell_starts: Starting index of each cell in ``sorted_atoms``.
+        cell_counts: Number of atoms in each spatial cell.
+        cell_pairs: Canonical cell-pair tasks with shape ``(n_tasks, 2)``.
+        task_offsets: Exclusive output offset for each task.
+        candidate_count: Total output candidates across all tasks.
+
+    Returns:
+        Aligned left and right atom-index arrays. Same-cell tasks emit each
+        unique pair once; cross-cell tasks emit their Cartesian product.
+
+    Raises:
+        ValueError: If shapes or counts are inconsistent.
+    """
+
+    sorted_atoms = as_mx_array(sorted_atoms, dtype=mx.int32)
+    cell_starts = as_mx_array(cell_starts, dtype=mx.int32)
+    cell_counts = as_mx_array(cell_counts, dtype=mx.int32)
+    cell_pairs = as_mx_array(cell_pairs, dtype=mx.int32)
+    task_offsets = as_mx_array(task_offsets, dtype=mx.int32)
+    if sorted_atoms.ndim != 1:
+        msg = "sorted_atoms must be one-dimensional"
+        raise ValueError(msg)
+    if cell_starts.ndim != 1 or cell_counts.shape != cell_starts.shape:
+        msg = "cell_starts and cell_counts must have matching one-dimensional shapes"
+        raise ValueError(msg)
+    if cell_pairs.ndim != 2 or cell_pairs.shape[1] != 2:
+        msg = "cell_pairs must have shape (n_tasks, 2)"
+        raise ValueError(msg)
+    if task_offsets.shape != (cell_pairs.shape[0],):
+        msg = "task_offsets must contain one output offset per cell-pair task"
+        raise ValueError(msg)
+    if candidate_count < 0:
+        msg = "candidate_count must be non-negative"
+        raise ValueError(msg)
+
+    task_count = int(cell_pairs.shape[0])
+    if task_count == 0 or candidate_count == 0:
+        empty = mx.zeros((0,), dtype=mx.int32)
+        return empty, empty
+    threads = min(256, task_count)
+    pairs_i, pairs_j = _neighbor_cell_pair_candidates_kernel()(
+        inputs=[
+            sorted_atoms,
+            cell_starts,
+            cell_counts,
+            cell_pairs,
+            task_offsets,
+            mx.array([task_count], dtype=mx.int32),
+        ],
+        output_shapes=[(candidate_count,), (candidate_count,)],
+        output_dtypes=[mx.int32, mx.int32],
+        grid=(task_count, 1, 1),
+        threadgroup=(threads, 1, 1),
+    )
+    return pairs_i, pairs_j
+
+
 def neighbor_pair_ordered_scatter(
     pairs_i: mx.array,
     pairs_j: mx.array,
@@ -1203,6 +1331,26 @@ def neighbor_pair_ordered_scatter(
     """
 
     pairs_i = as_mx_array(pairs_i, dtype=mx.int32)
+    return _neighbor_pair_ordered_scatter_sized(
+        pairs_i,
+        pairs_j,
+        close,
+        prefix,
+        accepted_count=int(pairs_i.shape[0]),
+    )
+
+
+def _neighbor_pair_ordered_scatter_sized(
+    pairs_i: mx.array,
+    pairs_j: mx.array,
+    close: mx.array,
+    prefix: mx.array,
+    *,
+    accepted_count: int,
+) -> tuple[mx.array, mx.array]:
+    """Scatter accepted candidates into an explicitly sized output."""
+
+    pairs_i = as_mx_array(pairs_i, dtype=mx.int32)
     pairs_j = as_mx_array(pairs_j, dtype=mx.int32)
     close = as_mx_array(close, dtype=mx.bool_)
     prefix = as_mx_array(prefix, dtype=mx.int32)
@@ -1220,6 +1368,13 @@ def neighbor_pair_ordered_scatter(
     if pair_count == 0:
         empty = mx.zeros((0,), dtype=mx.int32)
         return empty, empty
+    output_count = int(accepted_count)
+    if output_count < 0 or output_count > pair_count:
+        msg = "accepted_count must fit within the candidate-pair count"
+        raise ValueError(msg)
+    if output_count == 0:
+        empty = mx.zeros((0,), dtype=mx.int32)
+        return empty, empty
     threads = min(256, pair_count)
     accepted_i, accepted_j = _neighbor_pair_ordered_scatter_kernel()(
         inputs=[
@@ -1229,7 +1384,7 @@ def neighbor_pair_ordered_scatter(
             prefix,
             mx.array([pair_count], dtype=mx.int32),
         ],
-        output_shapes=[(pair_count,), (pair_count,)],
+        output_shapes=[(output_count,), (output_count,)],
         output_dtypes=[mx.int32, mx.int32],
         grid=(pair_count, 1, 1),
         threadgroup=(threads, 1, 1),

--- a/src/mlx_atomistic/neighbors.py
+++ b/src/mlx_atomistic/neighbors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from itertools import product
 from time import perf_counter
 from typing import Literal
@@ -18,6 +18,8 @@ from mlx_atomistic.cell_list import (
 )
 from mlx_atomistic.core import Cell, as_mx_array
 from mlx_atomistic.metal_kernels import (
+    _neighbor_cell_pair_candidates,
+    _neighbor_pair_ordered_scatter_sized,
     neighbor_pair_cutoff_mask,
     neighbor_pair_ordered_scatter,
 )
@@ -40,6 +42,9 @@ _ALLOWED_NEIGHBOR_BACKENDS = {
 _ALLOWED_NEIGHBOR_CHECK_BACKENDS = {"numpy", "mlx_scalar"}
 DEFAULT_MLX_DENSE_PAIR_LIMIT = 4096
 DEFAULT_MLX_CELL_PAIR_CANDIDATE_CHUNK = 1_000_000
+DEFAULT_MLX_SPATIAL_CANDIDATE_BATCH = 16_000_000
+DEFAULT_MLX_SPATIAL_CELL_SUBDIVISION = 3
+DEFAULT_MLX_SPATIAL_MAX_CELLS_PER_ATOM = 4
 DEFAULT_MLX_CELL_BLOCK_SIZE = 256
 # Default neighbor backend for systems above the dense-pair limit. Measured on
 # M5 Max (4k/16k/50k LJ, 2026-06-18): compacting candidates to real pairs
@@ -276,6 +281,12 @@ class NeighborListManager:
     updates_since_check: int = 0
     rebuild_wall_seconds: float = 0.0
     update_wall_seconds: float = 0.0
+    _cache_clear_pending: bool = field(
+        default=False,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def __post_init__(self) -> None:
         if self.check_interval <= 0:
@@ -392,6 +403,7 @@ class NeighborListManager:
     def rebuild(self, positions) -> NeighborList:
         """Force a neighbor-list rebuild from current positions."""
 
+        self._release_pending_metal_cache()
         start = perf_counter()
         self.neighbor_list = build_neighbor_list(
             positions,
@@ -409,6 +421,9 @@ class NeighborListManager:
         self.rebuild_count += 1
         self.last_max_displacement = 0.0
         self.updates_since_check = 0
+        self._cache_clear_pending = (
+            self.neighbor_list.compaction_backend == "metal_spatial_prefix_scan"
+        )
         return self.neighbor_list
 
     def update(self, positions) -> NeighborList:
@@ -416,6 +431,7 @@ class NeighborListManager:
 
         start = perf_counter()
         try:
+            self._release_pending_metal_cache()
             if self.needs_rebuild(positions):
                 return self.rebuild(positions)
             if self.neighbor_list is None:
@@ -424,6 +440,15 @@ class NeighborListManager:
             return self.neighbor_list
         finally:
             self.update_wall_seconds += perf_counter() - start
+
+    def _release_pending_metal_cache(self) -> None:
+        """Release inactive rebuild temporaries at the next safe call boundary."""
+
+        if not self._cache_clear_pending:
+            return
+        self._cache_clear_pending = False
+        if _uses_metal_device():
+            mx.clear_cache()
 
     def build_cell_candidate(
         self,
@@ -503,6 +528,7 @@ class NeighborListManager:
         self.updates_since_check = candidate.updates_since_check
         self.rebuild_wall_seconds = candidate.rebuild_wall_seconds
         self.update_wall_seconds = candidate.update_wall_seconds
+        self._cache_clear_pending = candidate._cache_clear_pending
 
 
 def build_neighbor_list(
@@ -530,20 +556,31 @@ def build_neighbor_list(
         msg = "block_size must be positive"
         raise ValueError(msg)
 
-    positions_np = np.asarray(positions, dtype=np.float32)
-    if positions_np.ndim != 2 or positions_np.shape[1] != 3:
+    positions_mx = as_mx_array(positions)
+    if positions_mx.ndim != 2 or positions_mx.shape[1] != 3:
         msg = "positions must have shape (n_particles, 3)"
-        raise ValueError(msg)
-    if not np.all(np.isfinite(positions_np)):
-        msg = "positions must be finite"
         raise ValueError(msg)
     search_radius = cutoff + skin
     fallback_reason = None
     if backend == "auto":
-        if positions_np.shape[0] <= max_mlx_dense_atoms:
+        if positions_mx.shape[0] <= max_mlx_dense_atoms:
             backend = "mlx_dense_pairs"
         else:
             backend = DEFAULT_LARGE_SYSTEM_NEIGHBOR_BACKEND
+    if backend == "mlx_cell_pairs" and _uses_metal_device():
+        return _build_mlx_spatial_cell_pair_list(
+            positions_mx,
+            cell,
+            cutoff=cutoff,
+            skin=skin,
+            search_radius=search_radius,
+            sort_pairs=sort_pairs,
+        )
+
+    positions_np = np.asarray(positions_mx, dtype=np.float32)
+    if not np.all(np.isfinite(positions_np)):
+        msg = "positions must be finite"
+        raise ValueError(msg)
     if backend == "mlx_dense_pairs":
         return _build_mlx_dense_pair_list(
             positions_np,
@@ -554,7 +591,7 @@ def build_neighbor_list(
             max_atoms=max_mlx_dense_atoms,
         )
     if backend == "mlx_cell_pairs":
-        return _build_mlx_cell_pair_list(
+        return _build_mlx_cell_pair_list_cpu(
             positions_np,
             cell,
             cutoff=cutoff,
@@ -599,6 +636,10 @@ def build_neighbor_list(
         skin=skin,
         stats=stats,
     )
+
+
+def _uses_metal_device() -> bool:
+    return "gpu" in str(mx.default_device()).lower()
 
 
 def _require_orthorhombic_cell_for_compact_neighbor_backend(
@@ -856,7 +897,309 @@ def _count_candidate_pairs_within_radius(
     return int(np.count_nonzero(distance2 < search_radius * search_radius))
 
 
-def _build_mlx_cell_pair_list(
+def _build_mlx_spatial_cell_pair_list(
+    positions_mx: mx.array,
+    cell: Cell,
+    *,
+    cutoff: float,
+    skin: float,
+    search_radius: float,
+    sort_pairs: bool,
+    subdivision: int = DEFAULT_MLX_SPATIAL_CELL_SUBDIVISION,
+    candidate_batch: int = DEFAULT_MLX_SPATIAL_CANDIDATE_BATCH,
+) -> NeighborList:
+    """Build compact pairs from a device-resident, spatially pruned cell grid."""
+
+    _require_orthorhombic_cell_for_compact_neighbor_backend(cell, "mlx_cell_pairs")
+    lengths = np.asarray(cell.lengths, dtype=np.float32)
+    if lengths.shape != (3,) or np.any(~np.isfinite(lengths)) or np.any(lengths <= 0.0):
+        msg = "cell lengths must be finite and positive"
+        raise ValueError(msg)
+    if subdivision <= 0:
+        msg = "spatial cell subdivision must be positive"
+        raise ValueError(msg)
+    if candidate_batch <= 0 or candidate_batch > np.iinfo(np.int32).max:
+        msg = "spatial candidate batch must be a positive int32-sized count"
+        raise ValueError(msg)
+
+    finite = mx.all(mx.isfinite(positions_mx))
+    mx.eval(finite)
+    if not bool(np.asarray(finite)):
+        msg = "positions must be finite"
+        raise ValueError(msg)
+
+    n_atoms = int(positions_mx.shape[0])
+    lengths64 = lengths.astype(np.float64)
+    n_cells_array = _bounded_spatial_grid(
+        lengths64,
+        search_radius=search_radius,
+        subdivision=subdivision,
+        n_atoms=n_atoms,
+    )
+    n_cells = tuple(int(value) for value in n_cells_array)
+    cell_count = int(np.prod(n_cells_array.astype(np.int64)))
+    cell_widths = lengths64 / n_cells_array.astype(np.float64)
+
+    lengths_mx = mx.array(lengths, dtype=mx.float32)
+    n_cells_mx = mx.array(n_cells_array, dtype=mx.int32)
+    wrapped = positions_mx - mx.floor(positions_mx / lengths_mx) * lengths_mx
+    cell_indices = mx.floor(wrapped / lengths_mx * n_cells_mx).astype(mx.int32)
+    cell_indices = mx.minimum(cell_indices, n_cells_mx - 1)
+    cell_ids = (
+        (cell_indices[:, 0] * n_cells[1] + cell_indices[:, 1]) * n_cells[2]
+        + cell_indices[:, 2]
+    )
+    sorted_atoms = mx.argsort(cell_ids).astype(mx.int32)
+    cell_counts_mx = mx.zeros((cell_count,), dtype=mx.int32).at[cell_ids].add(
+        mx.ones((n_atoms,), dtype=mx.int32)
+    )
+    mx.eval(sorted_atoms, cell_counts_mx)
+    cell_counts = np.asarray(cell_counts_mx, dtype=np.int32)
+    cell_starts = np.empty_like(cell_counts)
+    if cell_count:
+        cell_starts[0] = 0
+        np.cumsum(cell_counts[:-1], dtype=np.int64, out=cell_starts[1:])
+
+    task_left, task_right, task_candidate_counts = _spatial_cell_pair_tasks(
+        cell_counts,
+        n_cells,
+        cell_widths,
+        search_radius=search_radius,
+    )
+    candidate_count = int(np.sum(task_candidate_counts, dtype=np.int64))
+    if task_candidate_counts.size and int(np.max(task_candidate_counts)) > candidate_batch:
+        largest = int(np.max(task_candidate_counts))
+        msg = (
+            "one spatial cell-pair task exceeds the bounded Metal candidate batch: "
+            f"candidate_count={largest}, candidate_batch={candidate_batch}; "
+            "increase spatial subdivision or reduce local occupancy"
+        )
+        raise ValueError(msg)
+
+    cell_starts_mx = mx.array(cell_starts, dtype=mx.int32)
+    compact_chunks: list[mx.array] = []
+    compact_pair_count = 0
+    peak_candidate_count = 0
+    for task_start, task_stop in _spatial_task_batches(
+        task_candidate_counts,
+        candidate_batch=candidate_batch,
+    ):
+        batch_counts = task_candidate_counts[task_start:task_stop]
+        batch_candidate_count = int(np.sum(batch_counts, dtype=np.int64))
+        peak_candidate_count = max(peak_candidate_count, batch_candidate_count)
+        task_offsets = np.empty((batch_counts.shape[0],), dtype=np.int32)
+        task_offsets[0] = 0
+        if task_offsets.shape[0] > 1:
+            np.cumsum(batch_counts[:-1], dtype=np.int64, out=task_offsets[1:])
+        cell_pairs = np.stack(
+            (
+                task_left[task_start:task_stop],
+                task_right[task_start:task_stop],
+            ),
+            axis=1,
+        ).astype(np.int32, copy=False)
+        candidates_i, candidates_j = _neighbor_cell_pair_candidates(
+            sorted_atoms,
+            cell_starts_mx,
+            cell_counts_mx,
+            mx.array(cell_pairs, dtype=mx.int32),
+            mx.array(task_offsets, dtype=mx.int32),
+            candidate_count=batch_candidate_count,
+        )
+        close = neighbor_pair_cutoff_mask(
+            positions_mx,
+            candidates_i,
+            candidates_j,
+            cell.lengths,
+            search_radius=search_radius,
+        )
+        prefix = mx.cumsum(close.astype(mx.int32))
+        mx.eval(prefix)
+        accepted_count = int(np.asarray(prefix[-1]))
+        if accepted_count == 0:
+            continue
+        accepted_i, accepted_j = _neighbor_pair_ordered_scatter_sized(
+            candidates_i,
+            candidates_j,
+            close,
+            prefix,
+            accepted_count=accepted_count,
+        )
+        compact = mx.stack((accepted_i, accepted_j), axis=1)
+        mx.eval(compact)
+        compact_chunks.append(compact)
+        compact_pair_count += accepted_count
+
+    if compact_chunks:
+        pairs = mx.concatenate(compact_chunks, axis=0)
+    else:
+        pairs = mx.zeros((0, 2), dtype=mx.int32)
+    if sort_pairs and compact_pair_count:
+        right_order = mx.argsort(pairs[:, 1])
+        pairs = pairs[right_order]
+        left_order = mx.argsort(pairs[:, 0])
+        pairs = pairs[left_order]
+    mx.eval(pairs)
+
+    occupied_cell_count = int(np.count_nonzero(cell_counts))
+    estimated_cell_list_bytes = (
+        n_atoms * (3 * _FLOAT_BYTES + 2 * _INT_BYTES)
+        + cell_count * 2 * _INT_BYTES
+    )
+    stats = PairListStats(
+        pair_count=compact_pair_count,
+        n_cells=n_cells,
+        cell_count=cell_count,
+        occupied_cell_count=occupied_cell_count,
+        search_radius=search_radius,
+        estimated_pair_bytes=estimate_pair_list_bytes(compact_pair_count),
+        estimated_cell_list_bytes=estimated_cell_list_bytes,
+        backend="mlx_cell_pairs",
+        representation_kind="pairs",
+        candidate_count=candidate_count,
+        estimated_candidate_bytes=(
+            peak_candidate_count * (3 * _FLOAT_BYTES + _BOOL_BYTES)
+        ),
+        compaction_backend="metal_spatial_prefix_scan",
+        fallback_reason=None,
+    )
+    return NeighborList(
+        pairs,
+        cutoff=cutoff,
+        skin=skin,
+        stats=stats,
+    )
+
+
+def _spatial_cell_pair_tasks(
+    cell_counts: np.ndarray,
+    n_cells: tuple[int, int, int],
+    cell_widths: np.ndarray,
+    *,
+    search_radius: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return occupied canonical cell-pair tasks allowed by an AABB stencil."""
+
+    cell_count = int(np.prod(np.asarray(n_cells, dtype=np.int64)))
+    if cell_count == 0:
+        empty = np.empty((0,), dtype=np.int32)
+        return empty, empty, empty.astype(np.int64)
+    cell_ids = np.arange(cell_count, dtype=np.int64)
+    cell_x, cell_y, cell_z = np.unravel_index(cell_ids, n_cells)
+    encoded_chunks: list[np.ndarray] = []
+    for offset_x, offset_y, offset_z in _aabb_pruned_half_stencil(
+        cell_widths,
+        search_radius=search_radius,
+    ):
+        neighbor_x = (cell_x + offset_x) % n_cells[0]
+        neighbor_y = (cell_y + offset_y) % n_cells[1]
+        neighbor_z = (cell_z + offset_z) % n_cells[2]
+        neighbor_ids = (neighbor_x * n_cells[1] + neighbor_y) * n_cells[2] + neighbor_z
+        lower = np.minimum(cell_ids, neighbor_ids)
+        upper = np.maximum(cell_ids, neighbor_ids)
+        encoded_chunks.append(lower * cell_count + upper)
+    encoded = np.unique(np.concatenate(encoded_chunks))
+    left = encoded // cell_count
+    right = encoded % cell_count
+    left_counts = cell_counts[left]
+    right_counts = cell_counts[right]
+    same = left == right
+    candidate_counts = np.where(
+        same,
+        left_counts.astype(np.int64) * np.maximum(left_counts.astype(np.int64) - 1, 0) // 2,
+        left_counts.astype(np.int64) * right_counts.astype(np.int64),
+    )
+    occupied = candidate_counts > 0
+    return (
+        left[occupied].astype(np.int32, copy=False),
+        right[occupied].astype(np.int32, copy=False),
+        candidate_counts[occupied],
+    )
+
+
+def _bounded_spatial_grid(
+    lengths: np.ndarray,
+    *,
+    search_radius: float,
+    subdivision: int,
+    n_atoms: int,
+) -> np.ndarray:
+    """Return a fine grid without allocating a pathological number of empty cells."""
+
+    requested = np.maximum(
+        np.floor(lengths * float(subdivision) / float(search_radius)).astype(np.int64),
+        1,
+    )
+    max_cells = max(1, DEFAULT_MLX_SPATIAL_MAX_CELLS_PER_ATOM * n_atoms)
+    requested_count = int(np.prod(requested, dtype=np.int64))
+    if requested_count <= max_cells:
+        return requested.astype(np.int32)
+
+    scale = (float(max_cells) / float(requested_count)) ** (1.0 / 3.0)
+    bounded = np.maximum(np.floor(requested.astype(np.float64) * scale).astype(np.int64), 1)
+    while int(np.prod(bounded, dtype=np.int64)) > max_cells:
+        reducible = np.flatnonzero(bounded > 1)
+        if reducible.size == 0:
+            break
+        axis = int(reducible[np.argmax(bounded[reducible] / requested[reducible])])
+        bounded[axis] -= 1
+    return bounded.astype(np.int32)
+
+
+def _aabb_pruned_half_stencil(
+    cell_widths: np.ndarray,
+    *,
+    search_radius: float,
+) -> tuple[tuple[int, int, int], ...]:
+    """Return canonical cell offsets whose axis-aligned boxes can be in range."""
+
+    max_offsets = np.ceil(search_radius / cell_widths).astype(np.int32)
+    radius2 = float(search_radius) * float(search_radius)
+    tolerance = np.finfo(np.float64).eps * max(radius2, 1.0) * 16.0
+    offsets: list[tuple[int, int, int]] = []
+    for offset in product(
+        range(-int(max_offsets[0]), int(max_offsets[0]) + 1),
+        range(-int(max_offsets[1]), int(max_offsets[1]) + 1),
+        range(-int(max_offsets[2]), int(max_offsets[2]) + 1),
+    ):
+        if not _is_canonical_half_offset(offset):
+            continue
+        gap = np.maximum(np.abs(np.asarray(offset, dtype=np.float64)) - 1.0, 0.0)
+        minimum_distance2 = float(np.sum((gap * cell_widths) ** 2))
+        if minimum_distance2 <= radius2 + tolerance:
+            offsets.append(offset)
+    return tuple(offsets)
+
+
+def _is_canonical_half_offset(offset: tuple[int, int, int]) -> bool:
+    for component in offset:
+        if component:
+            return component > 0
+    return True
+
+
+def _spatial_task_batches(
+    task_candidate_counts: np.ndarray,
+    *,
+    candidate_batch: int,
+) -> tuple[tuple[int, int], ...]:
+    if task_candidate_counts.size == 0:
+        return ()
+    cumulative = np.cumsum(task_candidate_counts, dtype=np.int64)
+    batches: list[tuple[int, int]] = []
+    start = 0
+    prior = 0
+    while start < task_candidate_counts.shape[0]:
+        stop = int(np.searchsorted(cumulative, prior + candidate_batch, side="right"))
+        if stop <= start:
+            stop = start + 1
+        batches.append((start, stop))
+        prior = int(cumulative[stop - 1])
+        start = stop
+    return tuple(batches)
+
+
+def _build_mlx_cell_pair_list_cpu(
     positions_np: np.ndarray,
     cell: Cell,
     *,

--- a/tests/test_fused_lj_kernel.py
+++ b/tests/test_fused_lj_kernel.py
@@ -173,7 +173,122 @@ def test_neighbor_cutoff_mask_matches_mlx_and_preserves_compact_pair_order():
     } == {
         tuple(pair) for pair in np.asarray(oracle.pairs).tolist()
     }
-    assert first.compaction_backend == "metal_prefix_scan"
+    assert first.compaction_backend == "metal_spatial_prefix_scan"
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "case",
+    ["empty", "single", "periodic-boundary", "periodic-alias", "dense"],
+)
+def test_spatial_neighbor_pipeline_matches_cpu_oracle_for_edge_cases(case):
+    """Spatial Metal emission is exact, unique, and repeatable at edge cases."""
+
+    if case == "empty":
+        positions = np.empty((0, 3), dtype=np.float32)
+        cell = Cell.cubic(4.0)
+        cutoff = 0.8
+    elif case == "single":
+        positions = np.array([[0.2, 0.3, 0.4]], dtype=np.float32)
+        cell = Cell.cubic(4.0)
+        cutoff = 0.8
+    elif case == "periodic-boundary":
+        positions = np.array(
+            [[0.01, 1.0, 1.0], [3.99, 1.0, 1.0], [2.0, 2.0, 2.0]],
+            dtype=np.float32,
+        )
+        cell = Cell.cubic(4.0)
+        cutoff = 0.1
+    elif case == "periodic-alias":
+        positions = np.array(
+            [
+                [0.05, 0.05, 0.05],
+                [0.35, 0.05, 0.05],
+                [1.85, 0.05, 0.05],
+                [1.85, 1.85, 1.85],
+            ],
+            dtype=np.float32,
+        )
+        cell = Cell.cubic(2.0)
+        cutoff = 1.6
+    else:
+        rng = np.random.default_rng(91)
+        positions = rng.uniform(0.0, 0.4, size=(64, 3)).astype(np.float32)
+        cell = Cell.cubic(4.0)
+        cutoff = 0.3
+
+    oracle = build_neighbor_list(
+        positions,
+        cell,
+        cutoff=cutoff,
+        skin=0.0,
+        sort_pairs=True,
+        backend="periodic_cell_list",
+    )
+    first = build_neighbor_list(
+        positions,
+        cell,
+        cutoff=cutoff,
+        skin=0.0,
+        sort_pairs=False,
+        backend="mlx_cell_pairs",
+    )
+    second = build_neighbor_list(
+        positions,
+        cell,
+        cutoff=cutoff,
+        skin=0.0,
+        sort_pairs=False,
+        backend="mlx_cell_pairs",
+    )
+    sorted_pairs = build_neighbor_list(
+        positions,
+        cell,
+        cutoff=cutoff,
+        skin=0.0,
+        sort_pairs=True,
+        backend="mlx_cell_pairs",
+    )
+
+    expected = np.asarray(oracle.pairs)
+    observed = np.asarray(first.pairs)
+    assert np.array_equal(observed, np.asarray(second.pairs))
+    assert {tuple(pair) for pair in observed.tolist()} == {
+        tuple(pair) for pair in expected.tolist()
+    }
+    assert first.pair_count == len({tuple(pair) for pair in observed.tolist()})
+    assert np.array_equal(np.asarray(sorted_pairs.pairs), expected)
+    assert first.candidate_count is not None
+    assert first.candidate_count >= first.pair_count
+    assert first.compaction_backend == "metal_spatial_prefix_scan"
+
+
+@pytest.mark.gpu
+def test_spatial_neighbor_manager_releases_rebuild_cache_once(monkeypatch):
+    """A completed spatial rebuild releases inactive Metal buffers at the next update."""
+
+    positions, cell = fcc_lattice(256, density=0.8)
+    manager = NeighborListManager(
+        cell,
+        cutoff=2.5,
+        skin=0.4,
+        backend="mlx_cell_pairs",
+    )
+    clear_calls = 0
+    clear_cache = mx.clear_cache
+
+    def counted_clear_cache():
+        nonlocal clear_calls
+        clear_calls += 1
+        clear_cache()
+
+    monkeypatch.setattr(mx, "clear_cache", counted_clear_cache)
+    manager.update(positions)
+    assert clear_calls == 0
+    manager.update(positions)
+    assert clear_calls == 1
+    manager.update(positions)
+    assert clear_calls == 1
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Summary
- keep coordinates and compact neighbor pairs on MLX/Metal
- replace CPU candidate-array generation with a fine spatial grid, AABB-pruned canonical cell tasks, bounded Metal emission, and prefix-scan compaction
- release inactive rebuild buffers at the next safe update boundary so long runs remain memory-stable
- preserve the CPU implementation and public APIs

## Correctness
- exact CPU-oracle pair parity across random, empty, single-atom, periodic-boundary, periodic-alias, and dense cases
- deterministic unsorted ordering and canonical sorted ordering
- focused Metal topology and PME parity: 17 passed
- focused CPU neighbor/nonbonded suites: 65 passed
- required non-slow CPU CI lane passed locally under the 40 GB supervisor
- Ruff clean, API docs generated: 57 pages, diff check clean

## Bounded M5 Max result
| atoms | prior 750-step MLX | retained | reduction | OpenMM | remaining gap | peak process memory |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 23,558 | 12.6688 s | 8.7643 s | 30.8% | 0.6810 s | 12.9x | 1.76 GB |
| 47,116 | 20.5108 s | 13.9166 s | 32.1% | 1.0945 s | 12.7x | 2.76 GB |
| 94,232 | 40.4986 s | 24.3424 s | 39.9% | 1.6861 s | 14.4x | 4.80 GB |

At 94,232 atoms, emitted candidates fall from 468.3M to 184.1M, a 60.7% reduction. All retained runs are finite, below 40 GB, and pass the late-memory plateau check. The one-order-of-magnitude OpenMM stretch target is not yet met; the next likely lever is a tile/task force representation that avoids materializing and rescanning the full 60.5M-pair array.