### PR TITLE
Stop offering the generated reference as search results

### DIFF
--- a/scripts/gen_api_docs.py
+++ b/scripts/gen_api_docs.py
@@ -282,6 +282,17 @@ def render_module(mod, order: int) -> str | None:
         f"description: API reference for {mod.path}.",
         "sidebar:",
         f"  order: {order}",
+        # These pages are signatures lifted from the source, so one reads much
+        # like the next and a search engine has already declined to index them.
+        # "follow" keeps them a normal part of the site: still crawled, still
+        # passing their links on, just not offered as search results. The hand-
+        # written index at /api/ carries no such tag and remains the one address
+        # for the reference as a whole.
+        "head:",
+        "  - tag: meta",
+        "    attrs:",
+        "      name: robots",
+        '      content: "noindex, follow"',
         "---",
         "",
     ]

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -67,11 +67,23 @@ export default defineConfig({
         },
       ],
     }),
-    // Under trailingSlash: "ignore" the base index is emitted twice, once as
-    // /mlx-atomistic/ and once without the slash. Pages answers the slashless
-    // form with a 301 to the other, so listing it spends a crawl on an address
-    // that was never the destination. The page's own canonical has always been
-    // the slashed form; this makes the sitemap say the same thing.
-    sitemap({ filter: (page) => page !== SITE }),
+    // A sitemap is a list of addresses worth indexing, so two kinds of page
+    // are kept out of it.
+    //
+    // The first is the slashless base. Under trailingSlash: "ignore" the base
+    // index is emitted twice, as /mlx-atomistic/ and again without the slash,
+    // and Pages answers the slashless form with a 301 to the other. Listing it
+    // spends a crawl on an address that was never the destination, while the
+    // page's own canonical has named the slashed form all along.
+    //
+    // The second is the generated API reference under /api/. Those pages carry
+    // noindex, and asking a crawler to fetch a page in order to be told not to
+    // index it is the whole cost with none of the benefit. They stay reachable
+    // through the sidebar and the /api/ index, which is hand-written and stays
+    // listed here.
+    sitemap({
+      filter: (page) =>
+        page !== SITE && (!page.startsWith(`${SITE}/api/`) || page === `${SITE}/api/`),
+    }),
   ],
 });

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import sitemap from "@astrojs/sitemap";
 import starlightLlmsTxt from "starlight-llms-txt";
-import { socialHead } from "./src/seo.mjs";
+import { SITE, socialHead } from "./src/seo.mjs";
 
 export default defineConfig({
   site: "https://appautomaton.renocrypt.com",
@@ -67,6 +67,11 @@ export default defineConfig({
         },
       ],
     }),
-    sitemap(),
+    // Under trailingSlash: "ignore" the base index is emitted twice, once as
+    // /mlx-atomistic/ and once without the slash. Pages answers the slashless
+    // form with a 301 to the other, so listing it spends a crawl on an address
+    // that was never the destination. The page's own canonical has always been
+    // the slashed form; this makes the sitemap say the same thing.
+    sitemap({ filter: (page) => page !== SITE }),
   ],
 });


### PR DESCRIPTION
Stacked on #30. Until that merges this PR shows both commits; afterwards it shows only its own.

## Why

Search Console reports 34 pages on `appautomaton.renocrypt.com` as **Crawled - currently not indexed**, and every example given sits under `/mlx-atomistic/api/`. That is the standard verdict on reference generated from signatures: 57 pages that read alike, none of which answers a question anyone typed. Google fetched them and decided.

Separately, 5 project pages elsewhere on the host are **Discovered - currently not indexed** with `Last crawled: N/A`, meaning they have never been fetched at all. On a subdomain this young the crawl budget is narrow, and those two reports are the same problem seen from two ends.

## What changes

- `scripts/gen_api_docs.py` emits `<meta name="robots" content="noindex, follow">` on every generated module page. Emitted by the generator, so it covers modules added later without further edits.
- `site/astro.config.mjs` drops `/api/` leaf pages from the sitemap. Asking a crawler to fetch a page in order to be told not to index it is the cost with none of the benefit.

`noindex` rather than a `robots.txt` `Disallow`: `Disallow` blocks the fetch, so the directive is never read, and the URL can still surface as a bare result. These pages stay crawlable and keep passing their links on.

## What is deliberately untouched

- `/mlx-atomistic/` landing
- the hand-written `/api/` index, which stays indexable so the reference keeps one address for "mlx-atomistic api reference"
- all 18 `/benchmarks/` pages, which carry M5 Max measurements against OpenMM and LAMMPS and are the most rankable content on the site
- `/dft/`, `/mm/`, `/foundations/`, `/overview/`, `/project/`
- `llms.txt` and `llms-full.txt`, which should keep the full API. Being useful to an agent reading the whole library is not the same question as being offered as a search result.

## Verification

Full CI build reproduced locally, `gen_api_docs.py` through `astro build`:

```
sitemap entries          93 -> 35
pages carrying noindex   57
/api/ index robots meta  absent   (intended)
benchmarks robots meta   absent   (intended)
landing robots meta      absent   (intended)
```

Only `https://appautomaton.renocrypt.com/mlx-atomistic/api/` remains in the sitemap under `/api/`.