### PR TITLE
Keep the redirecting address out of the sitemap

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import sitemap from "@astrojs/sitemap";
 import starlightLlmsTxt from "starlight-llms-txt";
-import { socialHead } from "./src/seo.mjs";
+import { SITE, socialHead } from "./src/seo.mjs";
 
 export default defineConfig({
   site: "https://appautomaton.renocrypt.com",
@@ -67,6 +67,11 @@ export default defineConfig({
         },
       ],
     }),
-    sitemap(),
+    // Under trailingSlash: "ignore" the base index is emitted twice, once as
+    // /mlx-atomistic/ and once without the slash. Pages answers the slashless
+    // form with a 301 to the other, so listing it spends a crawl on an address
+    // that was never the destination. The page's own canonical has always been
+    // the slashed form; this makes the sitemap say the same thing.
+    sitemap({ filter: (page) => page !== SITE }),
   ],
 });


### PR DESCRIPTION
`trailingSlash: "ignore"` makes `@astrojs/sitemap` emit the base index twice: once as `https://appautomaton.renocrypt.com/mlx-atomistic/` and once without the trailing slash. GitHub Pages answers the slashless form with a `301` to the slashed one, so the sitemap has been handing Googlebot a redirect and asking it to spend a crawl discovering that.

Every page's `<link rel="canonical">` already names the slashed form, so this only makes the sitemap say what the pages have been saying.

## Verification

Reproduced the CI build locally, `gen_api_docs.py` through `astro build`, and diffed the emitted `sitemap-0.xml` against the one currently served:

```
1d0
< https://appautomaton.renocrypt.com/mlx-atomistic
```

93 entries become 92. Nothing else moves.

## Context

Part of a crawl-budget pass across the `appautomaton.renocrypt.com` host. Search Console currently reports 34 pages as `Crawled - currently not indexed`, most of them under `/mlx-atomistic/api/`, and 5 more as `Discovered - currently not indexed` with no crawl date at all. The subdomain has a narrow crawl budget, so addresses that resolve to a redirect are worth removing before anything else is tuned.