### PR TITLE
Point the site at the served custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://appautomaton.github.io/mlx-atomistic/">
-    <img src="https://appautomaton.github.io/mlx-atomistic/og.png" alt="mlx-atomistic: Apple Silicon-native molecular dynamics and DFT runtime on MLX and Metal" width="760">
+  <a href="https://appautomaton.renocrypt.com/mlx-atomistic/">
+    <img src="https://appautomaton.renocrypt.com/mlx-atomistic/og.png" alt="mlx-atomistic: Apple Silicon-native molecular dynamics and DFT runtime on MLX and Metal" width="760">
   </a>
 </p>
 
@@ -13,21 +13,21 @@
 </p>
 
 <p align="center">
-  <a href="https://appautomaton.github.io/mlx-atomistic/"><img alt="Documentation" src="https://img.shields.io/badge/docs-appautomaton.github.io-0c8c7e?style=flat-square&logo=readthedocs&logoColor=white"></a>
+  <a href="https://appautomaton.renocrypt.com/mlx-atomistic/"><img alt="Documentation" src="https://img.shields.io/badge/docs-appautomaton.renocrypt.com-0c8c7e?style=flat-square&logo=readthedocs&logoColor=white"></a>
   <a href="https://pypi.org/project/mlx-atomistic/"><img alt="PyPI" src="https://img.shields.io/pypi/v/mlx-atomistic?style=flat-square&logo=pypi&logoColor=white"></a>
   <a href="https://github.com/appautomaton/mlx-atomistic/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/appautomaton/mlx-atomistic/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="Python 3.13" src="https://img.shields.io/badge/python-3.13-3776AB?style=flat-square&logo=python&logoColor=white">
   <img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-1d1d1f?style=flat-square">
-  <a href="https://appautomaton.github.io"><img alt="Part of App Automaton" src="https://img.shields.io/badge/part%20of-App%20Automaton-0c8c7e?style=flat-square"></a>
+  <a href="https://appautomaton.renocrypt.com"><img alt="Part of App Automaton" src="https://img.shields.io/badge/part%20of-App%20Automaton-0c8c7e?style=flat-square"></a>
 </p>
 
 <p align="center">
-  <b><a href="https://appautomaton.github.io/mlx-atomistic/">Documentation</a></b> ·
-  <a href="https://appautomaton.github.io/mlx-atomistic/overview/">Overview</a> ·
-  <a href="https://appautomaton.github.io/mlx-atomistic/mm/molecular-mechanics/">Molecular mechanics</a> ·
-  <a href="https://appautomaton.github.io/mlx-atomistic/dft/dft-scf-core/">DFT</a> ·
-  <a href="https://appautomaton.github.io/mlx-atomistic/api/">API reference</a> ·
-  <a href="https://appautomaton.github.io/mlx-atomistic/benchmarks/">Benchmarks</a>
+  <b><a href="https://appautomaton.renocrypt.com/mlx-atomistic/">Documentation</a></b> ·
+  <a href="https://appautomaton.renocrypt.com/mlx-atomistic/overview/">Overview</a> ·
+  <a href="https://appautomaton.renocrypt.com/mlx-atomistic/mm/molecular-mechanics/">Molecular mechanics</a> ·
+  <a href="https://appautomaton.renocrypt.com/mlx-atomistic/dft/dft-scf-core/">DFT</a> ·
+  <a href="https://appautomaton.renocrypt.com/mlx-atomistic/api/">API reference</a> ·
+  <a href="https://appautomaton.renocrypt.com/mlx-atomistic/benchmarks/">Benchmarks</a>
 </p>
 
 ---
@@ -62,8 +62,8 @@ validation surfaces only. They never replace the MLX runtime path.
   GROMACS `.top`/`.gro` subsets, with explicit physical-unit metadata.
 - **Reference-validation ready:** OpenMM and LAMMPS surfaces are opt-in local
   validation lanes, not package/runtime dependencies.
-- **Self-documenting:** Google-style docstrings generate the [API reference](https://appautomaton.github.io/mlx-atomistic/api/)
-  and an [`llms.txt`](https://appautomaton.github.io/mlx-atomistic/llms.txt) for agentic tools.
+- **Self-documenting:** Google-style docstrings generate the [API reference](https://appautomaton.renocrypt.com/mlx-atomistic/api/)
+  and an [`llms.txt`](https://appautomaton.renocrypt.com/mlx-atomistic/llms.txt) for agentic tools.
 
 ## Quick start
 
@@ -111,13 +111,13 @@ under gitignored `results/`.
 ## Documentation
 
 The full documentation (narrative guides plus an auto-generated API reference)
-lives at **[appautomaton.github.io/mlx-atomistic](https://appautomaton.github.io/mlx-atomistic/)**:
+lives at **[appautomaton.renocrypt.com/mlx-atomistic](https://appautomaton.renocrypt.com/mlx-atomistic/)**:
 
-- [Overview](https://appautomaton.github.io/mlx-atomistic/overview/): what the runtime is and how the pieces fit.
-- [Molecular mechanics](https://appautomaton.github.io/mlx-atomistic/mm/molecular-mechanics/): topology, force-field terms, virtual sites, GBSA/OBC, soft-core λ, replica exchange.
-- [Density functional theory](https://appautomaton.github.io/mlx-atomistic/dft/dft-scf-core/): plane-wave SCF, exchange-correlation, mixing, forces.
-- [API reference](https://appautomaton.github.io/mlx-atomistic/api/): generated directly from the package docstrings.
-- [Benchmarks](https://appautomaton.github.io/mlx-atomistic/benchmarks/): validation gauntlet, stability, and performance methodology.
+- [Overview](https://appautomaton.renocrypt.com/mlx-atomistic/overview/): what the runtime is and how the pieces fit.
+- [Molecular mechanics](https://appautomaton.renocrypt.com/mlx-atomistic/mm/molecular-mechanics/): topology, force-field terms, virtual sites, GBSA/OBC, soft-core λ, replica exchange.
+- [Density functional theory](https://appautomaton.renocrypt.com/mlx-atomistic/dft/dft-scf-core/): plane-wave SCF, exchange-correlation, mixing, forces.
+- [API reference](https://appautomaton.renocrypt.com/mlx-atomistic/api/): generated directly from the package docstrings.
+- [Benchmarks](https://appautomaton.renocrypt.com/mlx-atomistic/benchmarks/): validation gauntlet, stability, and performance methodology.
 
 The narrative source lives in [`docs/`](docs/) and the site itself in [`site/`](site/).
 The API pages are regenerated from the package on every deploy, so they never drift
@@ -135,7 +135,7 @@ and reference-engine provenance, and [`docs/units.md`](docs/units.md) for the un
 
 ## Part of App Automaton
 
-mlx-atomistic is part of **[App Automaton](https://appautomaton.github.io)**, a set of
+mlx-atomistic is part of **[App Automaton](https://appautomaton.renocrypt.com)**, a set of
 open skills, harnesses, and on-device tools for engineering with AI coding agents,
 focused on local-first, Apple-Silicon-native execution.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://appautomaton.github.io/mlx-atomistic/"
+Documentation = "https://appautomaton.renocrypt.com/mlx-atomistic/"
 Source = "https://github.com/appautomaton/mlx-atomistic"
 Issues = "https://github.com/appautomaton/mlx-atomistic/issues"
 

--- a/site/README.md
+++ b/site/README.md
@@ -1,6 +1,6 @@
 # mlx-atomistic site
 
-Astro + Starlight site for https://appautomaton.github.io/mlx-atomistic.
+Astro + Starlight site for https://appautomaton.renocrypt.com/mlx-atomistic.
 
 ## Local dev
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -5,7 +5,7 @@ import starlightLlmsTxt from "starlight-llms-txt";
 import { socialHead } from "./src/seo.mjs";
 
 export default defineConfig({
-  site: "https://appautomaton.github.io",
+  site: "https://appautomaton.renocrypt.com",
   base: "/mlx-atomistic",
   trailingSlash: "ignore",
   integrations: [

--- a/site/og/card.html
+++ b/site/og/card.html
@@ -60,7 +60,7 @@
         <div class="tagline">Molecular dynamics &amp; DFT,<br />native to your Mac.</div>
         <div class="sub">An MLX + Metal runtime that drives the GPU on your machine — no CUDA, no server, no cloud.</div>
       </div>
-      <div class="foot">App&nbsp;Automaton&nbsp;·&nbsp;<b>appautomaton.github.io/mlx-atomistic</b></div>
+      <div class="foot">App&nbsp;Automaton&nbsp;·&nbsp;<b>appautomaton.renocrypt.com/mlx-atomistic</b></div>
 
       <svg class="visual" viewBox="0 0 520 630" fill="none" xmlns="http://www.w3.org/2000/svg">
         <defs>

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -45,4 +45,4 @@ Allow: /
 User-agent: CCBot
 Allow: /
 
-Sitemap: https://appautomaton.github.io/mlx-atomistic/sitemap-index.xml
+Sitemap: https://appautomaton.renocrypt.com/mlx-atomistic/sitemap-index.xml

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -534,12 +534,12 @@ const stats = [
       <div class="footer__inner">
         <span>
           mlx-atomistic · part of
-          <a href="https://appautomaton.github.io" rel="me">App&nbsp;Automaton</a>
+          <a href="https://appautomaton.renocrypt.com" rel="me">App&nbsp;Automaton</a>
         </span>
         <div class="footer__links">
           <a href="/mlx-atomistic/overview/">Docs</a>
           <a href="https://github.com/appautomaton/mlx-atomistic">GitHub</a>
-          <a href="https://appautomaton.github.io">App Automaton</a>
+          <a href="https://appautomaton.renocrypt.com">App Automaton</a>
         </div>
       </div>
     </footer>

--- a/site/src/seo.mjs
+++ b/site/src/seo.mjs
@@ -2,7 +2,7 @@
 // and src/pages/index.astro (the standalone landing page) so the structured-data
 // entity graph is defined exactly once and never drifts between pages.
 
-export const ORIGIN = "https://appautomaton.github.io";
+export const ORIGIN = "https://appautomaton.renocrypt.com";
 export const SITE = `${ORIGIN}/mlx-atomistic`;
 export const REPO = "https://github.com/appautomaton/mlx-atomistic";
 export const OG_IMAGE = `${SITE}/og.png`;


### PR DESCRIPTION
`appautomaton.github.io` 301-redirects to `appautomaton.renocrypt.com`, so every page here declared a canonical pointing at a URL that redirects straight back to it. Google worked around it by overriding the tag; Bing, LLM crawlers, and link-preview scrapers that read `og:url` literally did not.

Pure host swap — paths, structure, and content are unchanged. Covers canonical, `og:url`, `og:image`, JSON-LD, `sitemap.xml`, `robots.txt`, README links, and badges.

The GitHub repo `homepage` field has already been updated to match.