### PR TITLE
Optimize spatial PME direct forces

### DIFF
--- a/docs/benchmarks/scalable-charged-pme-runtime-m5max.md
+++ b/docs/benchmarks/scalable-charged-pme-runtime-m5max.md
@@ -199,6 +199,37 @@ The older **[runtime]** row correctly retains `openmm_ratio: null` because its
 original artifact predates this stronger manifest; historical evidence is not
 rewritten retroactively.
 
+## Spatial-direct development update
+
+A later bounded pass changed the recurring Metal work layout without changing
+the admitted workload or physics. It builds exact-cutoff 8x8 tiles from
+spatially sorted atom blocks, groups up to four tiles sharing a left block, and
+reuses that block while locally reducing force writes. A second kernel fuses
+sparse PME exclusions, Coulomb exceptions, 1-4 corrections, and LJ exceptions
+into one force buffer.
+
+| Development check | Existing route | Spatial/fused route | Change |
+| --- | ---: | ---: | ---: |
+| Direct-space force | 5.52227 ms | 3.79931 ms | 31.20% lower |
+| Sparse PME corrections | 0.568062 ms | 0.262083 ms | 53.86% lower |
+| Complete 75-step trajectory, median | 0.933094 s | 0.601954 s | 35.49% lower |
+
+The tile inventory reproduced all 60,502,167 compact pairs. Direct-force error
+was `6.32e-5 kJ/mol/A` RMS and `6.71e-4 kJ/mol/A` maximum; correction-force
+error was `4.68e-5 kJ/mol/A` RMS and `3.05e-4 kJ/mol/A` maximum. The complete
+run stayed finite, ended below a `3.51e-5 A` maximum constraint residual, and
+peaked at 5.69 GB across the process tree with a passing late-memory plateau
+check. The dual development representation reports 578 MB of persistent tile,
+topology-mask, and diagnostic-pair state; admitted tiles no longer allocate the
+additional per-pair LJ-scale array.
+
+This is development evidence, not a replacement for the manifest-bound
+1.003149-second MLX result or its `9.7586x` OpenMM ratio above. The bounded gate
+used the position-balanced order pairs, tiles, tiles, pairs; pair samples were
+1.045140 and 0.821048 seconds, while tile samples were 0.577860 and 0.626048
+seconds. This clears the 0.85-second development target, but no new cross-engine
+ratio is claimed without a fresh manifest-bound OpenMM comparison.
+
 ## Reproduce
 
 ```bash

--- a/docs/md-acceleration.md
+++ b/docs/md-acceleration.md
@@ -27,29 +27,36 @@ existing force, constraint, and restart validation gates.
 - `mlx_cell_blocks` keeps the periodic cell/bin candidate search in a
   fixed-shape block representation. It remains available for fixed-shape
   consumers and historical benchmark reproduction.
+- `mlx_cell_tiles` spatially sorts atoms into eight-atom blocks, retains exact
+  cutoff-plus-skin membership masks over non-empty 8x8 tiles, and groups tiles
+  sharing a left block for the prepared orthorhombic PME force route. It keeps
+  compact pairs as a diagnostic oracle during this development stage.
 - `python_neighbor` means the Python/NumPy cell-list builder is included in the
   benchmark before MLX pair evaluation.
 - `auto` uses dense MLX when no pair list is supplied and the dense memory
   estimate fits the configured budget; otherwise it falls back to tiled MLX.
   For neighbor-list managers, `auto` selects `mlx_dense_pairs` for supported
   small systems and `mlx_cell_pairs` above the small-system limit. The
-  production PME runner explicitly selects `mlx_cell_pairs`.
+  charged-PME performance runner explicitly selects `mlx_cell_tiles`; general
+  neighbor managers retain the established pair-oriented `auto` behavior.
 
 ## Current Hot-Path Recommendation
 
 Measure with `python -m mlx_atomistic.benchmarks.md_acceleration --json` before
 changing a force path. The large-system neighbor emitter and recurring direct
-force path are now Metal-native. Production remains on compact explicit pairs.
-The first exact 8x8 atom-tile implementation was parity-correct but slower end
-to end and has been removed; it is evidence for a different future layout, not
-an alternate production backend.
+force path are now Metal-native. The first canonical-ID 8x8 atom-tile
+implementation was parity-correct but slower end to end and was removed. The
+later retained route instead creates blocks from spatial order and groups
+same-left tiles, while preserving canonical atom indices at force scatter.
 
 The current production path also uses specialized rigid-water/constraint
-kernels and one fused standard-bonded force dispatch. The next candidate is a
-spatially coherent direct-force layout that avoids both the global compact-pair
-scan and the rejected 8x8 tile route's padded-lane expansion. Further neighbor
-rebuild work is lower priority unless a fresh profile moves it above direct
-force evaluation.
+kernels and one fused standard-bonded force dispatch. The charged-PME
+development runner now selects spatial tiles inside its narrow supported
+envelope and fails its profile gate on a compact-pair fallback. General
+large-system execution remains pair-oriented until the tile envelope is
+broadened deliberately. The next performance work should reduce remaining
+direct atomics and host-controlled rebuild work rather than add another wrapper
+around the same 8x8 schedule.
 
 For GPCRmd-scale periodic systems, dense all-pairs is not viable. The current
 large-system route uses `mlx_cell_pairs`. The historical implementation used
@@ -182,14 +189,59 @@ A synchronized post-constraint profile assigned 35.91% of wall time to direct
 LJ plus screened Coulomb, 14.48% to the then-unfused bonded terms, 12.12% to
 neighbor update/rebuild, 8.53% to constraints, 7.36% to force aggregation,
 6.16% to diagnostics, 6.06% to reciprocal PME, and 4.34% to PME corrections.
-The fused bonded route addresses the second item. Direct nonbonded work is now
-the clear next target, but it needs a better work layout rather than another
-padded tile wrapper or more Python-loop cleanup.
+The fused bonded route addressed the second item. The next pass therefore
+changed the direct-space work layout instead of adding another Python-loop
+cleanup.
+
+### Retained spatial-direct increment
+
+The retained 2026-08-01 development candidate is structurally different from
+the rejected atom-tile experiment below. It builds spatially sorted eight-atom
+blocks, evaluates exact cutoff membership for each 8x8 block pair on Metal,
+and compacts only accepted tiles. Accepted tiles are sorted by their left block
+and scheduled in groups of up to four, allowing one threadgroup to reuse the
+left atom coordinates and parameters and to reduce its atomic force writes.
+Small cell-count and task metadata still cross the host boundary during a
+rebuild. The existing exact compact-pair inventory remains the correctness
+oracle.
+
+The same pass combines sparse PME exclusions, Coulomb exceptions, 1-4 terms,
+and LJ exceptions into one Metal force buffer. This is a force-only production
+optimization; diagnostic energy and component paths remain independently
+observable.
+
+| Bounded development check | Before | Retained candidate | Change |
+| --- | ---: | ---: | ---: |
+| Isolated direct-space force | 5.52227 ms | 3.79931 ms | 31.20% lower |
+| Sparse PME correction force | 0.568062 ms | 0.262083 ms | 53.86% lower |
+| Complete 75-step trajectory, median | 0.933094 s | 0.601954 s | 35.49% lower |
+
+The spatial inventory contains 60,502,167 exact pairs in 2,751,445 tiles, or
+176,092,480 padded lanes with 34.36% occupancy. Direct-force agreement with the
+compact-pair route was `6.32e-5 kJ/mol/A` RMS and `6.71e-4 kJ/mol/A` maximum;
+the fused correction comparison was `4.68e-5 kJ/mol/A` RMS and
+`3.05e-4 kJ/mol/A` maximum. The complete trajectory remained finite, reused
+its PME plan, ended below a `3.51e-5 A` maximum constraint residual, and peaked
+at 5.69 GB across the process tree with a passing late-memory plateau check.
+The current development representation intentionally retains the 484 MB exact
+pair array as a diagnostic oracle; tile geometry, topology masks, and that
+oracle total about 578 MB of persistent indexed state. Per-pair LJ scales are
+no longer constructed for an admitted tile route.
+
+The complete gate used the position-balanced order pairs, tiles, tiles, pairs.
+The pair samples were 1.045140 and 0.821048 seconds; the tile samples were
+0.577860 and 0.626048 seconds. This clears the 0.85-second development target,
+but the candidate does not replace the existing manifest-bound 1.003149-second
+MLX result or establish a new OpenMM ratio. The main remaining costs are
+direct-space work, neighbor update/rebuild, constraints, reciprocal PME, force
+aggregation, and Python-side launch orchestration.
 
 ### Rejected atom-tile result
 
-The 2026-07-31 atom-tile experiment tested the full route instead of assuming
-that a faster kernel would make the trajectory faster. Its isolated 8x8 Metal
+The 2026-07-31 canonical-ID atom-tile experiment tested the full route instead
+of assuming that a faster kernel would make the trajectory faster. Its tiles
+were derived from the compact-pair list, unlike the retained spatially built
+route above. Its isolated 8x8 Metal
 kernel reduced median direct-force latency from 0.005548 to 0.004257 seconds,
 a 30.33% win, and matched the explicit-pair force within the established
 float32 tolerance. Initial integration lost badly because tile construction
@@ -210,9 +262,9 @@ competitive.
 The conditional repeat and 750-step proof were not run because the first exact
 comparison was decisive and projected about 29.6 seconds for 750 steps, above
 both the retained complete result and the 16.8615-second stretch target. The
-tile kernel, production routing, experimental selector, and candidate-only
-metadata were removed. Exact compact-pair ownership remains as the verified
-production foundation.
+candidate tile kernel, production routing, experimental selector, and metadata
+were removed. Exact compact-pair ownership remains the verified correctness
+foundation for the later spatial route.
 
 A fresh synthetic orthorhombic parity ladder now validates this route at
 1k/4k/16k/50k/92,001 atoms against the tiled all-pairs MLX oracle. At 92,001

--- a/site/src/content/docs/benchmarks/scalable-charged-pme-runtime-m5max.md
+++ b/site/src/content/docs/benchmarks/scalable-charged-pme-runtime-m5max.md
@@ -202,6 +202,37 @@ The older **[runtime]** row correctly retains `openmm_ratio: null` because its
 original artifact predates this stronger manifest; historical evidence is not
 rewritten retroactively.
 
+## Spatial-direct development update
+
+A later bounded pass changed the recurring Metal work layout without changing
+the admitted workload or physics. It builds exact-cutoff 8x8 tiles from
+spatially sorted atom blocks, groups up to four tiles sharing a left block, and
+reuses that block while locally reducing force writes. A second kernel fuses
+sparse PME exclusions, Coulomb exceptions, 1-4 corrections, and LJ exceptions
+into one force buffer.
+
+| Development check | Existing route | Spatial/fused route | Change |
+| --- | ---: | ---: | ---: |
+| Direct-space force | 5.52227 ms | 3.79931 ms | 31.20% lower |
+| Sparse PME corrections | 0.568062 ms | 0.262083 ms | 53.86% lower |
+| Complete 75-step trajectory, median | 0.933094 s | 0.601954 s | 35.49% lower |
+
+The tile inventory reproduced all 60,502,167 compact pairs. Direct-force error
+was `6.32e-5 kJ/mol/A` RMS and `6.71e-4 kJ/mol/A` maximum; correction-force
+error was `4.68e-5 kJ/mol/A` RMS and `3.05e-4 kJ/mol/A` maximum. The complete
+run stayed finite, ended below a `3.51e-5 A` maximum constraint residual, and
+peaked at 5.69 GB across the process tree with a passing late-memory plateau
+check. The dual development representation reports 578 MB of persistent tile,
+topology-mask, and diagnostic-pair state; admitted tiles no longer allocate the
+additional per-pair LJ-scale array.
+
+This is development evidence, not a replacement for the manifest-bound
+1.003149-second MLX result or its `9.7586x` OpenMM ratio above. The bounded gate
+used the position-balanced order pairs, tiles, tiles, pairs; pair samples were
+1.045140 and 0.821048 seconds, while tile samples were 0.577860 and 0.626048
+seconds. This clears the 0.85-second development target, but no new cross-engine
+ratio is claimed without a fresh manifest-bound OpenMM comparison.
+
 ## Reproduce
 
 ```bash

--- a/site/src/content/docs/mm/md-acceleration.md
+++ b/site/src/content/docs/mm/md-acceleration.md
@@ -30,29 +30,36 @@ existing force, constraint, and restart validation gates.
 - `mlx_cell_blocks` keeps the periodic cell/bin candidate search in a
   fixed-shape block representation. It remains available for fixed-shape
   consumers and historical benchmark reproduction.
+- `mlx_cell_tiles` spatially sorts atoms into eight-atom blocks, retains exact
+  cutoff-plus-skin membership masks over non-empty 8x8 tiles, and groups tiles
+  sharing a left block for the prepared orthorhombic PME force route. It keeps
+  compact pairs as a diagnostic oracle during this development stage.
 - `python_neighbor` means the Python/NumPy cell-list builder is included in the
   benchmark before MLX pair evaluation.
 - `auto` uses dense MLX when no pair list is supplied and the dense memory
   estimate fits the configured budget; otherwise it falls back to tiled MLX.
   For neighbor-list managers, `auto` selects `mlx_dense_pairs` for supported
   small systems and `mlx_cell_pairs` above the small-system limit. The
-  production PME runner explicitly selects `mlx_cell_pairs`.
+  charged-PME performance runner explicitly selects `mlx_cell_tiles`; general
+  neighbor managers retain the established pair-oriented `auto` behavior.
 
 ## Current Hot-Path Recommendation
 
 Measure with `python -m mlx_atomistic.benchmarks.md_acceleration --json` before
 changing a force path. The large-system neighbor emitter and recurring direct
-force path are now Metal-native. Production remains on compact explicit pairs.
-The first exact 8x8 atom-tile implementation was parity-correct but slower end
-to end and has been removed; it is evidence for a different future layout, not
-an alternate production backend.
+force path are now Metal-native. The first canonical-ID 8x8 atom-tile
+implementation was parity-correct but slower end to end and was removed. The
+later retained route instead creates blocks from spatial order and groups
+same-left tiles, while preserving canonical atom indices at force scatter.
 
 The current production path also uses specialized rigid-water/constraint
-kernels and one fused standard-bonded force dispatch. The next candidate is a
-spatially coherent direct-force layout that avoids both the global compact-pair
-scan and the rejected 8x8 tile route's padded-lane expansion. Further neighbor
-rebuild work is lower priority unless a fresh profile moves it above direct
-force evaluation.
+kernels and one fused standard-bonded force dispatch. The charged-PME
+development runner now selects spatial tiles inside its narrow supported
+envelope and fails its profile gate on a compact-pair fallback. General
+large-system execution remains pair-oriented until the tile envelope is
+broadened deliberately. The next performance work should reduce remaining
+direct atomics and host-controlled rebuild work rather than add another wrapper
+around the same 8x8 schedule.
 
 For GPCRmd-scale periodic systems, dense all-pairs is not viable. The current
 large-system route uses `mlx_cell_pairs`. The historical implementation used
@@ -185,14 +192,59 @@ A synchronized post-constraint profile assigned 35.91% of wall time to direct
 LJ plus screened Coulomb, 14.48% to the then-unfused bonded terms, 12.12% to
 neighbor update/rebuild, 8.53% to constraints, 7.36% to force aggregation,
 6.16% to diagnostics, 6.06% to reciprocal PME, and 4.34% to PME corrections.
-The fused bonded route addresses the second item. Direct nonbonded work is now
-the clear next target, but it needs a better work layout rather than another
-padded tile wrapper or more Python-loop cleanup.
+The fused bonded route addressed the second item. The next pass therefore
+changed the direct-space work layout instead of adding another Python-loop
+cleanup.
+
+### Retained spatial-direct increment
+
+The retained 2026-08-01 development candidate is structurally different from
+the rejected atom-tile experiment below. It builds spatially sorted eight-atom
+blocks, evaluates exact cutoff membership for each 8x8 block pair on Metal,
+and compacts only accepted tiles. Accepted tiles are sorted by their left block
+and scheduled in groups of up to four, allowing one threadgroup to reuse the
+left atom coordinates and parameters and to reduce its atomic force writes.
+Small cell-count and task metadata still cross the host boundary during a
+rebuild. The existing exact compact-pair inventory remains the correctness
+oracle.
+
+The same pass combines sparse PME exclusions, Coulomb exceptions, 1-4 terms,
+and LJ exceptions into one Metal force buffer. This is a force-only production
+optimization; diagnostic energy and component paths remain independently
+observable.
+
+| Bounded development check | Before | Retained candidate | Change |
+| --- | ---: | ---: | ---: |
+| Isolated direct-space force | 5.52227 ms | 3.79931 ms | 31.20% lower |
+| Sparse PME correction force | 0.568062 ms | 0.262083 ms | 53.86% lower |
+| Complete 75-step trajectory, median | 0.933094 s | 0.601954 s | 35.49% lower |
+
+The spatial inventory contains 60,502,167 exact pairs in 2,751,445 tiles, or
+176,092,480 padded lanes with 34.36% occupancy. Direct-force agreement with the
+compact-pair route was `6.32e-5 kJ/mol/A` RMS and `6.71e-4 kJ/mol/A` maximum;
+the fused correction comparison was `4.68e-5 kJ/mol/A` RMS and
+`3.05e-4 kJ/mol/A` maximum. The complete trajectory remained finite, reused
+its PME plan, ended below a `3.51e-5 A` maximum constraint residual, and peaked
+at 5.69 GB across the process tree with a passing late-memory plateau check.
+The current development representation intentionally retains the 484 MB exact
+pair array as a diagnostic oracle; tile geometry, topology masks, and that
+oracle total about 578 MB of persistent indexed state. Per-pair LJ scales are
+no longer constructed for an admitted tile route.
+
+The complete gate used the position-balanced order pairs, tiles, tiles, pairs.
+The pair samples were 1.045140 and 0.821048 seconds; the tile samples were
+0.577860 and 0.626048 seconds. This clears the 0.85-second development target,
+but the candidate does not replace the existing manifest-bound 1.003149-second
+MLX result or establish a new OpenMM ratio. The main remaining costs are
+direct-space work, neighbor update/rebuild, constraints, reciprocal PME, force
+aggregation, and Python-side launch orchestration.
 
 ### Rejected atom-tile result
 
-The 2026-07-31 atom-tile experiment tested the full route instead of assuming
-that a faster kernel would make the trajectory faster. Its isolated 8x8 Metal
+The 2026-07-31 canonical-ID atom-tile experiment tested the full route instead
+of assuming that a faster kernel would make the trajectory faster. Its tiles
+were derived from the compact-pair list, unlike the retained spatially built
+route above. Its isolated 8x8 Metal
 kernel reduced median direct-force latency from 0.005548 to 0.004257 seconds,
 a 30.33% win, and matched the explicit-pair force within the established
 float32 tolerance. Initial integration lost badly because tile construction
@@ -213,9 +265,9 @@ competitive.
 The conditional repeat and 750-step proof were not run because the first exact
 comparison was decisive and projected about 29.6 seconds for 750 steps, above
 both the retained complete result and the 16.8615-second stretch target. The
-tile kernel, production routing, experimental selector, and candidate-only
-metadata were removed. Exact compact-pair ownership remains as the verified
-production foundation.
+candidate tile kernel, production routing, experimental selector, and metadata
+were removed. Exact compact-pair ownership remains the verified correctness
+foundation for the later spatial route.
 
 A fresh synthetic orthorhombic parity ladder now validates this route at
 1k/4k/16k/50k/92,001 atoms against the tiled all-pairs MLX oracle. At 92,001

--- a/src/mlx_atomistic/benchmarks/charged_pme.py
+++ b/src/mlx_atomistic/benchmarks/charged_pme.py
@@ -33,6 +33,14 @@ PROFILE_SCHEMA = "mlx_atomistic.charged_pme_profile.v1"
 OPENMM_ADMISSION_SCHEMA = "mlx_atomistic.openmm_runtime_admission.v1"
 _PROFILE_STATE_RTOL = 5.0e-5
 _PROFILE_STATE_ATOL = 1.0e-5
+_PROCESS_MEMORY_LIMIT_BYTES = 40_000_000_000
+_SPATIAL_DIRECT_MIN_COMPLETE_SPEEDUP = 0.15
+# The isolated direct-force median varies by several percentage points under
+# low-power Metal. Keep this as a bounded smell gate; the position-balanced
+# complete-wall A/B below is the authoritative retention gate.
+_SPATIAL_DIRECT_MIN_KERNEL_SPEEDUP = 0.25
+_SPARSE_CORRECTION_MIN_SPEEDUP = 0.20
+_RUNTIME_NEIGHBOR_BACKENDS = frozenset({"mlx_cell_pairs", "mlx_cell_tiles"})
 
 
 def _constraint_route_inventory(
@@ -204,6 +212,7 @@ def runtime_payload(
     sample_interval: int | None = None,
     diagnostic_interval: int | None = None,
     runtime_profile: bool = False,
+    neighbor_backend: str = "mlx_cell_tiles",
 ) -> dict[str, Any]:
     """Run bounded fixed-cell charged-PME NVT with one reusable plan.
 
@@ -224,6 +233,8 @@ def runtime_payload(
             only the final step. Defaults to ``None``.
         runtime_profile: Enable synchronized benchmark-only route attribution.
             Defaults to ``False``.
+        neighbor_backend: Exact spatial tile candidate or compact-pair control.
+            Defaults to ``mlx_cell_tiles``.
 
     Returns:
         JSON-serializable passing, failed, blocked, or resource-ceiling payload.
@@ -249,6 +260,8 @@ def runtime_payload(
         "sample_interval": sample_interval,
         "diagnostic_interval": diagnostic_interval,
         "runtime_profile": bool(runtime_profile),
+        "neighbor_backend": str(neighbor_backend),
+        "process_memory_limit_bytes": _PROCESS_MEMORY_LIMIT_BYTES,
         "status": "blocked",
         "passed": False,
         "blockers": [],
@@ -272,6 +285,8 @@ def runtime_payload(
         validation_blockers.append("sample_interval_must_be_positive")
     if diagnostic_interval <= 0:
         validation_blockers.append("diagnostic_interval_must_be_positive")
+    if neighbor_backend not in _RUNTIME_NEIGHBOR_BACKENDS:
+        validation_blockers.append("neighbor_backend_must_be_pairs_or_tiles")
     required = (prepared_path / JSON_NAME, prepared_path / NPZ_NAME)
     validation_blockers.extend(
         f"missing_prepared_input:{path}" for path in required if not path.is_file()
@@ -303,7 +318,7 @@ def runtime_payload(
             skin=neighbor_skin,
             check_interval=neighbor_check_interval,
             sort_pairs=False,
-            backend="mlx_cell_pairs",
+            backend=neighbor_backend,
             displacement_check_backend="mlx_scalar",
         )
         setup_seconds = time.perf_counter() - setup_started
@@ -432,6 +447,18 @@ def runtime_payload(
             ),
         }
         final_plan = plan.to_dict()
+        process_peak_bytes = int(max_rss_mb() * 1024.0 * 1024.0)
+        memory = {
+            "max_rss_mb": process_peak_bytes / (1024.0 * 1024.0),
+            "process_peak_bytes": process_peak_bytes,
+            "process_memory_limit_bytes": _PROCESS_MEMORY_LIMIT_BYTES,
+            "mlx_active_memory_bytes": _mlx_memory_value("get_active_memory"),
+            "mlx_peak_memory_bytes": _mlx_memory_value("get_peak_memory"),
+            "mlx_cache_memory_bytes": _mlx_memory_value("get_cache_memory"),
+        }
+        expected_representation = (
+            "tiles" if neighbor_backend == "mlx_cell_tiles" else "pairs"
+        )
         checks = {
             "warmup_completed": warmups >= 1,
             "measured_steps_completed": steps >= 2,
@@ -453,23 +480,41 @@ def runtime_payload(
             "performance_eligible_constraint_routes": constraint_routes[
                 "performance_eligible"
             ],
-            "compact_neighbor_pairs": (
-                neighbor_report["manager_backend"] == "mlx_cell_pairs"
-                and neighbor_report["representation"] == "pairs"
+            "expected_neighbor_representation": (
+                neighbor_report["manager_backend"] == neighbor_backend
+                and neighbor_report["representation"] == expected_representation
             ),
             "no_neighbor_fallback": neighbor_report["fallback_reason"] is None,
             "positive_throughput": math.isfinite(ns_per_day) and ns_per_day > 0.0,
+            "process_memory_within_limit": (
+                process_peak_bytes <= _PROCESS_MEMORY_LIMIT_BYTES
+            ),
+            "mlx_peak_memory_within_limit": (
+                isinstance(memory["mlx_peak_memory_bytes"], int)
+                and memory["mlx_peak_memory_bytes"] <= _PROCESS_MEMORY_LIMIT_BYTES
+            ),
         }
         if runtime_profile:
             route_profile = measured_result.route_profile
             routes = route_profile.get("routes", {})
+            expected_direct_route = (
+                "direct_spatial_tiles"
+                if neighbor_backend == "mlx_cell_tiles"
+                else "direct_lj_screened_coulomb"
+            )
+            unexpected_direct_route = (
+                "direct_lj_screened_coulomb"
+                if neighbor_backend == "mlx_cell_tiles"
+                else "direct_spatial_tiles"
+            )
             checks.update(
                 {
                     "route_profile_reconciled": bool(
                         route_profile.get("reconciled", False)
                     ),
-                    "route_profile_direct": (
-                        "direct_lj_screened_coulomb" in routes
+                    "route_profile_expected_direct": expected_direct_route in routes,
+                    "route_profile_no_direct_fallback": (
+                        unexpected_direct_route not in routes
                     ),
                     "route_profile_reciprocal": "reciprocal_pme" in routes,
                     "route_profile_neighbor": "neighbor_update_rebuild" in routes,
@@ -512,12 +557,7 @@ def runtime_payload(
                 "openmm_ratio": None,
                 "comparison_status": "not_reported_without_matching_runtime_manifest",
             },
-            "memory": {
-                "max_rss_mb": max_rss_mb(),
-                "mlx_active_memory_bytes": _mlx_memory_value("get_active_memory"),
-                "mlx_peak_memory_bytes": _mlx_memory_value("get_peak_memory"),
-                "mlx_cache_memory_bytes": _mlx_memory_value("get_cache_memory"),
-            },
+            "memory": memory,
             "state": {
                 "potential_energy_kj_mol": _last_float(
                     measured_result.potential_energy
@@ -700,7 +740,8 @@ def _profile_tile_inventory(
     )
     if system.cell is None:
         raise ValueError("tile inventory requires a periodic cell")
-    nonbonded = _find_pme_term(tuple(force_terms))
+    bound_terms = _bind_pme_plans(force_terms, system.cell)
+    nonbonded = _find_pme_term(bound_terms)
     tile_manager = NeighborListManager(
         system.cell,
         cutoff=float(nonbonded.cutoff),
@@ -714,7 +755,13 @@ def _profile_tile_inventory(
     tiles = neighbor_list.tiles
     if tiles is None:
         raise RuntimeError("mlx_cell_tiles did not produce NeighborTiles")
-    mx.eval(tiles.atom_blocks, tiles.tile_blocks, tiles.member_mask)
+    mx.eval(
+        tiles.atom_blocks,
+        tiles.tile_blocks,
+        tiles.member_mask,
+        tiles.force_group_starts,
+        tiles.force_group_counts,
+    )
     pair_manager = NeighborListManager(
         system.cell,
         cutoff=float(nonbonded.cutoff),
@@ -724,15 +771,123 @@ def _profile_tile_inventory(
         backend="mlx_cell_pairs",
         displacement_check_backend="mlx_scalar",
     )
-    reference_pairs = pair_manager.update(system.positions).pairs
+    pair_neighbors = pair_manager.update(system.positions)
+    reference_pairs = pair_neighbors.pairs
     if reference_pairs is None:
         raise RuntimeError("mlx_cell_pairs did not produce compact pairs")
     reference_pair_count = int(reference_pairs.shape[0])
+    tile_binding = nonbonded._prepare_tile_force_binding(
+        system.cell,
+        neighbor_list.diagnostic_pairs,
+        tiles,
+    )
+    pair_binding = nonbonded._prepare_force_binding(
+        system.cell,
+        pair_neighbors.diagnostic_pairs,
+    )
+    if tile_binding is NotImplemented or pair_binding is NotImplemented:
+        raise RuntimeError("JAC direct-force bindings were not admitted")
+    if tile_binding.tile_decline_reason is not None:
+        raise RuntimeError(
+            f"spatial tile force route declined: {tile_binding.tile_decline_reason}"
+        )
+    tile_forces = nonbonded._direct_forces_from_binding(
+        system.positions,
+        tile_binding,
+    )
+    pair_forces = nonbonded._direct_forces_from_binding(
+        system.positions,
+        pair_binding,
+    )
+    mx.eval(tile_forces, pair_forces)
+    force_delta = np.asarray(tile_forces) - np.asarray(pair_forces)
+    force_rms_delta = float(np.sqrt(np.mean(force_delta * force_delta)))
+    force_max_delta = float(np.max(np.abs(force_delta)))
+    force_max_reference = float(np.max(np.abs(np.asarray(pair_forces))))
+
+    reference_corrections = nonbonded._exception_lj_forces(
+        system.positions,
+        system.cell,
+    ) + nonbonded._periodic_coulomb_correction_forces(
+        system.positions,
+        system.cell,
+    )
+    fused_corrections = nonbonded._prepared_sparse_correction_forces(
+        system.positions,
+        tile_binding,
+    )
+    mx.eval(reference_corrections, fused_corrections)
+    correction_delta = np.asarray(fused_corrections) - np.asarray(reference_corrections)
+    correction_rms_delta = float(np.sqrt(np.mean(correction_delta * correction_delta)))
+    correction_max_delta = float(np.max(np.abs(correction_delta)))
+
+    def interleaved_medians(reference_call, candidate_call) -> tuple[float, float]:
+        calls = {"reference": reference_call, "candidate": candidate_call}
+        for _ in range(2):
+            for call in calls.values():
+                value = call()
+                mx.eval(value)
+        samples = {"reference": [], "candidate": []}
+        for sample in range(6):
+            ordered = (
+                ("reference", "candidate")
+                if sample % 2 == 0
+                else ("candidate", "reference")
+            )
+            for name in ordered:
+                started = time.perf_counter()
+                value = calls[name]()
+                mx.eval(value)
+                samples[name].append(time.perf_counter() - started)
+        return (
+            float(np.median(samples["reference"])),
+            float(np.median(samples["candidate"])),
+        )
+
+    pair_direct_seconds, tile_direct_seconds = interleaved_medians(
+        lambda: nonbonded._direct_forces_from_binding(system.positions, pair_binding),
+        lambda: nonbonded._direct_forces_from_binding(system.positions, tile_binding),
+    )
+    reference_correction_seconds, fused_correction_seconds = interleaved_medians(
+        lambda: nonbonded._exception_lj_forces(
+            system.positions,
+            system.cell,
+        )
+        + nonbonded._periodic_coulomb_correction_forces(
+            system.positions,
+            system.cell,
+        ),
+        lambda: nonbonded._prepared_sparse_correction_forces(
+            system.positions,
+            tile_binding,
+        ),
+    )
+    diagnostic_pair_bytes = int(neighbor_list.diagnostic_pairs.size) * 4
+    tile_topology_bytes = sum(
+        int(values.size) * 4
+        for values in (
+            tile_binding.tile_lj_enabled_mask,
+            tile_binding.tile_lj_one_four_mask,
+        )
+        if values is not None
+    )
+    pair_scale_bytes = (
+        0
+        if tile_binding.aligned_lj_scales is None
+        else int(tile_binding.aligned_lj_scales.size) * 4
+    )
+    persistent_breakdown = {
+        "tile_geometry_bytes": tiles.estimated_bytes,
+        "diagnostic_pair_bytes": diagnostic_pair_bytes,
+        "tile_topology_mask_bytes": tile_topology_bytes,
+        "pair_scale_bytes": pair_scale_bytes,
+    }
     return {
         "backend": tile_manager.backend,
         "block_size": tiles.block_size,
         "block_count": tiles.block_count,
         "tile_count": tiles.tile_count,
+        "force_group_count": tiles.force_group_count,
         "exact_pair_count": tiles.exact_pair_count,
         "reference_pair_count": reference_pair_count,
         "pair_inventory_matches": tiles.exact_pair_count == reference_pair_count,
@@ -740,7 +895,32 @@ def _profile_tile_inventory(
         "padded_lane_count": tiles.padded_lane_count,
         "padding_waste_count": tiles.padding_waste_count,
         "padding_waste_fraction": tiles.padding_waste_fraction,
-        "estimated_persistent_bytes": tiles.estimated_bytes,
+        "estimated_persistent_bytes": sum(persistent_breakdown.values()),
+        "estimated_persistent_bytes_breakdown": persistent_breakdown,
+        "active_lane_fraction": (
+            0.0
+            if tiles.padded_lane_count == 0
+            else tiles.exact_pair_count / tiles.padded_lane_count
+        ),
+        "force_rms_delta_kj_mol_angstrom": force_rms_delta,
+        "force_max_delta_kj_mol_angstrom": force_max_delta,
+        "force_max_reference_kj_mol_angstrom": force_max_reference,
+        "correction_force_rms_delta_kj_mol_angstrom": correction_rms_delta,
+        "correction_force_max_delta_kj_mol_angstrom": correction_max_delta,
+        "reference_correction_median_seconds": reference_correction_seconds,
+        "fused_correction_median_seconds": fused_correction_seconds,
+        "correction_speedup_fraction": (
+            0.0
+            if reference_correction_seconds <= 0.0
+            else 1.0 - fused_correction_seconds / reference_correction_seconds
+        ),
+        "pair_direct_median_seconds": pair_direct_seconds,
+        "tile_direct_median_seconds": tile_direct_seconds,
+        "direct_speedup_fraction": (
+            0.0
+            if pair_direct_seconds <= 0.0
+            else 1.0 - tile_direct_seconds / pair_direct_seconds
+        ),
         "rebuild_wall_seconds": tile_manager.rebuild_wall_seconds,
         "update_wall_seconds": tile_manager.update_wall_seconds,
         "reference_pair_rebuild_wall_seconds": pair_manager.rebuild_wall_seconds,
@@ -762,7 +942,7 @@ def profile_payload(
     openmm_manifest: str | Path | None = None,
     manifest_comparison: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Run one clean and one synchronized charged-PME route profile.
+    """Run a matched pair/tile A/B and synchronized charged-PME route profile.
 
     Args:
         prepared: Strict production prepared-system directory.
@@ -779,12 +959,16 @@ def profile_payload(
         manifest_comparison: Optional persisted manifest comparison override.
 
     Returns:
-        Combined clean, instrumented, tile-inventory, and admission evidence.
+        Combined position-balanced pair/tile controls, instrumented tile,
+        tile-inventory, and admission evidence.
     """
 
     prepared_path = Path(prepared)
     out_path = Path(out)
+    pair_before_path = out_path.parent / "pair-control-before.json"
     clean_path = out_path.parent / "clean.json"
+    clean_repeat_path = out_path.parent / "clean-repeat.json"
+    pair_after_path = out_path.parent / "pair-control-after.json"
     instrumented_path = out_path.parent / "instrumented.json"
     admission_path = out_path.parent / "openmm-admission.json"
     default_runtime, default_manifest, default_comparison = (
@@ -802,6 +986,19 @@ def profile_payload(
         ),
         out=admission_path,
     )
+    pair_control_before = runtime_payload(
+        prepared=prepared_path,
+        warmups=warmups,
+        steps=steps,
+        out=pair_before_path,
+        dt_ps=dt_ps,
+        temperature_k=temperature_k,
+        seed=seed,
+        neighbor_skin=neighbor_skin,
+        neighbor_check_interval=neighbor_check_interval,
+        runtime_profile=False,
+        neighbor_backend="mlx_cell_pairs",
+    )
     clean = runtime_payload(
         prepared=prepared_path,
         warmups=warmups,
@@ -813,6 +1010,33 @@ def profile_payload(
         neighbor_skin=neighbor_skin,
         neighbor_check_interval=neighbor_check_interval,
         runtime_profile=False,
+        neighbor_backend="mlx_cell_tiles",
+    )
+    clean_repeat = runtime_payload(
+        prepared=prepared_path,
+        warmups=warmups,
+        steps=steps,
+        out=clean_repeat_path,
+        dt_ps=dt_ps,
+        temperature_k=temperature_k,
+        seed=seed,
+        neighbor_skin=neighbor_skin,
+        neighbor_check_interval=neighbor_check_interval,
+        runtime_profile=False,
+        neighbor_backend="mlx_cell_tiles",
+    )
+    pair_control_after = runtime_payload(
+        prepared=prepared_path,
+        warmups=warmups,
+        steps=steps,
+        out=pair_after_path,
+        dt_ps=dt_ps,
+        temperature_k=temperature_k,
+        seed=seed,
+        neighbor_skin=neighbor_skin,
+        neighbor_check_interval=neighbor_check_interval,
+        runtime_profile=False,
+        neighbor_backend="mlx_cell_pairs",
     )
     instrumented = runtime_payload(
         prepared=prepared_path,
@@ -825,10 +1049,17 @@ def profile_payload(
         neighbor_skin=neighbor_skin,
         neighbor_check_interval=neighbor_check_interval,
         runtime_profile=True,
+        neighbor_backend="mlx_cell_tiles",
     )
     tile_inventory: dict[str, Any] | None = None
     inventory_blocker = None
-    if clean.get("passed") and instrumented.get("passed"):
+    if (
+        pair_control_before.get("passed")
+        and clean.get("passed")
+        and clean_repeat.get("passed")
+        and pair_control_after.get("passed")
+        and instrumented.get("passed")
+    ):
         try:
             tile_inventory = _profile_tile_inventory(
                 prepared_path,
@@ -847,36 +1078,161 @@ def profile_payload(
         "temperature_k",
         "constraint_max_error_angstrom",
     )
-    clean_state = clean.get("state", {})
-    instrumented_state = instrumented.get("state", {})
-    state_consistent = all(
-        key in clean_state
-        and key in instrumented_state
-        and np.isclose(
-            float(clean_state[key]),
-            float(instrumented_state[key]),
-            # The synchronized profile deliberately uses the per-step route so
-            # its timers are exclusive, while the clean sample uses the
-            # compiled block route. Float32 reduction order may therefore
-            # diverge slightly even though both paths remain scientifically
-            # equivalent.
-            rtol=_PROFILE_STATE_RTOL,
-            atol=_PROFILE_STATE_ATOL,
+    def states_match(left: Mapping[str, Any], right: Mapping[str, Any]) -> bool:
+        return all(
+            key in left
+            and key in right
+            and np.isclose(
+                float(left[key]),
+                float(right[key]),
+                rtol=_PROFILE_STATE_RTOL,
+                atol=_PROFILE_STATE_ATOL,
+            )
+            for key in state_fields
         )
-        for key in state_fields
+
+    clean_samples = (clean, clean_repeat)
+    clean_states = [sample.get("state", {}) for sample in clean_samples]
+    instrumented_state = instrumented.get("state", {})
+    clean_instrumented_state_consistent = all(
+        states_match(state, instrumented_state) for state in clean_states
     )
+    control_candidate_state_consistent = all(
+        states_match(control.get("state", {}), candidate_state)
+        for control in (pair_control_before, pair_control_after)
+        for candidate_state in clean_states
+    )
+    pair_control_seconds = [
+        float(control.get("timings", {}).get("measured_seconds", math.inf))
+        for control in (pair_control_before, pair_control_after)
+    ]
+    pair_control_median_seconds = (
+        float(np.median(pair_control_seconds))
+        if all(math.isfinite(value) and value > 0.0 for value in pair_control_seconds)
+        else math.inf
+    )
+    tile_candidate_seconds = [
+        float(sample.get("timings", {}).get("measured_seconds", math.inf))
+        for sample in clean_samples
+    ]
+    tile_candidate_median_seconds = (
+        float(np.median(tile_candidate_seconds))
+        if all(math.isfinite(value) and value > 0.0 for value in tile_candidate_seconds)
+        else math.inf
+    )
+    complete_wall_speedup_fraction = (
+        0.0
+        if not math.isfinite(pair_control_median_seconds)
+        or pair_control_median_seconds <= 0.0
+        or not math.isfinite(tile_candidate_median_seconds)
+        else 1.0 - tile_candidate_median_seconds / pair_control_median_seconds
+    )
+    profile_process_peak_bytes = int(max_rss_mb() * 1024.0 * 1024.0)
+    profile_memory = {
+        "max_rss_mb": profile_process_peak_bytes / (1024.0 * 1024.0),
+        "process_peak_bytes": profile_process_peak_bytes,
+        "process_memory_limit_bytes": _PROCESS_MEMORY_LIMIT_BYTES,
+        "mlx_active_memory_bytes": _mlx_memory_value("get_active_memory"),
+        "mlx_peak_memory_bytes": _mlx_memory_value("get_peak_memory"),
+        "mlx_cache_memory_bytes": _mlx_memory_value("get_cache_memory"),
+    }
     checks = {
+        "pair_control_before_passed": pair_control_before.get("passed") is True,
         "clean_passed": clean.get("passed") is True,
+        "clean_repeat_passed": clean_repeat.get("passed") is True,
+        "pair_control_after_passed": pair_control_after.get("passed") is True,
         "instrumented_passed": instrumented.get("passed") is True,
+        "complete_wall_speedup": (
+            complete_wall_speedup_fraction >= _SPATIAL_DIRECT_MIN_COMPLETE_SPEEDUP
+        ),
         "route_profile_reconciled": route_profile.get("reconciled") is True,
-        "direct_route_present": "direct_lj_screened_coulomb" in routes,
+        "spatial_tile_route_present": "direct_spatial_tiles" in routes,
+        "compact_pair_fallback_absent": "direct_lj_screened_coulomb" not in routes,
         "reciprocal_route_present": "reciprocal_pme" in routes,
         "neighbor_route_present": "neighbor_update_rebuild" in routes,
         "integration_route_present": "integration_thermostat" in routes,
-        "clean_instrumented_state_consistent": state_consistent,
+        "clean_instrumented_state_consistent": clean_instrumented_state_consistent,
+        "control_candidate_state_consistent": control_candidate_state_consistent,
+        "process_memory_within_limit": (
+            profile_process_peak_bytes <= _PROCESS_MEMORY_LIMIT_BYTES
+        ),
+        "mlx_peak_memory_within_limit": (
+            isinstance(profile_memory["mlx_peak_memory_bytes"], int)
+            and profile_memory["mlx_peak_memory_bytes"]
+            <= _PROCESS_MEMORY_LIMIT_BYTES
+        ),
         "tile_inventory_present": tile_inventory is not None,
+        "tile_pair_inventory_matches": (
+            tile_inventory is not None
+            and tile_inventory.get("pair_inventory_matches") is True
+        ),
+        "tile_force_rms_within_tolerance": (
+            tile_inventory is not None
+            and float(tile_inventory.get("force_rms_delta_kj_mol_angstrom", math.inf))
+            <= 2.0e-4
+        ),
+        "tile_force_max_within_tolerance": (
+            tile_inventory is not None
+            and float(tile_inventory.get("force_max_delta_kj_mol_angstrom", math.inf))
+            <= 2.0e-2
+        ),
+        "tile_active_lane_fraction": (
+            tile_inventory is not None
+            and float(tile_inventory.get("active_lane_fraction", 0.0)) >= 0.30
+        ),
+        "tile_scheduled_lane_bound": (
+            tile_inventory is not None
+            and int(tile_inventory.get("padded_lane_count", 200_000_001))
+            <= 200_000_000
+        ),
+        "tile_direct_latency_speedup": (
+            tile_inventory is not None
+            and float(tile_inventory.get("direct_speedup_fraction", 0.0))
+            >= _SPATIAL_DIRECT_MIN_KERNEL_SPEEDUP
+        ),
+        "tile_persistent_estimate_within_limit": (
+            tile_inventory is not None
+            and int(
+                tile_inventory.get(
+                    "estimated_persistent_bytes",
+                    _PROCESS_MEMORY_LIMIT_BYTES + 1,
+                )
+            )
+            <= _PROCESS_MEMORY_LIMIT_BYTES
+        ),
+        "correction_force_rms_within_tolerance": (
+            tile_inventory is not None
+            and float(
+                tile_inventory.get(
+                    "correction_force_rms_delta_kj_mol_angstrom",
+                    math.inf,
+                )
+            )
+            <= 2.0e-4
+        ),
+        "correction_force_max_within_tolerance": (
+            tile_inventory is not None
+            and float(
+                tile_inventory.get(
+                    "correction_force_max_delta_kj_mol_angstrom",
+                    math.inf,
+                )
+            )
+            <= 2.0e-2
+        ),
+        "correction_latency_speedup": (
+            tile_inventory is not None
+            and float(tile_inventory.get("correction_speedup_fraction", 0.0))
+            >= _SPARSE_CORRECTION_MIN_SPEEDUP
+        ),
     }
     diagnostics = {
+        "pair_control_seconds": pair_control_seconds,
+        "pair_control_median_seconds": pair_control_median_seconds,
+        "tile_candidate_seconds": tile_candidate_seconds,
+        "tile_candidate_median_seconds": tile_candidate_median_seconds,
+        "complete_wall_speedup_fraction": complete_wall_speedup_fraction,
+        "complete_wall_speedup_gate": _SPATIAL_DIRECT_MIN_COMPLETE_SPEEDUP,
         "tile_pair_inventory_matches": (
             tile_inventory is not None
             and tile_inventory.get("pair_inventory_matches") is True
@@ -887,6 +1243,38 @@ def profile_payload(
             else int(tile_inventory["exact_pair_count"])
             - int(tile_inventory["reference_pair_count"])
         ),
+        "tile_force_rms_delta_kj_mol_angstrom": (
+            None
+            if tile_inventory is None
+            else tile_inventory["force_rms_delta_kj_mol_angstrom"]
+        ),
+        "tile_force_max_delta_kj_mol_angstrom": (
+            None
+            if tile_inventory is None
+            else tile_inventory["force_max_delta_kj_mol_angstrom"]
+        ),
+        "tile_direct_speedup_fraction": (
+            None
+            if tile_inventory is None
+            else tile_inventory["direct_speedup_fraction"]
+        ),
+        "tile_direct_speedup_gate": _SPATIAL_DIRECT_MIN_KERNEL_SPEEDUP,
+        "correction_force_rms_delta_kj_mol_angstrom": (
+            None
+            if tile_inventory is None
+            else tile_inventory["correction_force_rms_delta_kj_mol_angstrom"]
+        ),
+        "correction_force_max_delta_kj_mol_angstrom": (
+            None
+            if tile_inventory is None
+            else tile_inventory["correction_force_max_delta_kj_mol_angstrom"]
+        ),
+        "correction_speedup_fraction": (
+            None
+            if tile_inventory is None
+            else tile_inventory["correction_speedup_fraction"]
+        ),
+        "correction_speedup_gate": _SPARSE_CORRECTION_MIN_SPEEDUP,
     }
     passed = all(checks.values())
     payload = {
@@ -896,18 +1284,15 @@ def profile_payload(
         "blockers": [name for name, value in checks.items() if not value]
         + ([] if inventory_blocker is None else [f"tile_inventory:{inventory_blocker}"]),
         "prepared": str(prepared_path),
+        "pair_controls": [pair_control_before, pair_control_after],
         "clean": clean,
+        "clean_samples": [clean, clean_repeat],
         "instrumented": instrumented,
         "tile_inventory": tile_inventory,
         "openmm_admission": admission,
         "checks": checks,
         "diagnostics": diagnostics,
-        "memory": {
-            "max_rss_mb": max_rss_mb(),
-            "mlx_active_memory_bytes": _mlx_memory_value("get_active_memory"),
-            "mlx_peak_memory_bytes": _mlx_memory_value("get_peak_memory"),
-            "mlx_cache_memory_bytes": _mlx_memory_value("get_cache_memory"),
-        },
+        "memory": profile_memory,
     }
     return _write_runtime_payload(payload, out_path)
 
@@ -1060,6 +1445,11 @@ def main(argv: list[str] | None = None) -> None:
     runtime_parser.add_argument("--neighbor-check-interval", type=int, default=1)
     runtime_parser.add_argument("--sample-interval", type=int, default=None)
     runtime_parser.add_argument("--diagnostic-interval", type=int, default=None)
+    runtime_parser.add_argument(
+        "--neighbor-backend",
+        choices=sorted(_RUNTIME_NEIGHBOR_BACKENDS),
+        default="mlx_cell_tiles",
+    )
     runtime_parser.add_argument("--out", type=Path, required=True)
     profile_parser = commands.add_parser(
         "profile",
@@ -1102,6 +1492,7 @@ def main(argv: list[str] | None = None) -> None:
             neighbor_check_interval=args.neighbor_check_interval,
             sample_interval=args.sample_interval,
             diagnostic_interval=args.diagnostic_interval,
+            neighbor_backend=args.neighbor_backend,
             out=args.out,
         )
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/src/mlx_atomistic/forcefields.py
+++ b/src/mlx_atomistic/forcefields.py
@@ -29,6 +29,7 @@ from mlx_atomistic.gbsa import GBSAForcePotential as GBSAForcePotential
 from mlx_atomistic.metal_kernels import (
     _fused_bonded_force_only,
     _prepared_parameterized_pme_direct_force_only,
+    _tile_parameterized_pme_direct_force_only,
     aligned_topology_lj_scales,
     fused_parameterized_lj_forces,
     fused_parameterized_pme_direct_components,
@@ -36,6 +37,8 @@ from mlx_atomistic.metal_kernels import (
     fused_parameterized_pme_direct_force_only,
     fused_parameterized_pme_direct_forces,
     fused_pme_cutoff_correction_virial,
+    fused_sparse_pme_correction_forces,
+    tile_topology_lj_masks,
 )
 from mlx_atomistic.neighbors import NeighborBlocks, NeighborTiles, build_neighbor_list
 from mlx_atomistic.nonbonded import (
@@ -118,7 +121,7 @@ class _NonbondedForceBinding:
     cell: Cell
     pairs: mx.array
     pme_plan: PMEExecutionPlan
-    aligned_lj_scales: mx.array
+    aligned_lj_scales: mx.array | None
     box_lengths_and_inverses: mx.array
     half_sigma: mx.array
     sqrt_epsilon: mx.array
@@ -1428,6 +1431,10 @@ class NonbondedPotential:
             dtype=np.int32,
         ).reshape((-1, 2))
         correction_pairs_mx = mx.array(correction_pairs, dtype=mx.int32)
+        exception_pairs_mx = mx.array(exception_pairs, dtype=mx.int32)
+        exception_charge_products_mx = as_mx_array(charge_products)
+        exception_sigma_mx = as_mx_array(exception_sigma)
+        exception_epsilon_mx = as_mx_array(exception_epsilon)
         one_four_pairs_mx = mx.array(one_four_pairs, dtype=mx.int32)
         lj_one_four_pairs_mx = mx.array(lj_one_four_pairs, dtype=mx.int32)
         correction_charge_products = -(
@@ -1438,6 +1445,34 @@ class NonbondedPotential:
             (self.coulomb_one_four_scale - 1.0)
             * charges[one_four_pairs_mx[:, 0]]
             * charges[one_four_pairs_mx[:, 1]]
+        )
+        sparse_correction_pairs = mx.concatenate(
+            (correction_pairs_mx, exception_pairs_mx, one_four_pairs_mx),
+            axis=0,
+        )
+        sparse_correction_charge_products = mx.concatenate(
+            (
+                correction_charge_products,
+                exception_charge_products_mx,
+                one_four_charge_products,
+            ),
+            axis=0,
+        )
+        sparse_correction_lj_sigma = mx.concatenate(
+            (
+                mx.zeros((correction_pairs.shape[0],), dtype=mx.float32),
+                exception_sigma_mx,
+                mx.zeros((one_four_pairs.shape[0],), dtype=mx.float32),
+            ),
+            axis=0,
+        )
+        sparse_correction_lj_epsilon = mx.concatenate(
+            (
+                mx.zeros((correction_pairs.shape[0],), dtype=mx.float32),
+                exception_epsilon_mx,
+                mx.zeros((one_four_pairs.shape[0],), dtype=mx.float32),
+            ),
+            axis=0,
         )
         exceptions_excluded_by_topology = self.topology is not None and exception_pair_set.issubset(
             self.topology.exclusion_set
@@ -1501,10 +1536,10 @@ class NonbondedPotential:
         object.__setattr__(self, "sigma", sigma)
         object.__setattr__(self, "epsilon", epsilon)
         object.__setattr__(self, "charges", charges)
-        object.__setattr__(self, "exception_pairs", mx.array(exception_pairs, dtype=mx.int32))
-        object.__setattr__(self, "exception_charge_products", as_mx_array(charge_products))
-        object.__setattr__(self, "exception_sigma", as_mx_array(exception_sigma))
-        object.__setattr__(self, "exception_epsilon", as_mx_array(exception_epsilon))
+        object.__setattr__(self, "exception_pairs", exception_pairs_mx)
+        object.__setattr__(self, "exception_charge_products", exception_charge_products_mx)
+        object.__setattr__(self, "exception_sigma", exception_sigma_mx)
+        object.__setattr__(self, "exception_epsilon", exception_epsilon_mx)
         object.__setattr__(self, "nbfix_pairs", mx.array(nbfix_pairs, dtype=mx.int32))
         object.__setattr__(self, "nbfix_sigma", as_mx_array(nbfix_sigma))
         object.__setattr__(self, "nbfix_epsilon", as_mx_array(nbfix_epsilon))
@@ -1542,6 +1577,26 @@ class NonbondedPotential:
             self,
             "_ewald_one_four_charge_products",
             one_four_charge_products,
+        )
+        object.__setattr__(
+            self,
+            "_sparse_correction_pairs",
+            sparse_correction_pairs,
+        )
+        object.__setattr__(
+            self,
+            "_sparse_correction_charge_products",
+            sparse_correction_charge_products,
+        )
+        object.__setattr__(
+            self,
+            "_sparse_correction_lj_sigma",
+            sparse_correction_lj_sigma,
+        )
+        object.__setattr__(
+            self,
+            "_sparse_correction_lj_epsilon",
+            sparse_correction_lj_epsilon,
         )
         object.__setattr__(
             self,
@@ -2043,6 +2098,17 @@ class NonbondedPotential:
         tiles: NeighborTiles,
     ) -> tuple[mx.array, mx.array]:
         """Return binding-owned LJ eligibility and one-four tile masks."""
+
+        if "gpu" in str(mx.default_device()).lower():
+            enabled, one_four = tile_topology_lj_masks(
+                tiles.atom_blocks,
+                tiles.tile_blocks,
+                tiles.member_mask,
+                self._aligned_lj_exclusion_pairs,
+                self._aligned_lj_one_four_pairs,
+            )
+            mx.eval(enabled, one_four)
+            return enabled, one_four
 
         atom_blocks = np.asarray(tiles.atom_blocks, dtype=np.int32)
         tile_blocks = np.asarray(tiles.tile_blocks, dtype=np.int32)
@@ -3590,12 +3656,20 @@ class NonbondedPotential:
             tile_lj_enabled_mask, tile_lj_one_four_mask = self._tile_aligned_lj_masks(
                 tiles,
             )
+        tile_force_ready = bool(
+            tiles is not None
+            and pair_force_ready
+            and tiles.force_group_starts is not None
+            and tiles.force_group_counts is not None
+        )
         binding = _NonbondedForceBinding(
             cell=cell,
             pairs=direct_space_pairs,
             pme_plan=self.pme_plan,
-            aligned_lj_scales=self._compact_aligned_lj_scales(
-                direct_space_pairs,
+            aligned_lj_scales=(
+                None
+                if tile_force_ready
+                else self._compact_aligned_lj_scales(direct_space_pairs)
             ),
             box_lengths_and_inverses=box_cache[1],
             half_sigma=lj_invariants[2],
@@ -3609,14 +3683,43 @@ class NonbondedPotential:
                 None
                 if tiles is None
                 else (
-                    "tile_force_route_not_selected"
-                    if pair_force_ready
-                    else "tile_pair_kernel_unsupported"
+                    None
+                    if tile_force_ready
+                    else (
+                        "tile_pair_kernel_unsupported"
+                        if not pair_force_ready
+                        else "tile_force_schedule_unavailable"
+                    )
                 )
             ),
         )
         object.__setattr__(self, "_force_binding_cache", binding)
         return binding
+
+    def _prepared_sparse_correction_forces(
+        self,
+        positions: mx.array,
+        binding: _NonbondedForceBinding,
+    ) -> mx.array:
+        """Evaluate recurring PME sparse corrections through one GPU force buffer."""
+
+        if "gpu" not in str(mx.default_device()).lower():
+            return self._exception_lj_forces(
+                positions,
+                binding.cell,
+            ) + self._periodic_coulomb_correction_forces(
+                positions,
+                binding.cell,
+            )
+        return fused_sparse_pme_correction_forces(
+            positions,
+            self._sparse_correction_pairs,
+            binding.box_lengths_and_inverses,
+            self._sparse_correction_charge_products,
+            self._sparse_correction_lj_sigma,
+            self._sparse_correction_lj_epsilon,
+            coulomb_constant=self.coulomb_constant,
+        )
 
     def _forces_from_binding(
         self,
@@ -3635,7 +3738,60 @@ class NonbondedPotential:
             msg = "positions must have shape (n_atoms, 3)"
             raise ValueError(msg)
 
-        direct_forces = _prepared_parameterized_pme_direct_force_only(
+        direct_forces = self._direct_forces_from_binding(positions, binding)
+        _, reciprocal_forces = _prepared_pme_reciprocal_space_energy_forces(
+            positions,
+            self.charges,
+            binding.pme_plan,
+            include_self_correction=False,
+        )
+        return (
+            direct_forces
+            + reciprocal_forces
+            + self._prepared_sparse_correction_forces(
+                positions,
+                binding,
+            )
+        )
+
+    def _direct_forces_from_binding(
+        self,
+        positions: mx.array,
+        binding: _NonbondedForceBinding,
+    ) -> mx.array:
+        """Evaluate the admitted spatial-tile or compact-pair direct route."""
+
+        tiles = binding.tile_geometry
+        if (
+            tiles is not None
+            and binding.tile_decline_reason is None
+            and binding.tile_lj_enabled_mask is not None
+            and binding.tile_lj_one_four_mask is not None
+        ):
+            return _tile_parameterized_pme_direct_force_only(
+                positions,
+                tiles.atom_blocks,
+                tiles.tile_blocks,
+                tiles.member_mask,
+                binding.tile_lj_enabled_mask,
+                binding.tile_lj_one_four_mask,
+                tiles.force_group_starts,
+                tiles.force_group_counts,
+                binding.box_lengths_and_inverses,
+                binding.half_sigma,
+                binding.sqrt_epsilon,
+                self.charges,
+                cutoff=self.cutoff,
+                shift=self.lj_shift,
+                switch_distance=self.switch_distance,
+                one_four_scale=self.lj_one_four_scale,
+                coulomb_constant=self.coulomb_constant,
+                alpha=self.pme_config.alpha,
+            )
+        if binding.aligned_lj_scales is None:
+            msg = "compact-pair fallback requires aligned LJ scales"
+            raise RuntimeError(msg)
+        return _prepared_parameterized_pme_direct_force_only(
             positions,
             binding.pairs,
             binding.box_lengths_and_inverses,
@@ -3648,21 +3804,6 @@ class NonbondedPotential:
             switch_distance=self.switch_distance,
             coulomb_constant=self.coulomb_constant,
             alpha=self.pme_config.alpha,
-        )
-        _, reciprocal_forces = _prepared_pme_reciprocal_space_energy_forces(
-            positions,
-            self.charges,
-            binding.pme_plan,
-            include_self_correction=False,
-        )
-        return (
-            direct_forces
-            + self._exception_lj_forces(positions, binding.cell)
-            + reciprocal_forces
-            + self._periodic_coulomb_correction_forces(
-                positions,
-                binding.cell,
-            )
         )
 
     def _profile_forces_from_binding(
@@ -3684,22 +3825,14 @@ class NonbondedPotential:
             raise ValueError(msg)
 
         direct_started = route_profiler.start()
-        direct_forces = _prepared_parameterized_pme_direct_force_only(
-            positions,
-            binding.pairs,
-            binding.box_lengths_and_inverses,
-            binding.half_sigma,
-            binding.sqrt_epsilon,
-            self.charges,
-            binding.aligned_lj_scales,
-            cutoff=self.cutoff,
-            shift=self.lj_shift,
-            switch_distance=self.switch_distance,
-            coulomb_constant=self.coulomb_constant,
-            alpha=self.pme_config.alpha,
-        )
+        direct_forces = self._direct_forces_from_binding(positions, binding)
         route_profiler.finish(
-            "direct_lj_screened_coulomb",
+            (
+                "direct_spatial_tiles"
+                if binding.tile_geometry is not None
+                and binding.tile_decline_reason is None
+                else "direct_lj_screened_coulomb"
+            ),
             direct_started,
             direct_forces,
         )
@@ -3718,12 +3851,9 @@ class NonbondedPotential:
         )
 
         correction_started = route_profiler.start()
-        correction_forces = self._exception_lj_forces(
+        correction_forces = self._prepared_sparse_correction_forces(
             positions,
-            binding.cell,
-        ) + self._periodic_coulomb_correction_forces(
-            positions,
-            binding.cell,
+            binding,
         )
         route_profiler.finish(
             "pme_exceptions_corrections",

--- a/src/mlx_atomistic/md.py
+++ b/src/mlx_atomistic/md.py
@@ -2674,6 +2674,13 @@ def _neighbor_profile_values(neighbor_list: NeighborList | None) -> tuple[mx.arr
                 neighbor_list.tiles.member_mask,
             )
         )
+        if neighbor_list.tiles.force_group_starts is not None:
+            values.extend(
+                (
+                    neighbor_list.tiles.force_group_starts,
+                    neighbor_list.tiles.force_group_counts,
+                )
+            )
     return tuple(values)
 
 

--- a/src/mlx_atomistic/metal_kernels.py
+++ b/src/mlx_atomistic/metal_kernels.py
@@ -327,6 +327,8 @@ _pme_direct_kernel_singleton = None
 _pme_direct_virial_kernel_singleton = None
 _pme_direct_force_only_kernel_singleton = None
 _prepared_pme_direct_force_only_kernel_singleton = None
+_tile_pme_direct_force_only_kernel_singleton = None
+_sparse_pme_correction_force_only_kernel_singleton = None
 _pme_cutoff_correction_virial_kernel_singleton = None
 _pme_order5_spread_kernel_singleton = None
 _pme_order5_interpolate_kernel_singleton = None
@@ -334,6 +336,12 @@ _aligned_topology_lj_scales_kernel_singleton = None
 _neighbor_cell_pair_candidates_kernel_singleton = None
 _neighbor_pair_cutoff_mask_kernel_singleton = None
 _neighbor_pair_ordered_scatter_kernel_singleton = None
+_neighbor_cell_tile_candidates_kernel_singleton = None
+_neighbor_tile_membership_kernel_singleton = None
+_neighbor_tile_ordered_scatter_kernel_singleton = None
+_neighbor_tile_force_groups_kernel_singleton = None
+_neighbor_tile_pair_scatter_kernel_singleton = None
+_tile_topology_lj_masks_kernel_singleton = None
 _shake_cluster_position_kernel_singleton = None
 _shake_cluster_velocity_kernel_singleton = None
 _settle_water_position_kernel_singleton = None
@@ -343,6 +351,16 @@ _fused_bonded_force_only_kernel_singleton = None
 # Neighbor compaction preserves short runs of a common left atom, so one worker
 # can sum those contributions locally before issuing global atomics.
 _PREPARED_PME_PAIRS_PER_WORKER = 8
+
+_TILE_PME_BLOCK_SIZE = 8
+_TILE_PME_LANES_PER_TILE = _TILE_PME_BLOCK_SIZE * _TILE_PME_BLOCK_SIZE
+_TILE_PME_THREADGROUP_SIZE = _TILE_PME_LANES_PER_TILE
+_TILE_MEMBERSHIP_THREADGROUP_SIZE = _TILE_PME_LANES_PER_TILE
+_TILE_PME_THREADGROUP_TEMPORARY_BYTES = (
+    2 * _TILE_PME_BLOCK_SIZE * 4
+    + 2 * _TILE_PME_BLOCK_SIZE * (3 + 1 + 1 + 1) * 4
+    + 3 * _TILE_PME_LANES_PER_TILE * 4
+)
 
 # The float32 erf/expm1 implementation below is adapted from MLX's Metal
 # kernels:
@@ -600,13 +618,13 @@ _PARAMETERIZED_PME_DIRECT_SOURCE = r"""
     float ly = box[1];
     float lz = box[2];
 #ifdef MLX_ATOMISTIC_PREPARED_INVARIANTS
-    dx -= lx * floor(dx * box[3] + 0.5f);
-    dy -= ly * floor(dy * box[4] + 0.5f);
-    dz -= lz * floor(dz * box[5] + 0.5f);
+    dx -= lx * rint(dx * box[3]);
+    dy -= ly * rint(dy * box[4]);
+    dz -= lz * rint(dz * box[5]);
 #else
-    dx -= lx * floor(dx / lx + 0.5f);
-    dy -= ly * floor(dy / ly + 0.5f);
-    dz -= lz * floor(dz / lz + 0.5f);
+    dx -= lx * rint(dx / lx);
+    dy -= ly * rint(dy / ly);
+    dz -= lz * rint(dz / lz);
 #endif
 
     float r2 = dx * dx + dy * dy + dz * dz;
@@ -834,6 +852,278 @@ _PREPARED_PME_DIRECT_FORCE_ONLY_SOURCE = (
     f"#define MLX_ATOMISTIC_PAIRS_PER_WORKER {_PREPARED_PME_PAIRS_PER_WORKER}u\n"
     + _PARAMETERIZED_PME_DIRECT_SOURCE
 )
+
+# One 64-thread group walks a short contiguous run of tiles with a common left
+# block. It loads that block once and accumulates its force across the run, while
+# each right block is still reduced locally. This preserves exact 8x8 geometry
+# but removes repeated global writes and parameter gathers for the shared side.
+_TILE_PREPARED_PME_DIRECT_FORCE_ONLY_SOURCE = r"""
+    uint lane = thread_position_in_threadgroup.x;
+    uint group = threadgroup_position_in_grid.x;
+    int group_start = force_group_starts[group];
+    int group_count = force_group_counts[group];
+
+    threadgroup int left_atoms[8];
+    threadgroup int right_atoms[8];
+    threadgroup float left_positions[24];
+    threadgroup float right_positions[24];
+    threadgroup float left_half_sigma[8];
+    threadgroup float right_half_sigma[8];
+    threadgroup float left_sqrt_epsilon[8];
+    threadgroup float right_sqrt_epsilon[8];
+    threadgroup float left_charges[8];
+    threadgroup float right_charges[8];
+    threadgroup float pair_fx[64];
+    threadgroup float pair_fy[64];
+    threadgroup float pair_fz[64];
+
+    int left_block = tile_blocks[2 * group_start + 0];
+    if (lane < 8u) {
+        int left_atom = atom_blocks[8 * left_block + lane];
+        left_atoms[lane] = left_atom;
+        int safe_left = max(left_atom, 0);
+        left_positions[3 * lane + 0] = positions[3 * safe_left + 0];
+        left_positions[3 * lane + 1] = positions[3 * safe_left + 1];
+        left_positions[3 * lane + 2] = positions[3 * safe_left + 2];
+        left_half_sigma[lane] = half_sigma[safe_left];
+        left_sqrt_epsilon[lane] = sqrt_epsilon[safe_left];
+        left_charges[lane] = charges[safe_left];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float accumulated_left_fx = 0.0f;
+    float accumulated_left_fy = 0.0f;
+    float accumulated_left_fz = 0.0f;
+    uint left_slot = lane >> 3;
+    uint right_slot = lane & 7u;
+    uint word = lane >> 5;
+    uint bit = lane & 31u;
+
+    for (int local_tile = 0; local_tile < group_count; local_tile++) {
+        int tile = group_start + local_tile;
+        int tile_left_block = tile_blocks[2 * tile + 0];
+        int right_block = tile_blocks[2 * tile + 1];
+        bool same_block = tile_left_block == right_block;
+        if (lane < 8u) {
+            int right_atom = atom_blocks[8 * right_block + lane];
+            right_atoms[lane] = right_atom;
+            int safe_right = max(right_atom, 0);
+            right_positions[3 * lane + 0] = positions[3 * safe_right + 0];
+            right_positions[3 * lane + 1] = positions[3 * safe_right + 1];
+            right_positions[3 * lane + 2] = positions[3 * safe_right + 2];
+            right_half_sigma[lane] = half_sigma[safe_right];
+            right_sqrt_epsilon[lane] = sqrt_epsilon[safe_right];
+            right_charges[lane] = charges[safe_right];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        bool member = ((member_mask[2 * tile + word] >> bit) & 1u) != 0u;
+        int i = left_atoms[left_slot];
+        int j = right_atoms[right_slot];
+        float fx = 0.0f;
+        float fy = 0.0f;
+        float fz = 0.0f;
+        if (member && i >= 0 && j >= 0) {
+            float dx = left_positions[3 * left_slot + 0]
+                - right_positions[3 * right_slot + 0];
+            float dy = left_positions[3 * left_slot + 1]
+                - right_positions[3 * right_slot + 1];
+            float dz = left_positions[3 * left_slot + 2]
+                - right_positions[3 * right_slot + 2];
+            float lx = box[0];
+            float ly = box[1];
+            float lz = box[2];
+            dx -= lx * rint(dx * box[3]);
+            dy -= ly * rint(dy * box[4]);
+            dz -= lz * rint(dz * box[5]);
+            float r2 = dx * dx + dy * dy + dz * dz;
+            if (r2 > 0.0f && r2 < params[0]) {
+                float inv_distance = rsqrt(r2);
+                float inv_r2 = inv_distance * inv_distance;
+                float distance = r2 * inv_distance;
+                float scalar = 0.0f;
+                bool lj_enabled =
+                    ((lj_enabled_mask[2 * tile + word] >> bit) & 1u) != 0u;
+                if (lj_enabled) {
+                    bool one_four =
+                        ((lj_one_four_mask[2 * tile + word] >> bit) & 1u) != 0u;
+                    float lj_scale = one_four ? params[10] : 1.0f;
+                    float sigma_ij = left_half_sigma[left_slot]
+                        + right_half_sigma[right_slot];
+                    float epsilon_ij = left_sqrt_epsilon[left_slot]
+                        * right_sqrt_epsilon[right_slot];
+                    float sigma2_over_r2 = sigma_ij * sigma_ij * inv_r2;
+                    float inv_r6 =
+                        sigma2_over_r2 * sigma2_over_r2 * sigma2_over_r2;
+                    float inv_r12 = inv_r6 * inv_r6;
+                    float unswitched_energy =
+                        4.0f * epsilon_ij * (inv_r12 - inv_r6);
+                    if (params[1] > 0.5f) {
+                        float sigma2_over_rc2 = sigma_ij * sigma_ij / params[0];
+                        float inv_rc6 = sigma2_over_rc2
+                            * sigma2_over_rc2 * sigma2_over_rc2;
+                        unswitched_energy -= 4.0f * epsilon_ij
+                            * (inv_rc6 * inv_rc6 - inv_rc6);
+                    }
+
+                    float switch_value = 1.0f;
+                    float switch_derivative = 0.0f;
+                    if (params[2] > 0.5f) {
+                        float x = clamp(
+                            (distance - params[3]) * params[9],
+                            0.0f,
+                            1.0f
+                        );
+                        float x2 = x * x;
+                        float x3 = x2 * x;
+                        float x4 = x3 * x;
+                        float x5 = x4 * x;
+                        switch_value = 1.0f
+                            - (10.0f * x3 - 15.0f * x4 + 6.0f * x5);
+                        if (distance > params[3] && distance < params[5]) {
+                            switch_derivative = -(
+                                30.0f * x2 - 60.0f * x3 + 30.0f * x4
+                            ) * params[9];
+                        }
+                    }
+                    scalar += (
+                        24.0f * epsilon_ij * (2.0f * inv_r12 - inv_r6)
+                        * inv_r2 * switch_value
+                        - unswitched_energy * switch_derivative * inv_distance
+                    ) * lj_scale;
+                }
+
+                float qij = left_charges[left_slot] * right_charges[right_slot];
+                float erfc_term =
+                    1.0f - mlx_atomistic_erf(params[7] * distance);
+                scalar += params[6] * qij * (
+                    erfc_term * inv_r2 * inv_distance
+                    + params[8] * exp(-params[7] * params[7] * r2) * inv_r2
+                );
+                fx = scalar * dx;
+                fy = scalar * dy;
+                fz = scalar * dz;
+            }
+        }
+        pair_fx[lane] = fx;
+        pair_fy[lane] = fy;
+        pair_fz[lane] = fz;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (lane < 8u) {
+            float reduced_fx = 0.0f;
+            float reduced_fy = 0.0f;
+            float reduced_fz = 0.0f;
+            for (uint other = 0u; other < 8u; other++) {
+                uint pair_lane = 8u * lane + other;
+                reduced_fx += pair_fx[pair_lane];
+                reduced_fy += pair_fy[pair_lane];
+                reduced_fz += pair_fz[pair_lane];
+            }
+            if (same_block) {
+                for (uint other = 0u; other < 8u; other++) {
+                    uint pair_lane = 8u * other + lane;
+                    reduced_fx -= pair_fx[pair_lane];
+                    reduced_fy -= pair_fy[pair_lane];
+                    reduced_fz -= pair_fz[pair_lane];
+                }
+            }
+            accumulated_left_fx += reduced_fx;
+            accumulated_left_fy += reduced_fy;
+            accumulated_left_fz += reduced_fz;
+        } else if (lane < 16u && !same_block) {
+            uint slot = lane - 8u;
+            float reduced_fx = 0.0f;
+            float reduced_fy = 0.0f;
+            float reduced_fz = 0.0f;
+            for (uint other = 0u; other < 8u; other++) {
+                uint pair_lane = 8u * other + slot;
+                reduced_fx -= pair_fx[pair_lane];
+                reduced_fy -= pair_fy[pair_lane];
+                reduced_fz -= pair_fz[pair_lane];
+            }
+            int atom = right_atoms[slot];
+            if (
+                atom >= 0
+                && (reduced_fx != 0.0f || reduced_fy != 0.0f || reduced_fz != 0.0f)
+            ) {
+                atomic_fetch_add_explicit(
+                    &forces[3 * atom + 0], reduced_fx, memory_order_relaxed
+                );
+                atomic_fetch_add_explicit(
+                    &forces[3 * atom + 1], reduced_fy, memory_order_relaxed
+                );
+                atomic_fetch_add_explicit(
+                    &forces[3 * atom + 2], reduced_fz, memory_order_relaxed
+                );
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (lane < 8u) {
+        int atom = left_atoms[lane];
+        if (
+            atom >= 0
+            && (
+                accumulated_left_fx != 0.0f
+                || accumulated_left_fy != 0.0f
+                || accumulated_left_fz != 0.0f
+            )
+        ) {
+            atomic_fetch_add_explicit(
+                &forces[3 * atom + 0], accumulated_left_fx, memory_order_relaxed
+            );
+            atomic_fetch_add_explicit(
+                &forces[3 * atom + 1], accumulated_left_fy, memory_order_relaxed
+            );
+            atomic_fetch_add_explicit(
+                &forces[3 * atom + 2], accumulated_left_fz, memory_order_relaxed
+            );
+        }
+    }
+"""
+
+_SPARSE_PME_CORRECTION_FORCE_ONLY_SOURCE = r"""
+    uint t = thread_position_in_grid.x;
+    if (t >= (uint)npair[0]) {
+        return;
+    }
+
+    int atom_i = pairs_i[t];
+    int atom_j = pairs_j[t];
+    float dx = positions[3 * atom_i + 0] - positions[3 * atom_j + 0];
+    float dy = positions[3 * atom_i + 1] - positions[3 * atom_j + 1];
+    float dz = positions[3 * atom_i + 2] - positions[3 * atom_j + 2];
+    dx -= box[0] * rint(dx * box[3]);
+    dy -= box[1] * rint(dy * box[4]);
+    dz -= box[2] * rint(dz * box[5]);
+    float r2 = dx * dx + dy * dy + dz * dz;
+    if (r2 <= 0.0f) {
+        return;
+    }
+
+    float inv_distance = rsqrt(r2);
+    float inv_r2 = inv_distance * inv_distance;
+    float scalar = params[0] * charge_products[t] * inv_r2 * inv_distance;
+    float epsilon = lj_epsilon[t];
+    if (epsilon > 0.0f) {
+        float sigma2_over_r2 = lj_sigma[t] * lj_sigma[t] * inv_r2;
+        float inv_r6 = sigma2_over_r2 * sigma2_over_r2 * sigma2_over_r2;
+        float inv_r12 = inv_r6 * inv_r6;
+        scalar += 24.0f * epsilon * (2.0f * inv_r12 - inv_r6) * inv_r2;
+    }
+
+    float fx = scalar * dx;
+    float fy = scalar * dy;
+    float fz = scalar * dz;
+    atomic_fetch_add_explicit(&forces[3 * atom_i + 0], fx, memory_order_relaxed);
+    atomic_fetch_add_explicit(&forces[3 * atom_i + 1], fy, memory_order_relaxed);
+    atomic_fetch_add_explicit(&forces[3 * atom_i + 2], fz, memory_order_relaxed);
+    atomic_fetch_add_explicit(&forces[3 * atom_j + 0], -fx, memory_order_relaxed);
+    atomic_fetch_add_explicit(&forces[3 * atom_j + 1], -fy, memory_order_relaxed);
+    atomic_fetch_add_explicit(&forces[3 * atom_j + 2], -fz, memory_order_relaxed);
+"""
 
 _PME_CUTOFF_CORRECTION_VIRIAL_SOURCE = r"""
     uint t = thread_position_in_grid.x;
@@ -1266,6 +1556,224 @@ _NEIGHBOR_PAIR_ORDERED_SCATTER_SOURCE = r"""
     int j = pairs_j[t];
     accepted_i[out] = min(i, j);
     accepted_j[out] = max(i, j);
+"""
+
+_NEIGHBOR_CELL_TILE_CANDIDATES_SOURCE = r"""
+    uint task = thread_position_in_grid.x;
+    if (task >= (uint)counts[0]) {
+        return;
+    }
+
+    int left_cell = cell_pairs[2 * task + 0];
+    int right_cell = cell_pairs[2 * task + 1];
+    int left_start = cell_block_starts[left_cell];
+    int right_start = cell_block_starts[right_cell];
+    int left_count = cell_block_counts[left_cell];
+    int right_count = cell_block_counts[right_cell];
+    int output = task_offsets[task];
+
+    if (left_cell == right_cell) {
+        for (int left = 0; left < left_count; left++) {
+            for (int right = left; right < right_count; right++) {
+                tile_left[output] = left_start + left;
+                tile_right[output] = right_start + right;
+                output++;
+            }
+        }
+        return;
+    }
+
+    for (int left = 0; left < left_count; left++) {
+        for (int right = 0; right < right_count; right++) {
+            tile_left[output] = left_start + left;
+            tile_right[output] = right_start + right;
+            output++;
+        }
+    }
+"""
+
+_NEIGHBOR_TILE_MEMBERSHIP_SOURCE = r"""
+    uint lane = thread_position_in_threadgroup.x;
+    uint tile = threadgroup_position_in_grid.x;
+    uint left_slot = lane >> 3;
+    uint right_slot = lane & 7u;
+    threadgroup uint active[64];
+
+    int left_block = tile_blocks[2 * tile + 0];
+    int right_block = tile_blocks[2 * tile + 1];
+    int atom_i = atom_blocks[8 * left_block + left_slot];
+    int atom_j = atom_blocks[8 * right_block + right_slot];
+    bool valid = atom_i >= 0 && atom_j >= 0;
+    if (left_block == right_block) {
+        valid = valid && left_slot < right_slot;
+    }
+    bool close = false;
+    if (valid) {
+        float dx = positions[3 * atom_i + 0] - positions[3 * atom_j + 0];
+        float dy = positions[3 * atom_i + 1] - positions[3 * atom_j + 1];
+        float dz = positions[3 * atom_i + 2] - positions[3 * atom_j + 2];
+        dx -= box[0] * rint(dx / box[0]);
+        dy -= box[1] * rint(dy / box[1]);
+        dz -= box[2] * rint(dz / box[2]);
+        close = dx * dx + dy * dy + dz * dz < params[0];
+    }
+    active[lane] = close ? 1u : 0u;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (lane < 2u) {
+        uint word = 0u;
+        uint base = 32u * lane;
+        for (uint bit = 0u; bit < 32u; bit++) {
+            word |= active[base + bit] << bit;
+        }
+        member_mask[2 * tile + lane] = word;
+    }
+    if (lane == 0u) {
+        int total = 0;
+        for (uint index = 0u; index < 64u; index++) {
+            total += (int)active[index];
+        }
+        member_counts[tile] = total;
+    }
+"""
+
+_NEIGHBOR_TILE_ORDERED_SCATTER_SOURCE = r"""
+    uint tile = thread_position_in_grid.x;
+    if (tile >= (uint)counts[0] || member_counts[tile] == 0) {
+        return;
+    }
+    uint output = (uint)(prefix[tile] - 1);
+    accepted_tile_blocks[2 * output + 0] = tile_blocks[2 * tile + 0];
+    accepted_tile_blocks[2 * output + 1] = tile_blocks[2 * tile + 1];
+    accepted_member_mask[2 * output + 0] = member_mask[2 * tile + 0];
+    accepted_member_mask[2 * output + 1] = member_mask[2 * tile + 1];
+"""
+
+_NEIGHBOR_TILE_FORCE_GROUPS_SOURCE = r"""
+    uint block = thread_position_in_grid.x;
+    if (block >= (uint)counts[0] || tile_counts[block] == 0) {
+        return;
+    }
+
+    int tile_count = tile_counts[block];
+    int tile_start = tile_prefix[block] - tile_count;
+    int group_count = group_counts[block];
+    int group_start = group_prefix[block] - group_count;
+    int tiles_per_group = counts[1];
+    for (int local = 0; local < group_count; local++) {
+        int consumed = local * tiles_per_group;
+        int output = group_start + local;
+        force_group_starts[output] = tile_start + consumed;
+        force_group_counts[output] = min(tiles_per_group, tile_count - consumed);
+    }
+"""
+
+_NEIGHBOR_TILE_PAIR_SCATTER_SOURCE = r"""
+    uint lane = thread_position_in_threadgroup.x;
+    uint tile = threadgroup_position_in_grid.x;
+    uint word_index = lane >> 5;
+    uint bit_index = lane & 31u;
+    threadgroup uint scan[64];
+
+    uint word = member_mask[2 * tile + word_index];
+    uint active = (word >> bit_index) & 1u;
+    scan[lane] = active;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint offset = 1u; offset < 64u; offset <<= 1u) {
+        uint addend = lane >= offset ? scan[lane - offset] : 0u;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        scan[lane] += addend;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (active == 0u) {
+        return;
+    }
+
+    uint base = (uint)(member_prefix[tile] - member_counts[tile]);
+    uint output = base + scan[lane] - 1u;
+    int left_block = tile_blocks[2 * tile + 0];
+    int right_block = tile_blocks[2 * tile + 1];
+    int atom_i = atom_blocks[8 * left_block + (lane >> 3)];
+    int atom_j = atom_blocks[8 * right_block + (lane & 7u)];
+    accepted_i[output] = min(atom_i, atom_j);
+    accepted_j[output] = max(atom_i, atom_j);
+"""
+
+_TILE_TOPOLOGY_LJ_MASKS_SOURCE = r"""
+    uint lane = thread_position_in_threadgroup.x;
+    uint tile = threadgroup_position_in_grid.x;
+    uint word_index = lane >> 5;
+    uint bit_index = lane & 31u;
+    threadgroup uint enabled[64];
+    threadgroup uint one_four[64];
+
+    uint member_word = member_mask[2 * tile + word_index];
+    bool member = ((member_word >> bit_index) & 1u) != 0u;
+    int left_block = tile_blocks[2 * tile + 0];
+    int right_block = tile_blocks[2 * tile + 1];
+    int atom_i = atom_blocks[8 * left_block + (lane >> 3)];
+    int atom_j = atom_blocks[8 * right_block + (lane & 7u)];
+    int left = min(atom_i, atom_j);
+    int right = max(atom_i, atom_j);
+
+    bool excluded = false;
+    if (member) {
+        int lower = 0;
+        int upper = counts[1];
+        while (lower < upper) {
+            int middle = lower + (upper - lower) / 2;
+            int known_left = excluded_i[middle];
+            int known_right = excluded_j[middle];
+            if (
+                known_left < left
+                || (known_left == left && known_right < right)
+            ) {
+                lower = middle + 1;
+            } else {
+                upper = middle;
+            }
+        }
+        excluded = lower < counts[1]
+            && excluded_i[lower] == left
+            && excluded_j[lower] == right;
+    }
+
+    bool scaled = false;
+    if (member && !excluded && counts[2] > 0) {
+        int lower = 0;
+        int upper = counts[2];
+        while (lower < upper) {
+            int middle = lower + (upper - lower) / 2;
+            int known_left = one_four_i[middle];
+            int known_right = one_four_j[middle];
+            if (
+                known_left < left
+                || (known_left == left && known_right < right)
+            ) {
+                lower = middle + 1;
+            } else {
+                upper = middle;
+            }
+        }
+        scaled = lower < counts[2]
+            && one_four_i[lower] == left
+            && one_four_j[lower] == right;
+    }
+    enabled[lane] = member && !excluded ? 1u : 0u;
+    one_four[lane] = scaled ? 1u : 0u;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (lane < 2u) {
+        uint enabled_word = 0u;
+        uint one_four_word = 0u;
+        uint base = 32u * lane;
+        for (uint bit = 0u; bit < 32u; bit++) {
+            enabled_word |= enabled[base + bit] << bit;
+            one_four_word |= one_four[base + bit] << bit;
+        }
+        lj_enabled_mask[2 * tile + lane] = enabled_word;
+        lj_one_four_mask[2 * tile + lane] = one_four_word;
+    }
 """
 
 _CONSTRAINT_HEADER = r"""
@@ -1829,6 +2337,61 @@ def _prepared_pme_direct_force_only_kernel():
     return _prepared_pme_direct_force_only_kernel_singleton
 
 
+def _tile_pme_direct_force_only_kernel():
+    """Return the cached spatial 8x8 tile direct-force kernel."""
+
+    global _tile_pme_direct_force_only_kernel_singleton
+    if _tile_pme_direct_force_only_kernel_singleton is None:
+        _tile_pme_direct_force_only_kernel_singleton = mx.fast.metal_kernel(
+            name="spatial_tile_prepared_parameterized_pme_direct_force_only",
+            input_names=[
+                "positions",
+                "atom_blocks",
+                "tile_blocks",
+                "member_mask",
+                "lj_enabled_mask",
+                "lj_one_four_mask",
+                "force_group_starts",
+                "force_group_counts",
+                "box",
+                "half_sigma",
+                "sqrt_epsilon",
+                "charges",
+                "params",
+            ],
+            output_names=["forces"],
+            source=_TILE_PREPARED_PME_DIRECT_FORCE_ONLY_SOURCE,
+            header=_ERF_HEADER,
+            atomic_outputs=True,
+        )
+    return _tile_pme_direct_force_only_kernel_singleton
+
+
+def _sparse_pme_correction_force_only_kernel():
+    """Return the cached fused sparse PME-correction force kernel."""
+
+    global _sparse_pme_correction_force_only_kernel_singleton
+    if _sparse_pme_correction_force_only_kernel_singleton is None:
+        _sparse_pme_correction_force_only_kernel_singleton = mx.fast.metal_kernel(
+            name="sparse_pme_correction_force_only",
+            input_names=[
+                "positions",
+                "pairs_i",
+                "pairs_j",
+                "box",
+                "charge_products",
+                "lj_sigma",
+                "lj_epsilon",
+                "params",
+                "npair",
+            ],
+            output_names=["forces"],
+            source=_SPARSE_PME_CORRECTION_FORCE_ONLY_SOURCE,
+            atomic_outputs=True,
+        )
+    return _sparse_pme_correction_force_only_kernel_singleton
+
+
 def _parameterized_pme_direct_virial_kernel():
     """Return the cached diagnostic fused LJ/PME-direct virial kernel."""
 
@@ -2010,6 +2573,123 @@ def _neighbor_pair_ordered_scatter_kernel():
             source=_NEIGHBOR_PAIR_ORDERED_SCATTER_SOURCE,
         )
     return _neighbor_pair_ordered_scatter_kernel_singleton
+
+
+def _neighbor_cell_tile_candidates_kernel():
+    """Return the cached spatial cell-block tile-emission kernel."""
+
+    global _neighbor_cell_tile_candidates_kernel_singleton
+    if _neighbor_cell_tile_candidates_kernel_singleton is None:
+        _neighbor_cell_tile_candidates_kernel_singleton = mx.fast.metal_kernel(
+            name="neighbor_cell_tile_candidates",
+            input_names=[
+                "cell_block_starts",
+                "cell_block_counts",
+                "cell_pairs",
+                "task_offsets",
+                "counts",
+            ],
+            output_names=["tile_left", "tile_right"],
+            source=_NEIGHBOR_CELL_TILE_CANDIDATES_SOURCE,
+        )
+    return _neighbor_cell_tile_candidates_kernel_singleton
+
+
+def _neighbor_tile_membership_kernel():
+    """Return the cached exact spatial-tile membership kernel."""
+
+    global _neighbor_tile_membership_kernel_singleton
+    if _neighbor_tile_membership_kernel_singleton is None:
+        _neighbor_tile_membership_kernel_singleton = mx.fast.metal_kernel(
+            name="neighbor_tile_membership",
+            input_names=["positions", "atom_blocks", "tile_blocks", "box", "params"],
+            output_names=["member_mask", "member_counts"],
+            source=_NEIGHBOR_TILE_MEMBERSHIP_SOURCE,
+        )
+    return _neighbor_tile_membership_kernel_singleton
+
+
+def _neighbor_tile_ordered_scatter_kernel():
+    """Return the cached non-empty spatial-tile compaction kernel."""
+
+    global _neighbor_tile_ordered_scatter_kernel_singleton
+    if _neighbor_tile_ordered_scatter_kernel_singleton is None:
+        _neighbor_tile_ordered_scatter_kernel_singleton = mx.fast.metal_kernel(
+            name="neighbor_tile_ordered_scatter",
+            input_names=[
+                "tile_blocks",
+                "member_mask",
+                "member_counts",
+                "prefix",
+                "counts",
+            ],
+            output_names=["accepted_tile_blocks", "accepted_member_mask"],
+            source=_NEIGHBOR_TILE_ORDERED_SCATTER_SOURCE,
+        )
+    return _neighbor_tile_ordered_scatter_kernel_singleton
+
+
+def _neighbor_tile_force_groups_kernel():
+    """Return the cached spatial-tile force-group schedule kernel."""
+
+    global _neighbor_tile_force_groups_kernel_singleton
+    if _neighbor_tile_force_groups_kernel_singleton is None:
+        _neighbor_tile_force_groups_kernel_singleton = mx.fast.metal_kernel(
+            name="neighbor_tile_force_groups",
+            input_names=[
+                "tile_counts",
+                "tile_prefix",
+                "group_counts",
+                "group_prefix",
+                "counts",
+            ],
+            output_names=["force_group_starts", "force_group_counts"],
+            source=_NEIGHBOR_TILE_FORCE_GROUPS_SOURCE,
+        )
+    return _neighbor_tile_force_groups_kernel_singleton
+
+
+def _neighbor_tile_pair_scatter_kernel():
+    """Return the cached tile-membership diagnostic-pair decoder."""
+
+    global _neighbor_tile_pair_scatter_kernel_singleton
+    if _neighbor_tile_pair_scatter_kernel_singleton is None:
+        _neighbor_tile_pair_scatter_kernel_singleton = mx.fast.metal_kernel(
+            name="neighbor_tile_pair_scatter",
+            input_names=[
+                "atom_blocks",
+                "tile_blocks",
+                "member_mask",
+                "member_counts",
+                "member_prefix",
+            ],
+            output_names=["accepted_i", "accepted_j"],
+            source=_NEIGHBOR_TILE_PAIR_SCATTER_SOURCE,
+        )
+    return _neighbor_tile_pair_scatter_kernel_singleton
+
+
+def _tile_topology_lj_masks_kernel():
+    """Return the cached tile-aligned topology-mask kernel."""
+
+    global _tile_topology_lj_masks_kernel_singleton
+    if _tile_topology_lj_masks_kernel_singleton is None:
+        _tile_topology_lj_masks_kernel_singleton = mx.fast.metal_kernel(
+            name="tile_topology_lj_masks",
+            input_names=[
+                "atom_blocks",
+                "tile_blocks",
+                "member_mask",
+                "excluded_i",
+                "excluded_j",
+                "one_four_i",
+                "one_four_j",
+                "counts",
+            ],
+            output_names=["lj_enabled_mask", "lj_one_four_mask"],
+            source=_TILE_TOPOLOGY_LJ_MASKS_SOURCE,
+        )
+    return _tile_topology_lj_masks_kernel_singleton
 
 
 def _shake_cluster_position_kernel():
@@ -2268,6 +2948,312 @@ def _neighbor_cell_pair_candidates(
         threadgroup=(threads, 1, 1),
     )
     return pairs_i, pairs_j
+
+
+def _neighbor_cell_tile_candidates(
+    cell_block_starts: mx.array,
+    cell_block_counts: mx.array,
+    cell_pairs: mx.array,
+    task_offsets: mx.array,
+    *,
+    candidate_count: int,
+) -> mx.array:
+    """Emit spatial block-pair tile candidates on Metal."""
+
+    cell_block_starts = as_mx_array(cell_block_starts, dtype=mx.int32)
+    cell_block_counts = as_mx_array(cell_block_counts, dtype=mx.int32)
+    cell_pairs = as_mx_array(cell_pairs, dtype=mx.int32)
+    task_offsets = as_mx_array(task_offsets, dtype=mx.int32)
+    if (
+        cell_block_starts.ndim != 1
+        or cell_block_counts.shape != cell_block_starts.shape
+    ):
+        msg = "cell block starts and counts must have matching one-dimensional shapes"
+        raise ValueError(msg)
+    if cell_pairs.ndim != 2 or cell_pairs.shape[1] != 2:
+        msg = "cell_pairs must have shape (n_tasks, 2)"
+        raise ValueError(msg)
+    if task_offsets.shape != (cell_pairs.shape[0],):
+        msg = "task_offsets must contain one output offset per cell-pair task"
+        raise ValueError(msg)
+    if candidate_count < 0:
+        msg = "candidate_count must be non-negative"
+        raise ValueError(msg)
+    task_count = int(cell_pairs.shape[0])
+    if task_count == 0 or candidate_count == 0:
+        return mx.zeros((0, 2), dtype=mx.int32)
+    threads = min(256, task_count)
+    tile_left, tile_right = _neighbor_cell_tile_candidates_kernel()(
+        inputs=[
+            cell_block_starts,
+            cell_block_counts,
+            cell_pairs,
+            task_offsets,
+            mx.array([task_count], dtype=mx.int32),
+        ],
+        output_shapes=[(candidate_count,), (candidate_count,)],
+        output_dtypes=[mx.int32, mx.int32],
+        grid=(task_count, 1, 1),
+        threadgroup=(threads, 1, 1),
+    )
+    return mx.stack((tile_left, tile_right), axis=1)
+
+
+def _neighbor_tile_membership(
+    positions: mx.array,
+    atom_blocks: mx.array,
+    tile_blocks: mx.array,
+    box_lengths: mx.array,
+    *,
+    search_radius: float,
+) -> tuple[mx.array, mx.array]:
+    """Encode exact cutoff-plus-skin membership for spatial 8x8 tiles."""
+
+    positions = as_mx_array(positions, dtype=mx.float32)
+    atom_blocks = as_mx_array(atom_blocks, dtype=mx.int32)
+    tile_blocks = as_mx_array(tile_blocks, dtype=mx.int32)
+    box_lengths = as_mx_array(box_lengths, dtype=mx.float32)
+    if positions.ndim != 2 or positions.shape[1] != 3:
+        msg = "positions must have shape (n_atoms, 3)"
+        raise ValueError(msg)
+    if atom_blocks.ndim != 2 or atom_blocks.shape[1] != _TILE_PME_BLOCK_SIZE:
+        msg = "atom_blocks must have shape (n_blocks, 8)"
+        raise ValueError(msg)
+    if tile_blocks.ndim != 2 or tile_blocks.shape[1] != 2:
+        msg = "tile_blocks must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    if box_lengths.shape != (3,):
+        msg = "box_lengths must have shape (3,)"
+        raise ValueError(msg)
+    if not isfinite(float(search_radius)) or float(search_radius) <= 0.0:
+        msg = "search_radius must be finite and positive"
+        raise ValueError(msg)
+    tile_count = int(tile_blocks.shape[0])
+    if tile_count == 0:
+        return (
+            mx.zeros((0, 2), dtype=mx.uint32),
+            mx.zeros((0,), dtype=mx.int32),
+        )
+    member_mask, member_counts = _neighbor_tile_membership_kernel()(
+        inputs=[
+            positions,
+            atom_blocks,
+            tile_blocks,
+            box_lengths,
+            mx.array([float(search_radius) ** 2], dtype=mx.float32),
+        ],
+        output_shapes=[(tile_count, 2), (tile_count,)],
+        output_dtypes=[mx.uint32, mx.int32],
+        grid=(tile_count * _TILE_PME_LANES_PER_TILE, 1, 1),
+        threadgroup=(_TILE_MEMBERSHIP_THREADGROUP_SIZE, 1, 1),
+        init_value=0,
+    )
+    return member_mask, member_counts
+
+
+def _neighbor_tile_ordered_scatter_sized(
+    tile_blocks: mx.array,
+    member_mask: mx.array,
+    member_counts: mx.array,
+    prefix: mx.array,
+    *,
+    accepted_count: int,
+) -> tuple[mx.array, mx.array]:
+    """Compact non-empty spatial tiles into explicitly sized outputs."""
+
+    tile_blocks = as_mx_array(tile_blocks, dtype=mx.int32)
+    member_mask = as_mx_array(member_mask, dtype=mx.uint32)
+    member_counts = as_mx_array(member_counts, dtype=mx.int32)
+    prefix = as_mx_array(prefix, dtype=mx.int32)
+    tile_count = int(tile_blocks.shape[0])
+    if tile_blocks.ndim != 2 or tile_blocks.shape[1] != 2:
+        msg = "tile_blocks must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    if member_mask.shape != (tile_count, 2):
+        msg = "member_mask must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    if member_counts.shape != (tile_count,) or prefix.shape != (tile_count,):
+        msg = "member_counts and prefix must contain one value per tile"
+        raise ValueError(msg)
+    if accepted_count < 0 or accepted_count > tile_count:
+        msg = "accepted_count must fit within the candidate tile count"
+        raise ValueError(msg)
+    if accepted_count == 0:
+        return (
+            mx.zeros((0, 2), dtype=mx.int32),
+            mx.zeros((0, 2), dtype=mx.uint32),
+        )
+    accepted_tiles, accepted_mask = _neighbor_tile_ordered_scatter_kernel()(
+        inputs=[
+            tile_blocks,
+            member_mask,
+            member_counts,
+            prefix,
+            mx.array([tile_count], dtype=mx.int32),
+        ],
+        output_shapes=[(accepted_count, 2), (accepted_count, 2)],
+        output_dtypes=[mx.int32, mx.uint32],
+        grid=(tile_count, 1, 1),
+        threadgroup=(min(256, tile_count), 1, 1),
+        init_value=0,
+    )
+    return accepted_tiles, accepted_mask
+
+
+def _neighbor_tile_force_groups_sized(
+    tile_counts: mx.array,
+    tile_prefix: mx.array,
+    group_counts: mx.array,
+    group_prefix: mx.array,
+    *,
+    accepted_count: int,
+    tiles_per_group: int,
+) -> tuple[mx.array, mx.array]:
+    """Build contiguous same-left-block force groups from tile row counts."""
+
+    tile_counts = as_mx_array(tile_counts, dtype=mx.int32)
+    tile_prefix = as_mx_array(tile_prefix, dtype=mx.int32)
+    group_counts = as_mx_array(group_counts, dtype=mx.int32)
+    group_prefix = as_mx_array(group_prefix, dtype=mx.int32)
+    block_count = int(tile_counts.shape[0])
+    if any(
+        values.shape != (block_count,)
+        for values in (tile_prefix, group_counts, group_prefix)
+    ):
+        msg = "tile and group counts/prefixes must have matching one-dimensional shapes"
+        raise ValueError(msg)
+    if tiles_per_group <= 0:
+        msg = "tiles_per_group must be positive"
+        raise ValueError(msg)
+    if accepted_count < 0:
+        msg = "accepted_count must be non-negative"
+        raise ValueError(msg)
+    if accepted_count == 0:
+        empty = mx.zeros((0,), dtype=mx.int32)
+        return empty, empty
+    force_group_starts, force_group_sizes = _neighbor_tile_force_groups_kernel()(
+        inputs=[
+            tile_counts,
+            tile_prefix,
+            group_counts,
+            group_prefix,
+            mx.array([block_count, tiles_per_group], dtype=mx.int32),
+        ],
+        output_shapes=[(accepted_count,), (accepted_count,)],
+        output_dtypes=[mx.int32, mx.int32],
+        grid=(block_count, 1, 1),
+        threadgroup=(min(256, block_count), 1, 1),
+        init_value=0,
+    )
+    return force_group_starts, force_group_sizes
+
+
+def _neighbor_tile_member_pairs_sized(
+    atom_blocks: mx.array,
+    tile_blocks: mx.array,
+    member_mask: mx.array,
+    member_counts: mx.array,
+    member_prefix: mx.array,
+    *,
+    accepted_count: int,
+) -> mx.array:
+    """Decode diagnostic pairs from already-computed tile membership."""
+
+    atom_blocks = as_mx_array(atom_blocks, dtype=mx.int32)
+    tile_blocks = as_mx_array(tile_blocks, dtype=mx.int32)
+    member_mask = as_mx_array(member_mask, dtype=mx.uint32)
+    member_counts = as_mx_array(member_counts, dtype=mx.int32)
+    member_prefix = as_mx_array(member_prefix, dtype=mx.int32)
+    tile_count = int(tile_blocks.shape[0])
+    if atom_blocks.ndim != 2 or atom_blocks.shape[1] != _TILE_PME_BLOCK_SIZE:
+        msg = "atom_blocks must have shape (n_blocks, 8)"
+        raise ValueError(msg)
+    if tile_blocks.ndim != 2 or tile_blocks.shape[1] != 2:
+        msg = "tile_blocks must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    if member_mask.shape != (tile_count, 2):
+        msg = "member_mask must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    if member_counts.shape != (tile_count,) or member_prefix.shape != (tile_count,):
+        msg = "member counts and prefix must contain one value per tile"
+        raise ValueError(msg)
+    if accepted_count < 0 or (tile_count == 0 and accepted_count != 0):
+        msg = "accepted_count is incompatible with tile membership"
+        raise ValueError(msg)
+    if accepted_count == 0:
+        return mx.zeros((0, 2), dtype=mx.int32)
+    accepted_i, accepted_j = _neighbor_tile_pair_scatter_kernel()(
+        inputs=[
+            atom_blocks,
+            tile_blocks,
+            member_mask,
+            member_counts,
+            member_prefix,
+        ],
+        output_shapes=[(accepted_count,), (accepted_count,)],
+        output_dtypes=[mx.int32, mx.int32],
+        grid=(tile_count * _TILE_PME_LANES_PER_TILE, 1, 1),
+        threadgroup=(_TILE_MEMBERSHIP_THREADGROUP_SIZE, 1, 1),
+        init_value=0,
+    )
+    return mx.stack((accepted_i, accepted_j), axis=1)
+
+
+def tile_topology_lj_masks(
+    atom_blocks: mx.array,
+    tile_blocks: mx.array,
+    member_mask: mx.array,
+    excluded_pairs: mx.array,
+    one_four_pairs: mx.array,
+) -> tuple[mx.array, mx.array]:
+    """Build tile-aligned LJ eligibility and 1-4 masks on Metal."""
+
+    atom_blocks = as_mx_array(atom_blocks, dtype=mx.int32)
+    tile_blocks = as_mx_array(tile_blocks, dtype=mx.int32)
+    member_mask = as_mx_array(member_mask, dtype=mx.uint32)
+    excluded_pairs = as_mx_array(excluded_pairs, dtype=mx.int32)
+    one_four_pairs = as_mx_array(one_four_pairs, dtype=mx.int32)
+    if atom_blocks.ndim != 2 or atom_blocks.shape[1] != _TILE_PME_BLOCK_SIZE:
+        msg = "atom_blocks must have shape (n_blocks, 8)"
+        raise ValueError(msg)
+    if tile_blocks.ndim != 2 or tile_blocks.shape[1] != 2:
+        msg = "tile_blocks must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    tile_count = int(tile_blocks.shape[0])
+    if member_mask.shape != (tile_count, 2):
+        msg = "member_mask must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    for name, values in (
+        ("excluded_pairs", excluded_pairs),
+        ("one_four_pairs", one_four_pairs),
+    ):
+        if values.ndim != 2 or values.shape[1] != 2:
+            msg = f"{name} must have shape (n, 2)"
+            raise ValueError(msg)
+    if tile_count == 0:
+        empty = mx.zeros((0, 2), dtype=mx.uint32)
+        return empty, empty
+    enabled_mask, one_four_mask = _tile_topology_lj_masks_kernel()(
+        inputs=[
+            atom_blocks,
+            tile_blocks,
+            member_mask,
+            excluded_pairs[:, 0],
+            excluded_pairs[:, 1],
+            one_four_pairs[:, 0],
+            one_four_pairs[:, 1],
+            mx.array(
+                [tile_count, int(excluded_pairs.shape[0]), int(one_four_pairs.shape[0])],
+                dtype=mx.int32,
+            ),
+        ],
+        output_shapes=[(tile_count, 2), (tile_count, 2)],
+        output_dtypes=[mx.uint32, mx.uint32],
+        grid=(tile_count * _TILE_PME_LANES_PER_TILE, 1, 1),
+        threadgroup=(_TILE_MEMBERSHIP_THREADGROUP_SIZE, 1, 1),
+        init_value=0,
+    )
+    return enabled_mask, one_four_mask
 
 
 def neighbor_pair_ordered_scatter(
@@ -3659,6 +4645,205 @@ def _prepared_parameterized_pme_direct_force_only(
         output_dtypes=[mx.float32],
         grid=(worker_count, 1, 1),
         threadgroup=(threads, 1, 1),
+        init_value=0.0,
+    )
+    return forces
+
+
+def _tile_parameterized_pme_direct_force_only(
+    positions: mx.array,
+    atom_blocks: mx.array,
+    tile_blocks: mx.array,
+    member_mask: mx.array,
+    lj_enabled_mask: mx.array,
+    lj_one_four_mask: mx.array,
+    force_group_starts: mx.array,
+    force_group_counts: mx.array,
+    box_lengths_and_inverses: mx.array,
+    half_sigma: mx.array,
+    sqrt_epsilon: mx.array,
+    charges: mx.array,
+    *,
+    cutoff: float,
+    shift: bool,
+    switch_distance: float | None,
+    one_four_scale: float,
+    coulomb_constant: float,
+    alpha: float,
+) -> mx.array:
+    """Evaluate prepared direct forces from exact spatial 8x8 tiles."""
+
+    positions = as_mx_array(positions, dtype=mx.float32)
+    atom_blocks = as_mx_array(atom_blocks, dtype=mx.int32)
+    tile_blocks = as_mx_array(tile_blocks, dtype=mx.int32)
+    member_mask = as_mx_array(member_mask, dtype=mx.uint32)
+    lj_enabled_mask = as_mx_array(lj_enabled_mask, dtype=mx.uint32)
+    lj_one_four_mask = as_mx_array(lj_one_four_mask, dtype=mx.uint32)
+    force_group_starts = as_mx_array(force_group_starts, dtype=mx.int32)
+    force_group_counts = as_mx_array(force_group_counts, dtype=mx.int32)
+    box = as_mx_array(box_lengths_and_inverses, dtype=mx.float32)
+    half_sigma = as_mx_array(half_sigma, dtype=mx.float32)
+    sqrt_epsilon = as_mx_array(sqrt_epsilon, dtype=mx.float32)
+    charges = as_mx_array(charges, dtype=mx.float32)
+    if positions.ndim != 2 or positions.shape[1] != 3:
+        msg = "positions must have shape (n_atoms, 3)"
+        raise ValueError(msg)
+    n_atoms = int(positions.shape[0])
+    if atom_blocks.ndim != 2 or atom_blocks.shape[1] != _TILE_PME_BLOCK_SIZE:
+        msg = "atom_blocks must have shape (n_blocks, 8)"
+        raise ValueError(msg)
+    if tile_blocks.ndim != 2 or tile_blocks.shape[1] != 2:
+        msg = "tile_blocks must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    tile_count = int(tile_blocks.shape[0])
+    mask_shape = (tile_count, 2)
+    if member_mask.shape != mask_shape:
+        msg = "member_mask must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    if lj_enabled_mask.shape != mask_shape or lj_one_four_mask.shape != mask_shape:
+        msg = "tile LJ masks must have shape (n_tiles, 2)"
+        raise ValueError(msg)
+    group_count = int(force_group_starts.shape[0])
+    if force_group_starts.ndim != 1 or force_group_counts.shape != (group_count,):
+        msg = "tile force group starts and counts must have matching vector shapes"
+        raise ValueError(msg)
+    if box.shape != (6,):
+        msg = "box_lengths_and_inverses must have shape (6,)"
+        raise ValueError(msg)
+    if half_sigma.shape != (n_atoms,) or sqrt_epsilon.shape != (n_atoms,):
+        msg = "prepared LJ parameters must have shape (n_atoms,)"
+        raise ValueError(msg)
+    if charges.shape != (n_atoms,):
+        msg = "charges must have shape (n_atoms,)"
+        raise ValueError(msg)
+    if cutoff is None or not isfinite(float(cutoff)) or cutoff <= 0.0:
+        msg = "tile PME direct forces require a finite positive cutoff"
+        raise ValueError(msg)
+    if not isfinite(float(alpha)) or alpha <= 0.0:
+        msg = "tile PME direct forces require finite positive alpha"
+        raise ValueError(msg)
+    if not isfinite(float(coulomb_constant)):
+        msg = "coulomb_constant must be finite"
+        raise ValueError(msg)
+    if not isfinite(float(one_four_scale)) or one_four_scale < 0.0:
+        msg = "one_four_scale must be finite and non-negative"
+        raise ValueError(msg)
+    cutoff_value = float(cutoff)
+    if switch_distance is not None and (
+        not isfinite(float(switch_distance))
+        or float(switch_distance) < 0.0
+        or float(switch_distance) >= cutoff_value
+    ):
+        msg = "switch_distance must be finite, non-negative, and below cutoff"
+        raise ValueError(msg)
+    if tile_count == 0:
+        return mx.zeros_like(positions)
+    if group_count == 0:
+        msg = "non-empty tile geometry requires at least one force group"
+        raise ValueError(msg)
+
+    has_switch = switch_distance is not None
+    switch_value = 0.0 if switch_distance is None else float(switch_distance)
+    switch_width = 1.0 if switch_distance is None else cutoff_value - switch_value
+    alpha_value = float(alpha)
+    params = mx.array(
+        [
+            cutoff_value * cutoff_value,
+            float(bool(shift)),
+            float(has_switch),
+            switch_value,
+            switch_width,
+            cutoff_value,
+            float(coulomb_constant),
+            alpha_value,
+            2.0 * alpha_value / sqrt(pi),
+            1.0 / switch_width,
+            float(one_four_scale),
+        ],
+        dtype=mx.float32,
+    )
+    (forces,) = _tile_pme_direct_force_only_kernel()(
+        inputs=[
+            positions,
+            atom_blocks,
+            tile_blocks,
+            member_mask,
+            lj_enabled_mask,
+            lj_one_four_mask,
+            force_group_starts,
+            force_group_counts,
+            box,
+            half_sigma,
+            sqrt_epsilon,
+            charges,
+            params,
+        ],
+        output_shapes=[(n_atoms, 3)],
+        output_dtypes=[mx.float32],
+        grid=(group_count * _TILE_PME_THREADGROUP_SIZE, 1, 1),
+        threadgroup=(_TILE_PME_THREADGROUP_SIZE, 1, 1),
+        init_value=0.0,
+    )
+    return forces
+
+
+def fused_sparse_pme_correction_forces(
+    positions: mx.array,
+    pairs: mx.array,
+    box_lengths_and_inverses: mx.array,
+    charge_products: mx.array,
+    lj_sigma: mx.array,
+    lj_epsilon: mx.array,
+    *,
+    coulomb_constant: float,
+) -> mx.array:
+    """Evaluate sparse PME exclusions, exceptions, and 1-4 force corrections."""
+
+    positions = as_mx_array(positions, dtype=mx.float32)
+    pairs = as_mx_array(pairs, dtype=mx.int32)
+    box = as_mx_array(box_lengths_and_inverses, dtype=mx.float32)
+    charge_products = as_mx_array(charge_products, dtype=mx.float32)
+    lj_sigma = as_mx_array(lj_sigma, dtype=mx.float32)
+    lj_epsilon = as_mx_array(lj_epsilon, dtype=mx.float32)
+    if positions.ndim != 2 or positions.shape[1] != 3:
+        msg = "positions must have shape (n_atoms, 3)"
+        raise ValueError(msg)
+    if pairs.ndim != 2 or pairs.shape[1] != 2:
+        msg = "pairs must have shape (n_pairs, 2)"
+        raise ValueError(msg)
+    pair_count = int(pairs.shape[0])
+    for name, values in (
+        ("charge_products", charge_products),
+        ("lj_sigma", lj_sigma),
+        ("lj_epsilon", lj_epsilon),
+    ):
+        if values.shape != (pair_count,):
+            msg = f"{name} must have shape (n_pairs,)"
+            raise ValueError(msg)
+    if box.shape != (6,):
+        msg = "box_lengths_and_inverses must have shape (6,)"
+        raise ValueError(msg)
+    if not isfinite(float(coulomb_constant)):
+        msg = "coulomb_constant must be finite"
+        raise ValueError(msg)
+    if pair_count == 0:
+        return mx.zeros_like(positions)
+    (forces,) = _sparse_pme_correction_force_only_kernel()(
+        inputs=[
+            positions,
+            pairs[:, 0],
+            pairs[:, 1],
+            box,
+            charge_products,
+            lj_sigma,
+            lj_epsilon,
+            mx.array([float(coulomb_constant)], dtype=mx.float32),
+            mx.array([pair_count], dtype=mx.int32),
+        ],
+        output_shapes=[positions.shape],
+        output_dtypes=[mx.float32],
+        grid=(pair_count, 1, 1),
+        threadgroup=(min(256, pair_count), 1, 1),
         init_value=0.0,
     )
     return forces

--- a/src/mlx_atomistic/neighbors.py
+++ b/src/mlx_atomistic/neighbors.py
@@ -20,7 +20,12 @@ from mlx_atomistic.cell_list import (
 from mlx_atomistic.core import Cell, as_mx_array
 from mlx_atomistic.metal_kernels import (
     _neighbor_cell_pair_candidates,
+    _neighbor_cell_tile_candidates,
     _neighbor_pair_ordered_scatter_sized,
+    _neighbor_tile_force_groups_sized,
+    _neighbor_tile_member_pairs_sized,
+    _neighbor_tile_membership,
+    _neighbor_tile_ordered_scatter_sized,
     neighbor_pair_cutoff_mask,
     neighbor_pair_ordered_scatter,
 )
@@ -50,6 +55,7 @@ DEFAULT_MLX_SPATIAL_CELL_SUBDIVISION = 3
 DEFAULT_MLX_SPATIAL_MAX_CELLS_PER_ATOM = 4
 DEFAULT_MLX_CELL_BLOCK_SIZE = 256
 DEFAULT_MLX_CELL_TILE_BLOCK_SIZE = 8
+DEFAULT_MLX_CELL_TILE_FORCE_GROUP_SIZE = 4
 DEFAULT_MLX_CELL_TILE_BATCH = 65_536
 # Default neighbor backend for systems above the dense-pair limit. Measured on
 # M5 Max (4k/16k/50k LJ, 2026-06-18): compacting candidates to real pairs
@@ -161,6 +167,8 @@ class NeighborTiles:
     member_mask: mx.array
     exact_pair_count: int
     raw_candidate_count: int
+    force_group_starts: mx.array | None = None
+    force_group_counts: mx.array | None = None
     generation: int = 0
     block_size: int = DEFAULT_MLX_CELL_TILE_BLOCK_SIZE
 
@@ -186,6 +194,58 @@ class NeighborTiles:
         if self.member_mask.dtype != mx.uint32:
             msg = "member_mask must use uint32 words"
             raise ValueError(msg)
+        if (self.force_group_starts is None) != (self.force_group_counts is None):
+            msg = "force group starts and counts must either both be present or absent"
+            raise ValueError(msg)
+        if self.force_group_starts is not None and self.force_group_counts is not None:
+            if self.force_group_starts.ndim != 1 or (
+                self.force_group_counts.shape != self.force_group_starts.shape
+            ):
+                msg = "force group starts and counts must have matching vector shapes"
+                raise ValueError(msg)
+            if (
+                self.force_group_starts.dtype != mx.int32
+                or self.force_group_counts.dtype != mx.int32
+            ):
+                msg = "force group starts and counts must use int32"
+                raise ValueError(msg)
+            group_count = int(self.force_group_starts.shape[0])
+            if self.tile_count == 0:
+                if group_count:
+                    msg = "empty tile geometry cannot contain force groups"
+                    raise ValueError(msg)
+            elif group_count == 0:
+                msg = "non-empty tile geometry requires force groups"
+                raise ValueError(msg)
+            else:
+                starts = self.force_group_starts
+                counts = self.force_group_counts
+                ends = starts + counts
+                safe_starts = mx.clip(starts, 0, self.tile_count - 1)
+                safe_ends = mx.clip(ends - 1, 0, self.tile_count - 1)
+                valid = (
+                    (starts >= 0)
+                    & (counts >= 1)
+                    & (counts <= DEFAULT_MLX_CELL_TILE_FORCE_GROUP_SIZE)
+                    & (ends <= self.tile_count)
+                    & (
+                        self.tile_blocks[safe_starts, 0]
+                        == self.tile_blocks[safe_ends, 0]
+                    )
+                )
+                schedule_valid = (
+                    mx.all(valid)
+                    & (starts[0] == 0)
+                    & (ends[-1] == self.tile_count)
+                    & mx.all(starts[1:] == ends[:-1])
+                )
+                mx.eval(schedule_valid)
+                if not bool(np.asarray(schedule_valid)):
+                    msg = (
+                        "force groups must cover tiles contiguously in same-left "
+                        "groups of at most four"
+                    )
+                    raise ValueError(msg)
         if self.exact_pair_count < 0 or self.exact_pair_count > self.padded_lane_count:
             msg = "exact_pair_count must fit within padded tile lanes"
             raise ValueError(msg)
@@ -227,6 +287,14 @@ class NeighborTiles:
         return self.tile_count * self.lanes_per_tile
 
     @property
+    def force_group_count(self) -> int:
+        """Number of same-left-block tile groups in the direct-force schedule."""
+
+        if self.force_group_starts is None:
+            return 0
+        return int(self.force_group_starts.shape[0])
+
+    @property
     def padding_waste_count(self) -> int:
         """Number of scheduled lanes that are not exact Verlet members."""
 
@@ -244,8 +312,16 @@ class NeighborTiles:
     def estimated_bytes(self) -> int:
         """Estimated persistent bytes for block, tile, and membership arrays."""
 
+        schedule_size = 0
+        if self.force_group_starts is not None and self.force_group_counts is not None:
+            schedule_size = self.force_group_starts.size + self.force_group_counts.size
         return int(
-            (self.atom_blocks.size + self.tile_blocks.size + self.member_mask.size)
+            (
+                self.atom_blocks.size
+                + self.tile_blocks.size
+                + self.member_mask.size
+                + schedule_size
+            )
             * _INT_BYTES
         )
 
@@ -626,9 +702,10 @@ class NeighborListManager:
         self.rebuild_count += 1
         self.last_max_displacement = 0.0
         self.updates_since_check = 0
-        self._cache_clear_pending = (
-            self.neighbor_list.compaction_backend == "metal_spatial_prefix_scan"
-        )
+        self._cache_clear_pending = self.neighbor_list.compaction_backend in {
+            "metal_spatial_prefix_scan",
+            "metal_spatial_tile_prefix_scan",
+        }
         return self.neighbor_list
 
     def update(self, positions) -> NeighborList:
@@ -811,6 +888,15 @@ def build_neighbor_list(
             backend = DEFAULT_LARGE_SYSTEM_NEIGHBOR_BACKEND
     if backend == "mlx_cell_pairs" and _uses_metal_device():
         return _build_mlx_spatial_cell_pair_list(
+            positions_mx,
+            cell,
+            cutoff=cutoff,
+            skin=skin,
+            search_radius=search_radius,
+            sort_pairs=sort_pairs,
+        )
+    if backend == "mlx_cell_tiles" and _uses_metal_device():
+        return _build_mlx_spatial_cell_tile_list(
             positions_mx,
             cell,
             cutoff=cutoff,
@@ -1133,6 +1219,257 @@ def _candidate_pairs_to_blocks(
         block_size=block_size,
         candidate_count=count,
         compact_pair_count=compact_pair_count,
+    )
+
+
+def _build_mlx_spatial_cell_tile_list(
+    positions_mx: mx.array,
+    cell: Cell,
+    *,
+    cutoff: float,
+    skin: float,
+    search_radius: float,
+    sort_pairs: bool,
+    subdivision: int = DEFAULT_MLX_SPATIAL_CELL_SUBDIVISION,
+) -> NeighborList:
+    """Build exact spatial 8x8 tiles with Metal membership and compaction."""
+
+    _require_orthorhombic_cell_for_compact_neighbor_backend(cell, "mlx_cell_tiles")
+    lengths_mx = as_mx_array(cell.lengths, dtype=mx.float32)
+    mx.eval(lengths_mx)
+    lengths = np.asarray(lengths_mx, dtype=np.float32)
+    if lengths.shape != (3,) or np.any(~np.isfinite(lengths)) or np.any(lengths <= 0.0):
+        msg = "cell lengths must be finite and positive"
+        raise ValueError(msg)
+    if subdivision <= 0:
+        msg = "spatial cell subdivision must be positive"
+        raise ValueError(msg)
+
+    finite = mx.all(mx.isfinite(positions_mx))
+    mx.eval(finite)
+    if not bool(np.asarray(finite)):
+        msg = "positions must be finite"
+        raise ValueError(msg)
+
+    n_atoms = int(positions_mx.shape[0])
+    lengths64 = lengths.astype(np.float64)
+    n_cells_array = _bounded_spatial_grid(
+        lengths64,
+        search_radius=search_radius,
+        subdivision=subdivision,
+        n_atoms=n_atoms,
+    )
+    n_cells = tuple(int(value) for value in n_cells_array)
+    cell_count = int(np.prod(n_cells_array.astype(np.int64)))
+    cell_widths = lengths64 / n_cells_array.astype(np.float64)
+
+    n_cells_mx = mx.array(n_cells_array, dtype=mx.int32)
+    wrapped = positions_mx - mx.floor(positions_mx / lengths_mx) * lengths_mx
+    cell_indices = mx.floor(wrapped / lengths_mx * n_cells_mx).astype(mx.int32)
+    cell_indices = mx.minimum(cell_indices, n_cells_mx - 1)
+    cell_ids = (
+        (cell_indices[:, 0] * n_cells[1] + cell_indices[:, 1]) * n_cells[2]
+        + cell_indices[:, 2]
+    )
+    sorted_atoms = mx.argsort(cell_ids).astype(mx.int32)
+    cell_counts_mx = mx.zeros((cell_count,), dtype=mx.int32).at[cell_ids].add(
+        mx.ones((n_atoms,), dtype=mx.int32)
+    )
+    mx.eval(sorted_atoms, cell_counts_mx)
+    cell_counts = np.asarray(cell_counts_mx, dtype=np.int32)
+    cell_starts = np.empty_like(cell_counts)
+    if cell_count:
+        cell_starts[0] = 0
+        np.cumsum(cell_counts[:-1], dtype=np.int64, out=cell_starts[1:])
+
+    cell_block_counts = (
+        cell_counts + DEFAULT_MLX_CELL_TILE_BLOCK_SIZE - 1
+    ) // DEFAULT_MLX_CELL_TILE_BLOCK_SIZE
+    cell_block_starts = np.empty_like(cell_block_counts)
+    if cell_count:
+        cell_block_starts[0] = 0
+        np.cumsum(
+            cell_block_counts[:-1],
+            dtype=np.int64,
+            out=cell_block_starts[1:],
+        )
+    block_count = int(np.sum(cell_block_counts, dtype=np.int64))
+    if block_count:
+        block_cells = np.repeat(
+            np.arange(cell_count, dtype=np.int32),
+            cell_block_counts,
+        )
+        block_local = np.arange(block_count, dtype=np.int32) - np.repeat(
+            cell_block_starts,
+            cell_block_counts,
+        )
+        block_cells_mx = mx.array(block_cells, dtype=mx.int32)
+        within_cell = (
+            mx.array(block_local * DEFAULT_MLX_CELL_TILE_BLOCK_SIZE, dtype=mx.int32)[
+                :, None
+            ]
+            + mx.arange(DEFAULT_MLX_CELL_TILE_BLOCK_SIZE, dtype=mx.int32)[None, :]
+        )
+        sorted_offsets = (
+            mx.array(cell_starts, dtype=mx.int32)[block_cells_mx][:, None]
+            + within_cell
+        )
+        valid = within_cell < cell_counts_mx[block_cells_mx][:, None]
+        safe_offsets = mx.minimum(sorted_offsets, n_atoms - 1)
+        atom_blocks = mx.where(
+            valid,
+            sorted_atoms[safe_offsets],
+            mx.array(-1, dtype=mx.int32),
+        ).astype(mx.int32)
+    else:
+        atom_blocks = mx.zeros(
+            (0, DEFAULT_MLX_CELL_TILE_BLOCK_SIZE),
+            dtype=mx.int32,
+        )
+
+    task_left, task_right, task_atom_candidate_counts = _spatial_cell_pair_tasks(
+        cell_counts,
+        n_cells,
+        cell_widths,
+        search_radius=search_radius,
+    )
+    left_block_counts = cell_block_counts[task_left].astype(np.int64)
+    right_block_counts = cell_block_counts[task_right].astype(np.int64)
+    task_tile_counts = left_block_counts * right_block_counts
+    same_cell = task_left == task_right
+    same_counts = left_block_counts[same_cell]
+    task_tile_counts[same_cell] = same_counts * (same_counts + 1) // 2
+    candidate_tile_count = int(np.sum(task_tile_counts, dtype=np.int64))
+    if candidate_tile_count > np.iinfo(np.int32).max:
+        msg = "spatial tile candidate count exceeds int32 capacity"
+        raise ValueError(msg)
+    task_offsets = np.empty((task_tile_counts.shape[0],), dtype=np.int32)
+    if task_offsets.size:
+        task_offsets[0] = 0
+        np.cumsum(task_tile_counts[:-1], dtype=np.int64, out=task_offsets[1:])
+    cell_pairs = np.stack((task_left, task_right), axis=1).astype(
+        np.int32,
+        copy=False,
+    )
+    candidate_tiles = _neighbor_cell_tile_candidates(
+        mx.array(cell_block_starts, dtype=mx.int32),
+        mx.array(cell_block_counts, dtype=mx.int32),
+        mx.array(cell_pairs, dtype=mx.int32),
+        mx.array(task_offsets, dtype=mx.int32),
+        candidate_count=candidate_tile_count,
+    )
+    candidate_mask, member_counts = _neighbor_tile_membership(
+        positions_mx,
+        atom_blocks,
+        candidate_tiles,
+        lengths_mx,
+        search_radius=search_radius,
+    )
+
+    if candidate_tile_count:
+        nonempty_prefix = mx.cumsum((member_counts > 0).astype(mx.int32))
+        member_prefix = mx.cumsum(member_counts)
+        mx.eval(nonempty_prefix, member_prefix)
+        tile_count = int(np.asarray(nonempty_prefix[-1]))
+        exact_pair_count = int(np.asarray(member_prefix[-1]))
+        tile_blocks, member_mask = _neighbor_tile_ordered_scatter_sized(
+            candidate_tiles,
+            candidate_mask,
+            member_counts,
+            nonempty_prefix,
+            accepted_count=tile_count,
+        )
+        # Cell-pair tasks are spatially coherent but periodic canonicalization
+        # does not guarantee monotonic block IDs. Group only the much smaller
+        # non-empty tile inventory so every force group owns one left block.
+        force_order = mx.argsort(tile_blocks[:, 0])
+        tile_blocks = tile_blocks[force_order]
+        member_mask = member_mask[force_order]
+        pairs = _neighbor_tile_member_pairs_sized(
+            atom_blocks,
+            candidate_tiles,
+            candidate_mask,
+            member_counts,
+            member_prefix,
+            accepted_count=exact_pair_count,
+        )
+        tile_counts_by_left = mx.zeros((block_count,), dtype=mx.int32).at[
+            tile_blocks[:, 0]
+        ].add(mx.ones((tile_count,), dtype=mx.int32))
+        tile_prefix_by_left = mx.cumsum(tile_counts_by_left)
+        force_groups_by_left = (
+            tile_counts_by_left + DEFAULT_MLX_CELL_TILE_FORCE_GROUP_SIZE - 1
+        ) // DEFAULT_MLX_CELL_TILE_FORCE_GROUP_SIZE
+        force_group_prefix = mx.cumsum(force_groups_by_left)
+        mx.eval(tile_prefix_by_left, force_group_prefix)
+        force_group_count = int(np.asarray(force_group_prefix[-1]))
+        force_group_starts, force_group_counts = _neighbor_tile_force_groups_sized(
+            tile_counts_by_left,
+            tile_prefix_by_left,
+            force_groups_by_left,
+            force_group_prefix,
+            accepted_count=force_group_count,
+            tiles_per_group=DEFAULT_MLX_CELL_TILE_FORCE_GROUP_SIZE,
+        )
+    else:
+        tile_count = 0
+        exact_pair_count = 0
+        tile_blocks = mx.zeros((0, 2), dtype=mx.int32)
+        member_mask = mx.zeros((0, 2), dtype=mx.uint32)
+        pairs = mx.zeros((0, 2), dtype=mx.int32)
+        force_group_starts = mx.zeros((0,), dtype=mx.int32)
+        force_group_counts = mx.zeros((0,), dtype=mx.int32)
+    if sort_pairs and exact_pair_count:
+        right_order = mx.argsort(pairs[:, 1])
+        pairs = pairs[right_order]
+        left_order = mx.argsort(pairs[:, 0])
+        pairs = pairs[left_order]
+    mx.eval(
+        atom_blocks,
+        tile_blocks,
+        member_mask,
+        force_group_starts,
+        force_group_counts,
+        pairs,
+    )
+
+    raw_candidate_count = int(np.sum(task_atom_candidate_counts, dtype=np.int64))
+    tiles = NeighborTiles(
+        atom_blocks=atom_blocks,
+        tile_blocks=tile_blocks,
+        member_mask=member_mask,
+        exact_pair_count=exact_pair_count,
+        raw_candidate_count=raw_candidate_count,
+        force_group_starts=force_group_starts,
+        force_group_counts=force_group_counts,
+    )
+    estimated_cell_list_bytes = (
+        n_atoms * (3 * _FLOAT_BYTES + 2 * _INT_BYTES)
+        + cell_count * 2 * _INT_BYTES
+    )
+    stats = PairListStats(
+        pair_count=exact_pair_count,
+        n_cells=n_cells,
+        cell_count=cell_count,
+        occupied_cell_count=int(np.count_nonzero(cell_counts)),
+        search_radius=search_radius,
+        estimated_pair_bytes=(
+            tiles.estimated_bytes + estimate_pair_list_bytes(exact_pair_count)
+        ),
+        estimated_cell_list_bytes=estimated_cell_list_bytes,
+        backend="mlx_cell_tiles",
+        representation_kind="tiles",
+        candidate_count=raw_candidate_count,
+        estimated_candidate_bytes=candidate_tile_count * (5 * _INT_BYTES),
+        compaction_backend="metal_spatial_tile_prefix_scan",
+        fallback_reason=None,
+    )
+    return NeighborList(
+        pairs,
+        cutoff=cutoff,
+        skin=skin,
+        stats=stats,
+        tiles=tiles,
     )
 
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1866,15 +1866,21 @@ def test_charged_pme_profile_combines_clean_instrumented_and_inventory(
 
     def fake_runtime_payload(**kwargs):
         profiled = kwargs["runtime_profile"]
+        backend = kwargs["neighbor_backend"]
         return {
             "passed": True,
             "state": state,
             "neighbor": {"compact_pair_count": 24},
+            "timings": {
+                "measured_seconds": (
+                    1.0 if backend == "mlx_cell_pairs" else 0.8
+                )
+            },
             "route_profile": (
                 {
                     "reconciled": True,
                     "routes": {
-                        "direct_lj_screened_coulomb": {},
+                        "direct_spatial_tiles": {},
                         "reciprocal_pme": {},
                         "neighbor_update_rebuild": {},
                         "integration_thermostat": {},
@@ -1886,6 +1892,7 @@ def test_charged_pme_profile_combines_clean_instrumented_and_inventory(
         }
 
     monkeypatch.setattr(charged_pme, "runtime_payload", fake_runtime_payload)
+    monkeypatch.setattr(charged_pme, "_mlx_memory_value", lambda _name: 1024)
     monkeypatch.setattr(
         charged_pme,
         "_profile_tile_inventory",
@@ -1893,6 +1900,15 @@ def test_charged_pme_profile_combines_clean_instrumented_and_inventory(
             "exact_pair_count": 24,
             "reference_pair_count": 24,
             "pair_inventory_matches": True,
+            "force_rms_delta_kj_mol_angstrom": 1.0e-4,
+            "force_max_delta_kj_mol_angstrom": 1.0e-2,
+            "active_lane_fraction": 0.5,
+            "padded_lane_count": 64,
+            "estimated_persistent_bytes": 1024,
+            "direct_speedup_fraction": 0.3,
+            "correction_force_rms_delta_kj_mol_angstrom": 1.0e-4,
+            "correction_force_max_delta_kj_mol_angstrom": 1.0e-2,
+            "correction_speedup_fraction": 0.25,
         },
     )
 
@@ -1909,10 +1925,88 @@ def test_charged_pme_profile_combines_clean_instrumented_and_inventory(
 
     assert payload["passed"] is True
     assert payload["checks"]["route_profile_reconciled"] is True
+    assert payload["checks"]["complete_wall_speedup"] is True
+    assert payload["checks"]["compact_pair_fallback_absent"] is True
+    assert payload["checks"]["tile_direct_latency_speedup"] is True
+    assert payload["checks"]["correction_latency_speedup"] is True
+    assert payload["diagnostics"]["complete_wall_speedup_fraction"] == pytest.approx(
+        0.2
+    )
     assert payload["diagnostics"]["tile_pair_inventory_matches"] is True
     assert payload["diagnostics"]["tile_pair_inventory_delta"] == 0
     assert payload["openmm_admission"]["status"] == "provisional"
     assert json.loads((tmp_path / "profile.json").read_text())["passed"] is True
+
+
+def test_charged_pme_profile_rejects_complete_regression_and_pair_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    state = {
+        "potential_energy_kj_mol": -10.0,
+        "kinetic_energy_kj_mol": 2.0,
+        "total_energy_kj_mol": -8.0,
+        "temperature_k": 300.0,
+        "constraint_max_error_angstrom": 1.0e-6,
+    }
+
+    def fake_runtime_payload(**kwargs):
+        backend = kwargs["neighbor_backend"]
+        profiled = kwargs["runtime_profile"]
+        return {
+            "passed": True,
+            "state": state,
+            "timings": {
+                "measured_seconds": 1.0 if backend == "mlx_cell_pairs" else 0.95
+            },
+            "route_profile": (
+                {
+                    "reconciled": True,
+                    "routes": {
+                        "direct_spatial_tiles": {},
+                        "direct_lj_screened_coulomb": {},
+                        "reciprocal_pme": {},
+                        "neighbor_update_rebuild": {},
+                        "integration_thermostat": {},
+                    },
+                }
+                if profiled
+                else {}
+            ),
+        }
+
+    monkeypatch.setattr(charged_pme, "runtime_payload", fake_runtime_payload)
+    monkeypatch.setattr(charged_pme, "_mlx_memory_value", lambda _name: 1024)
+    monkeypatch.setattr(
+        charged_pme,
+        "_profile_tile_inventory",
+        lambda *args, **kwargs: {
+            "exact_pair_count": 24,
+            "reference_pair_count": 24,
+            "pair_inventory_matches": True,
+            "force_rms_delta_kj_mol_angstrom": 1.0e-4,
+            "force_max_delta_kj_mol_angstrom": 1.0e-2,
+            "active_lane_fraction": 0.5,
+            "padded_lane_count": 64,
+            "estimated_persistent_bytes": 1024,
+            "direct_speedup_fraction": 0.35,
+            "correction_force_rms_delta_kj_mol_angstrom": 1.0e-4,
+            "correction_force_max_delta_kj_mol_angstrom": 1.0e-2,
+            "correction_speedup_fraction": 0.25,
+        },
+    )
+
+    payload = charged_pme.profile_payload(
+        prepared=tmp_path / "prepared",
+        warmups=1,
+        steps=2,
+        seed=17,
+        out=tmp_path / "profile.json",
+    )
+
+    assert payload["passed"] is False
+    assert "complete_wall_speedup" in payload["blockers"]
+    assert "compact_pair_fallback_absent" in payload["blockers"]
 
 
 def test_charged_pme_profile_resolves_new_report_schema(tmp_path):

--- a/tests/test_fused_lj_kernel.py
+++ b/tests/test_fused_lj_kernel.py
@@ -15,6 +15,7 @@ import pytest
 
 from mlx_atomistic.constraints import SettleWaterConstraints, _ShakeClusterConstraints
 from mlx_atomistic.core import Cell
+from mlx_atomistic.force_runtime import _PreparedForcePipeline
 from mlx_atomistic.forcefields import NonbondedPotential
 from mlx_atomistic.initialize import fcc_lattice, thermal_velocities
 from mlx_atomistic.md import (
@@ -24,13 +25,20 @@ from mlx_atomistic.md import (
     simulate_nvt,
 )
 from mlx_atomistic.metal_kernels import (
+    _prepared_parameterized_pme_direct_force_only,
+    _tile_parameterized_pme_direct_force_only,
     fused_lj_forces,
     fused_parameterized_pme_direct_components,
     fused_parameterized_pme_direct_force_only,
+    fused_sparse_pme_correction_forces,
     neighbor_pair_cutoff_mask,
     neighbor_pair_ordered_scatter,
 )
-from mlx_atomistic.neighbors import NeighborListManager, build_neighbor_list
+from mlx_atomistic.neighbors import (
+    NeighborListManager,
+    NeighborTiles,
+    build_neighbor_list,
+)
 from mlx_atomistic.pme import PMEConfig
 from mlx_atomistic.topology import Topology
 
@@ -404,6 +412,14 @@ def test_spatial_neighbor_pipeline_matches_cpu_oracle_for_edge_cases(case):
         sort_pairs=True,
         backend="mlx_cell_pairs",
     )
+    tiled = build_neighbor_list(
+        positions,
+        cell,
+        cutoff=cutoff,
+        skin=0.0,
+        sort_pairs=True,
+        backend="mlx_cell_tiles",
+    )
 
     expected = np.asarray(oracle.pairs)
     observed = np.asarray(first.pairs)
@@ -413,9 +429,296 @@ def test_spatial_neighbor_pipeline_matches_cpu_oracle_for_edge_cases(case):
     }
     assert first.pair_count == len({tuple(pair) for pair in observed.tolist()})
     assert np.array_equal(np.asarray(sorted_pairs.pairs), expected)
+    assert np.array_equal(np.asarray(tiled.pairs), expected)
+    assert tiled.tiles is not None
+    assert np.array_equal(np.asarray(tiled.tiles.materialize_pairs()), expected)
+    assert tiled.tiles.force_group_starts is not None
+    assert tiled.tiles.force_group_counts is not None
     assert first.candidate_count is not None
     assert first.candidate_count >= first.pair_count
     assert first.compaction_backend == "metal_spatial_prefix_scan"
+    assert tiled.compaction_backend == "metal_spatial_tile_prefix_scan"
+
+
+@pytest.mark.gpu
+def test_spatial_tile_builder_and_direct_kernel_match_compact_pair_route():
+    """Device-built spatial tiles preserve membership, topology, and forces."""
+
+    rng = np.random.default_rng(41)
+    lattice = (
+        np.stack(np.meshgrid(np.arange(3), np.arange(3), np.arange(3)), axis=-1)
+        .reshape((-1, 3))
+        .astype(np.float32)
+    )
+    positions_np = 0.6 + 1.65 * lattice[:23]
+    positions_np += rng.uniform(-0.08, 0.08, size=positions_np.shape).astype(np.float32)
+    positions_np[0, 0] = 0.05
+    positions_np[-1, 0] = 8.95
+    positions = mx.array(positions_np, dtype=mx.float32)
+    cell = Cell.cubic(9.0)
+    pair_neighbors = build_neighbor_list(
+        positions,
+        cell,
+        cutoff=2.6,
+        skin=0.35,
+        sort_pairs=True,
+        backend="mlx_cell_pairs",
+    )
+    tile_neighbors = build_neighbor_list(
+        positions,
+        cell,
+        cutoff=2.6,
+        skin=0.35,
+        sort_pairs=True,
+        backend="mlx_cell_tiles",
+    )
+    assert tile_neighbors.tiles is not None
+    assert tile_neighbors.compaction_backend == "metal_spatial_tile_prefix_scan"
+    tile_blocks = np.asarray(tile_neighbors.tiles.tile_blocks)
+    group_starts = np.asarray(tile_neighbors.tiles.force_group_starts)
+    group_counts = np.asarray(tile_neighbors.tiles.force_group_counts)
+    group_ends = group_starts + group_counts
+    assert np.all(tile_blocks[1:, 0] >= tile_blocks[:-1, 0])
+    assert group_starts[0] == 0
+    assert np.all(group_starts[1:] == group_ends[:-1])
+    assert group_ends[-1] == tile_neighbors.tiles.tile_count
+    assert np.all(group_counts >= 1)
+    assert np.all(group_counts <= 4)
+    assert np.all(tile_blocks[group_starts, 0] == tile_blocks[group_ends - 1, 0])
+    np.testing.assert_array_equal(
+        np.asarray(tile_neighbors.diagnostic_pairs),
+        np.asarray(pair_neighbors.diagnostic_pairs),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(tile_neighbors.tiles.materialize_pairs()),
+        np.asarray(pair_neighbors.diagnostic_pairs),
+    )
+
+    sigma = rng.uniform(0.85, 1.15, size=23).astype(np.float32)
+    epsilon = rng.uniform(0.1, 0.35, size=23).astype(np.float32)
+    charges = rng.uniform(-0.45, 0.45, size=23).astype(np.float32)
+    charges -= np.mean(charges, dtype=np.float32)
+    topology = Topology.from_sequences(
+        n_atoms=23,
+        bonds=[(0, 1), (5, 6), (12, 13)],
+        one_four_pairs=[(0, 4), (5, 9)],
+        eager_nonbonded_pair_limit=0,
+    )
+    potential = NonbondedPotential(
+        sigma=sigma,
+        epsilon=epsilon,
+        charges=charges,
+        cutoff=2.6,
+        lj_shift=True,
+        switch_distance=2.1,
+        electrostatics="pme",
+        pme_config=PMEConfig(
+            mesh_shape=(16, 16, 16),
+            alpha=0.34,
+            real_cutoff=2.6,
+        ),
+        topology=topology,
+        lj_one_four_scale=0.5,
+        coulomb_one_four_scale=0.75,
+        exception_pairs=[(1, 9)],
+        exception_charge_products=[0.025],
+        exception_sigma=[1.05],
+        exception_epsilon=[0.08],
+    ).bind_pme_plan(cell)
+    tile_binding = potential._prepare_tile_force_binding(
+        cell,
+        tile_neighbors.diagnostic_pairs,
+        tile_neighbors.tiles,
+    )
+    assert tile_binding is not NotImplemented
+    assert tile_binding.tile_decline_reason is None
+    assert tile_binding.aligned_lj_scales is None
+    pair_binding = potential._prepare_force_binding(
+        cell,
+        pair_neighbors.diagnostic_pairs,
+    )
+    assert pair_binding is not NotImplemented
+
+    tile_direct = potential._direct_forces_from_binding(positions, tile_binding)
+    pair_direct = potential._direct_forces_from_binding(positions, pair_binding)
+    fused_corrections = potential._prepared_sparse_correction_forces(
+        positions,
+        tile_binding,
+    )
+    reference_corrections = potential._exception_lj_forces(
+        positions,
+        cell,
+    ) + potential._periodic_coulomb_correction_forces(
+        positions,
+        cell,
+    )
+    tile_full = potential._forces_from_binding(positions, tile_binding)
+    pair_full = potential._forces_from_binding(positions, pair_binding)
+    pipeline = _PreparedForcePipeline.prepare((potential,), cell=cell)
+    routed_forces = pipeline.bind(tile_neighbors).forces(positions)
+    mx.eval(
+        tile_direct,
+        pair_direct,
+        fused_corrections,
+        reference_corrections,
+        tile_full,
+        pair_full,
+        routed_forces,
+    )
+    np.testing.assert_allclose(
+        np.asarray(tile_direct),
+        np.asarray(pair_direct),
+        rtol=2.0e-5,
+        atol=2.0e-3,
+    )
+    np.testing.assert_allclose(
+        np.asarray(tile_full),
+        np.asarray(pair_full),
+        rtol=2.0e-5,
+        atol=2.0e-3,
+    )
+    np.testing.assert_allclose(
+        np.asarray(fused_corrections),
+        np.asarray(reference_corrections),
+        rtol=2.0e-5,
+        atol=2.0e-3,
+    )
+    np.testing.assert_allclose(
+        np.asarray(routed_forces),
+        np.asarray(pair_full),
+        rtol=2.0e-5,
+        atol=2.0e-3,
+    )
+
+
+@pytest.mark.gpu
+def test_sparse_pme_correction_uses_reference_half_box_tie_convention():
+    """Sparse correction forces match Cell.minimum_image at exactly half a box."""
+
+    positions = mx.array([[3.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=mx.float32)
+    pairs = mx.array([[0, 1]], dtype=mx.int32)
+    cell = Cell.cubic(6.0)
+    box_lengths = mx.diag(cell.matrix)
+    box = mx.concatenate((box_lengths, 1.0 / box_lengths))
+    observed = fused_sparse_pme_correction_forces(
+        positions,
+        pairs,
+        box,
+        mx.array([1.0], dtype=mx.float32),
+        mx.array([0.0], dtype=mx.float32),
+        mx.array([0.0], dtype=mx.float32),
+        coulomb_constant=1.0,
+    )
+    displacement = cell.minimum_image(positions[0] - positions[1])
+    expected_force = displacement / mx.power(mx.sum(displacement * displacement), 1.5)
+    expected = mx.stack((expected_force, -expected_force))
+    mx.eval(observed, expected)
+    np.testing.assert_allclose(np.asarray(observed), np.asarray(expected), rtol=1e-6)
+
+
+@pytest.mark.gpu
+def test_direct_plus_sparse_correction_matches_reference_at_half_box():
+    """Pair and tile PME force sums share Cell's exact half-box convention."""
+
+    positions = mx.array([[3.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=mx.float32)
+    pairs = mx.array([[0, 1]], dtype=mx.int32)
+    cell = Cell.cubic(6.0)
+    box_lengths = mx.diag(cell.matrix)
+    box = mx.concatenate((box_lengths, 1.0 / box_lengths))
+    charges = mx.array([1.0, -1.0], dtype=mx.float32)
+    alpha = 0.35
+    direct = fused_parameterized_pme_direct_force_only(
+        positions,
+        pairs,
+        box_lengths,
+        mx.ones((2,), dtype=mx.float32),
+        mx.zeros((2,), dtype=mx.float32),
+        charges,
+        mx.zeros((1,), dtype=mx.float32),
+        cutoff=3.1,
+        shift=False,
+        switch_distance=None,
+        coulomb_constant=1.0,
+        alpha=alpha,
+    )
+    prepared_direct = _prepared_parameterized_pme_direct_force_only(
+        positions,
+        pairs,
+        box,
+        mx.full((2,), 0.5, dtype=mx.float32),
+        mx.zeros((2,), dtype=mx.float32),
+        charges,
+        mx.zeros((1,), dtype=mx.float32),
+        cutoff=3.1,
+        shift=False,
+        switch_distance=None,
+        coulomb_constant=1.0,
+        alpha=alpha,
+    )
+    tile_direct = _tile_parameterized_pme_direct_force_only(
+        positions,
+        mx.array([[0, 1, -1, -1, -1, -1, -1, -1]], dtype=mx.int32),
+        mx.array([[0, 0]], dtype=mx.int32),
+        mx.array([[2, 0]], dtype=mx.uint32),
+        mx.zeros((1, 2), dtype=mx.uint32),
+        mx.zeros((1, 2), dtype=mx.uint32),
+        mx.array([0], dtype=mx.int32),
+        mx.array([1], dtype=mx.int32),
+        box,
+        mx.full((2,), 0.5, dtype=mx.float32),
+        mx.zeros((2,), dtype=mx.float32),
+        charges,
+        cutoff=3.1,
+        shift=False,
+        switch_distance=None,
+        one_four_scale=0.5,
+        coulomb_constant=1.0,
+        alpha=alpha,
+    )
+    correction = fused_sparse_pme_correction_forces(
+        positions,
+        pairs,
+        box,
+        mx.array([1.0], dtype=mx.float32),
+        mx.array([0.0], dtype=mx.float32),
+        mx.array([0.0], dtype=mx.float32),
+        coulomb_constant=1.0,
+    )
+
+    displacement = cell.minimum_image(positions[0] - positions[1])
+    r2 = mx.sum(displacement * displacement)
+    distance = mx.sqrt(r2)
+    erfc_term = 1.0 - mx.erf(alpha * distance)
+    direct_scalar = -(
+        erfc_term / (r2 * distance)
+        + (2.0 * alpha / np.sqrt(np.pi)) * mx.exp(-(alpha * alpha) * r2) / r2
+    )
+    correction_scalar = 1.0 / (r2 * distance)
+    expected_atom = (direct_scalar + correction_scalar) * displacement
+    expected = mx.stack((expected_atom, -expected_atom))
+    observed = [value + correction for value in (direct, prepared_direct, tile_direct)]
+    mx.eval(expected, *observed)
+    for value in observed:
+        np.testing.assert_allclose(np.asarray(value), np.asarray(expected), rtol=2e-6)
+
+
+@pytest.mark.gpu
+def test_neighbor_tiles_reject_invalid_force_group_schedule():
+    """Tile geometry rejects schedules that mix different left blocks."""
+
+    with pytest.raises(ValueError, match="same-left"):
+        NeighborTiles(
+            atom_blocks=mx.array(
+                [[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]],
+                dtype=mx.int32,
+            ),
+            tile_blocks=mx.array([[0, 0], [1, 1]], dtype=mx.int32),
+            member_mask=mx.array([[1, 0], [1, 0]], dtype=mx.uint32),
+            exact_pair_count=2,
+            raw_candidate_count=2,
+            force_group_starts=mx.array([0], dtype=mx.int32),
+            force_group_counts=mx.array([2], dtype=mx.int32),
+        )
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## What changed

- Build exact 8x8 neighbor tiles from spatially ordered atom blocks and schedule up to four same-left tiles per Metal threadgroup.
- Reuse the left block locally, reduce global force atomics, and fuse sparse PME exclusions, exceptions, and 1-4 corrections into one force buffer.
- Preserve compact pairs as an explicit diagnostic oracle while avoiding the unused per-pair LJ-scale allocation on admitted tile routes.
- Add route-persistence, complete pair-versus-tile A/B, memory, schedule-integrity, and half-box minimum-image gates.
- Document the bounded evidence without replacing the existing manifest-bound OpenMM comparison.

## Why

The JAC profile was dominated by repeatedly scanning roughly 60.5 million compact pairs, global atomic force writes, and separate sparse correction outputs. Earlier canonical-ID tiles improved the isolated kernel but regressed the complete trajectory. This version creates spatial blocks first, groups tiles that can reuse one endpoint, and makes complete-wall improvement the retention criterion.

## Bounded evidence

| Check | Result |
| --- | ---: |
| 75-step compact-pair median | 0.933094 s |
| 75-step spatial-tile median | 0.601954 s |
| Complete-wall improvement | 35.49% |
| Direct-force improvement | 31.20% |
| Sparse-correction improvement | 53.86% |
| Direct force RMS / max delta | 6.32e-5 / 6.71e-4 kJ/mol/A |
| Correction RMS / max delta | 4.68e-5 / 3.05e-4 kJ/mol/A |
| Maximum constraint residual | 3.51e-5 A |
| Process-tree peak | 5.69 GB; plateau passed |

The gate used the position-balanced order pairs, tiles, tiles, pairs under the 40 GB process-tree limit. No compact-pair force fallback occurred. The existing `9.7586x` OpenMM comparison remains the admitted cross-engine result; this development A/B does not publish a new ratio.

## Validation

- `uv run ruff check src tests scripts`
- Full default CPU pytest suite
- `21 passed` in `tests/test_fused_lj_kernel.py --run-gpu`
- Exact-half-box direct plus correction oracle on all Metal direct routes
- `scripts/gen_api_docs.py`: 57 pages
- `git diff --check`
