### PR TITLE
Harden DFT and NPT capability contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Python environments and local config
 .venv/
+.uv-cache/
 .env
 .env.*
 !.env.example
@@ -60,6 +61,8 @@ tmp/
 *.hdf5
 *.xyz
 *.traj
+*.dcd
+*.xtc
 notebooks/ligand-receptor-motion/data/cache/
 notebooks/ligand-receptor-motion/data/gpcrmd-cache/
 notebooks/ligand-receptor-motion/data/gpcrmd-mlx/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,12 @@ Read this section first. These hold everywhere in the repo.
   `results/` is local generated output and gitignored. Neither is a dependency,
   package input, or build target unless a task explicitly moves that boundary.
 - Do not add heavyweight chemistry or ML packages without a concrete need.
+- For scientific and performance claims, trust evidence in this order: source
+  inputs and parsed manifests, source-bound contracts and reports, committed
+  scientific summaries, then catalog, readiness, or narrative metadata.
+- Label evidence as source, project-derived, historical-frozen, or
+  current-verified. Missing raw evidence or a source-fingerprint mismatch is
+  never current verification.
 
 ## Repository layout
 
@@ -132,6 +138,11 @@ Isolate agents that edit files in parallel into their own worktrees so changes
 never collide, then merge back through normal Git history. Keep the `vendors/`
 boundary in every worktree. Use worktrees only when parallel branch isolation is
 worth the extra setup.
+
+One coordinator worktree owns the active `.agent` lifecycle state. Parallel
+worktrees are disposable execution surfaces; do not switch branches in a
+worktree used by another active session. Serialize formal Metal and reference
+measurements even when their source edits are isolated.
 
 From the repository root:
 

--- a/docs/benchmarks/dft-performance-decisions-m5max.md
+++ b/docs/benchmarks/dft-performance-decisions-m5max.md
@@ -114,8 +114,18 @@ and numerical gate for a candidate that passes this ladder.
 | Residual-aware CholeskyQR | Skips the second pass only for a validated loose-residual basis; paired complete diagnostics reduced median wall from 56.855 to 55.384 seconds. | `6e49877` |
 | Davidson-to-density FFT reuse | Reuses the final direct-validation real-space orbitals; a complete paired diagnostic removed 24,192 FFT vector-equivalents and reduced wall by 2.61% with an identical trajectory. | `a8e0b6b` |
 | Deferred adaptive residual validation | Uses paired residuals only during inexact adaptive cycles, restores direct validation at the final tolerance, and reduced complete diagnostic wall by 7.97%. | `1c92075` |
+| Device-inclusive effective-potential timing | Replaces lazy graph-construction clocks for the independent Hartree and exchange-correlation branches with one combined materialization boundary, preserving concurrency without reporting enqueue time as device work. | `5f94bc0` |
+| Exact repeated band-point reuse | Reuses an immutable eigenspace only when an earlier path point has the exact same reduced supercell vector; requested point identity and primitive-cell unfolding remain point-specific. | `b3d009b` |
 | Scientific EOS and band gates | Separated runtime convergence from equation-of-state (EOS) and band validation; Silicon admission was later recorded against all-electron references. | `78d4b9d`, `1972dce` |
 | Hpsi stage profiler | Separates local FFT, compact scatter/gather, kinetic, and Goedecker-Teter-Hutter (GTH) pseudopotential work using stable captured inputs. Profiles are diagnostic rather than production timings. | `9cd4ef6` |
+
+The repeated-point candidate used a same-process A/B/B/A Metal diagnostic with
+the Silicon folded-path topology and a bounded two-atom fixed-density proxy.
+The three-point short path reduced exact eigensolves from three to two and mean
+wall from 42.88 to 29.34 milliseconds. The 41-point full path reduced solves
+from 41 to 39 and mean wall from 547.12 to 517.83 milliseconds. Maximum
+eigenvalue differences were zero in both profiles. These are project-derived
+retention measurements, not formal Silicon production timings.
 
 The stable 64-vector profiler attributed 72.60% of independently synchronized
 Hpsi time to the local FFT path, 23.30% to compact scatter, and 5.60% to GTH.

--- a/docs/dft-geometry-optimization.md
+++ b/docs/dft-geometry-optimization.md
@@ -14,6 +14,10 @@ from mlx_atomistic.dft import GeometryOptimizationConfig, optimize_geometry
 result = optimize_geometry(system, config=GeometryOptimizationConfig(max_steps=5))
 ```
 
+`relaxation_mode="ions"` is the only admitted mode. Requests for variable-cell
+or coupled ion/cell relaxation fail during configuration validation; they are
+not silently reduced to fixed-cell work.
+
 Each geometry step does:
 
 1. Run SCF at the current ion positions.
@@ -82,3 +86,5 @@ This milestone is still a proof-level fixed-cell relaxation workflow, not a
 chemically certified production materials optimizer. Spin/k-point diagnostics,
 nonlocal projectors, finite-difference stress, and geometry optimization exist as
 prototype surfaces; production validation and cell relaxation remain out of scope.
+Unsupported cell-relaxation modes fail closed at the public configuration
+boundary.

--- a/docs/dft-production-core.md
+++ b/docs/dft-production-core.md
@@ -52,7 +52,10 @@ non-self-consistently along a high-symmetry path.
 
 ## Stress, Relaxation, And Restart
 
-Finite-difference stress estimates diagonal orthorhombic stress by changing cell lengths and rerunning SCF. Geometry optimization remains ion-position-first by default, with config fields now prepared for cell and coupled relaxation modes.
+Finite-difference stress estimates diagonal orthorhombic stress by changing
+cell lengths and rerunning SCF. Geometry optimization supports fixed-cell ion
+relaxation only. `GeometryOptimizationConfig` rejects variable-cell and coupled
+ion/cell modes instead of silently accepting settings the optimizer cannot use.
 
 Dense SCF restart files store density, orbitals, ion positions, cell lengths, spin metadata, and Γ k-point metadata for small-system continuation workflows.
 

--- a/docs/dft-production-core.md
+++ b/docs/dft-production-core.md
@@ -31,6 +31,10 @@ Periodic SCF and bands use the MLX-native block-Davidson/Rayleigh-Ritz solver
 without building the full plane-wave Hamiltonian. Diagnostics expose residuals,
 orthonormality error, subspace work, and convergence metadata.
 
+Periodic SCF reports one device-inclusive `effective_potential` timing for the
+independent Hartree and exchange-correlation branches. They share a single MLX
+materialization boundary so phase accounting does not serialize the runtime.
+
 Adaptive periodic SCF uses paired subspace residuals only while its requested
 eigensolver tolerance is looser than the final Davidson tolerance. It restores
 direct-operator residual validation at the final tolerance, and SCF convergence

--- a/docs/production-md.md
+++ b/docs/production-md.md
@@ -43,6 +43,13 @@ continuation. GPCRmd readiness reports this runtime capability separately from
 the `npt_workload_certification` validation gap; it is not classified as
 unsupported physics. Unsupported production cases remain blockers.
 
+Project-defined NPT transfer runs use `run_mlx(..., protocol_overrides=...)`
+instead of rewriting prepared source metadata. Trajectories and checkpoints
+record the raw and resolved source protocol, the effective validation protocol,
+and their exact diff. Resume fails closed when that protocol identity changes.
+The GPCRmd 729 source workload remains fixed-cell NVT; an NPT transfer run is a
+separate validation protocol, not a source-protocol reproduction.
+
 ## Bounded GPCRmd 729 Fixed-Cell Result
 
 The fresh production-readiness row uses

--- a/docs/production-md.md
+++ b/docs/production-md.md
@@ -35,10 +35,13 @@ unsupported or incomplete PME/barostat requests, virtual sites,
 Drude/polarizable terms, and other terms the MLX engine cannot yet represent
 faithfully. Fixed-cell orthorhombic PME is a bounded production surface:
 accepted artifacts must provide complete configuration/readiness metadata and
-must fit the measured atom/mesh/cutoff/cell envelope. First-path NPT remains a
-proof surface: `simulate_npt()` currently completes its NVT steps and makes one
-terminal cell proposal rather than scheduling repeated proposals inside the MD
-loop. Unsupported production cases remain blockers.
+must fit the measured atom/mesh/cutoff/cell envelope. NPT remains a proof
+surface: `simulate_npt()` schedules molecule-aware Monte Carlo cell proposals
+at exact in-loop intervals, transactionally rebuilds cell-bound force and
+Neighbor state, and persists barostat state for deterministic MLX checkpoint
+continuation. GPCRmd readiness reports this runtime capability separately from
+the `npt_workload_certification` validation gap; it is not classified as
+unsupported physics. Unsupported production cases remain blockers.
 
 ## Bounded GPCRmd 729 Fixed-Cell Result
 
@@ -226,7 +229,7 @@ evidence for a complete membrane-production workflow.
 For GPCRmd 729, the selected fixed-cell NVT fixture now has source-backed
 preparation, independent parity, bounded finite execution, saved output, and
 checkpoint continuation. The next gaps are larger than this closure:
-production NPT and cell changes, analytic PME virial, triclinic PME,
-production-length stability, broader GPCRmd coverage, and a general
-membrane-production readiness claim. No OpenMM/MLX throughput ratio is valid
-until both engines run a matching runtime manifest.
+at-scale production NPT certification, workload-validated cell changes and
+analytic PME virial, triclinic PME, production-length stability, broader GPCRmd
+coverage, and a general membrane-production readiness claim. No OpenMM/MLX
+throughput ratio is valid until both engines run a matching runtime manifest.

--- a/src/mlx_atomistic/dft/__init__.py
+++ b/src/mlx_atomistic/dft/__init__.py
@@ -1,5 +1,6 @@
 """Legacy Γ-point reference and periodic plane-wave DFT runtimes."""
 
+from mlx_atomistic.dft._runtime_observer import RuntimeObserver
 from mlx_atomistic.dft.artifacts import (
     PERIODIC_SCF_CHECKPOINT_KIND,
     PERIODIC_SCF_CHECKPOINT_SCHEMA,
@@ -224,6 +225,7 @@ __all__ = [
     "ReciprocalGrid",
     "ReferenceComparisonResult",
     "ReferenceDFTCase",
+    "RuntimeObserver",
     "SCFConfig",
     "SCFForceConsistencyResult",
     "SCFResult",

--- a/src/mlx_atomistic/dft/__init__.py
+++ b/src/mlx_atomistic/dft/__init__.py
@@ -1,4 +1,4 @@
-"""Spin-unpolarized Γ-point plane-wave DFT prototype."""
+"""Legacy Γ-point reference and periodic plane-wave DFT runtimes."""
 
 from mlx_atomistic.dft.artifacts import (
     PERIODIC_SCF_CHECKPOINT_KIND,

--- a/src/mlx_atomistic/dft/_periodic_band.py
+++ b/src/mlx_atomistic/dft/_periodic_band.py
@@ -260,17 +260,32 @@ class _PeriodicBandController:
         total_start = perf_counter()
         with _bounded_dft_allocator(), _GTHProjectorCache() as projector_cache:
             reciprocal, effective_potential = self._build_effective_potential()
-            points = tuple(
-                self._solve_point(
-                    point_index,
-                    point,
-                    reciprocal=reciprocal,
-                    effective_potential=effective_potential,
-                    projector_cache=projector_cache,
-                )
-                for point_index, point in enumerate(self.request.band_path.points)
-            )
-        return self._finalize(points, total_start=total_start)
+            points: list[PeriodicBandPointResult] = []
+            solved_points: dict[
+                tuple[float, float, float],
+                tuple[int, PeriodicBandPointResult],
+            ] = {}
+            for point_index, point in enumerate(self.request.band_path.points):
+                cached = solved_points.get(point.vector)
+                if cached is None:
+                    result = self._solve_point(
+                        point_index,
+                        point,
+                        reciprocal=reciprocal,
+                        effective_potential=effective_potential,
+                        projector_cache=projector_cache,
+                    )
+                    solved_points[point.vector] = (point_index, result)
+                else:
+                    source_index, source = cached
+                    result = self._reuse_point(
+                        point_index,
+                        point,
+                        source_index=source_index,
+                        source=source,
+                    )
+                points.append(result)
+        return self._finalize(tuple(points), total_start=total_start)
 
     def _build_effective_potential(self) -> tuple[ReciprocalGrid, mx.array]:
         start = perf_counter()
@@ -384,6 +399,28 @@ class _PeriodicBandController:
             restart_count=eigen.restart_count,
         )
 
+    def _reuse_point(
+        self,
+        point_index: int,
+        point: KPoint,
+        *,
+        source_index: int,
+        source: PeriodicBandPointResult,
+    ) -> PeriodicBandPointResult:
+        """Reuse an exact earlier k-point eigenspace within this path."""
+
+        self._emit_point_started(point_index, point)
+        self._emit_point_completed(
+            point_index,
+            source.eigen,
+            reused_from_point_index=source_index,
+        )
+        return PeriodicBandPointResult(
+            requested_kpoint=point,
+            basis=source.basis,
+            eigen=source.eigen,
+        )
+
     @staticmethod
     def _validate_point_result(
         point_index: int,
@@ -418,16 +455,20 @@ class _PeriodicBandController:
         self,
         point_index: int,
         eigen: PeriodicEigenResult,
+        *,
+        reused_from_point_index: int | None = None,
     ) -> None:
         observer = self.request.observer
         if observer is not None:
-            observer.emit(
-                "band_kpoint",
-                status="completed",
-                point_index=point_index,
-                iterations=eigen.iterations,
-                worst_residual=float(mx.max(eigen.residuals)),
-            )
+            fields: dict[str, object] = {
+                "status": "completed",
+                "point_index": point_index,
+                "iterations": eigen.iterations,
+                "worst_residual": float(mx.max(eigen.residuals)),
+            }
+            if reused_from_point_index is not None:
+                fields["reused_from_point_index"] = reused_from_point_index
+            observer.emit("band_kpoint", **fields)
 
     def _finalize(
         self,

--- a/src/mlx_atomistic/dft/_periodic_scf_engine.py
+++ b/src/mlx_atomistic/dft/_periodic_scf_engine.py
@@ -323,9 +323,10 @@ class _PeriodicSCFProgress:
     density_residual: float = float("inf")
     energy_delta: float | None = None
     timings: dict[str, float] = field(
+        # Keep the independent Hartree/XC branches behind one synchronized
+        # boundary so timing remains device-inclusive without serializing them.
         default_factory=lambda: {
-            "hartree": 0.0,
-            "xc": 0.0,
+            "effective_potential": 0.0,
             "eigensolver": 0.0,
             "total": 0.0,
         }
@@ -696,13 +697,10 @@ class _PeriodicSCFController:
     def _effective_potential(self) -> tuple[mx.array, XCResult, mx.array]:
         start = perf_counter()
         hartree = hartree_potential(self.progress.density, self.setup.system.grid)
-        self.progress.timings["hartree"] += (perf_counter() - start) * 1000.0
-        start = perf_counter()
         xc_result = self.setup.xc.evaluate(
             self.progress.density,
             self.setup.system.grid,
         )
-        self.progress.timings["xc"] += (perf_counter() - start) * 1000.0
         effective_snapshot = mx.array(self.setup.local_potential + hartree + xc_result.potential)
         xc_finite = (
             mx.all(mx.isfinite(xc_result.energy_density))
@@ -711,6 +709,9 @@ class _PeriodicSCFController:
         )
         effective_finite = mx.all(mx.isfinite(effective_snapshot))
         mx.eval(effective_snapshot, xc_finite, effective_finite)
+        self.progress.timings["effective_potential"] += (
+            perf_counter() - start
+        ) * 1000.0
         if not bool(xc_finite):
             msg = "SCF exchange-correlation result is non-finite"
             raise ValueError(msg)

--- a/src/mlx_atomistic/dft/gga.py
+++ b/src/mlx_atomistic/dft/gga.py
@@ -3,13 +3,14 @@
 The defining idea: a GGA energy is ``E_xc = ∫ ε(ρ, ∇ρ) dr``, and its potential is
 the functional derivative ``v_xc = δE_xc/δρ = ∂ε/∂ρ - ∇·(∂ε/∂∇ρ)``. The gradient
 term is the part that is famously error-prone to hand-derive. Here we write *only*
-the energy density and obtain ``v_xc`` from ``mx.grad`` of the total energy — the
-autodiff machinery reconstructs the divergence term automatically, provided the
-density gradient is built with a differentiable (MLX-native) FFT.
+the energy density and obtain ``v_xc`` with ``mx.value_and_grad``. The autodiff
+machinery reconstructs the divergence term automatically, provided the density
+gradient is built with a differentiable (MLX-native) FFT.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from math import log, pi
 
@@ -24,6 +25,8 @@ _KAPPA = 0.804
 _MU = 0.2195149727645171
 _BETA = 0.06672455060314922
 _GAMMA = (1.0 - log(2.0)) / (pi * pi)
+
+_EnergyDensityFunction = Callable[[mx.array, RealSpaceGrid, float], mx.array]
 
 
 def density_gradient(rho: mx.array, grid: RealSpaceGrid) -> mx.array:
@@ -61,6 +64,30 @@ def _pbe_correlation_energy_density(
     reduced_gradient_term = z / (a * (1.0 - z + z * z))
     h = _GAMMA * mx.log1p((_BETA / _GAMMA) * reduced_gradient_term)
     return rho * (eps_c_unif + h)
+
+
+def _evaluate_pbe(
+    name: str,
+    energy_density_function: _EnergyDensityFunction,
+    density: mx.array,
+    grid: RealSpaceGrid,
+    density_floor: float,
+) -> XCResult:
+    """Evaluate one PBE variant without repeating its forward energy graph."""
+
+    rho = mx.maximum(mx.array(density), density_floor)
+
+    def energy_and_density(field: mx.array) -> tuple[mx.array, mx.array]:
+        energy_density = energy_density_function(field, grid, density_floor)
+        return mx.sum(energy_density) * grid.dv, energy_density
+
+    (total_energy, energy_density), derivative = mx.value_and_grad(energy_and_density)(rho)
+    return XCResult(
+        name=name,
+        energy_density=energy_density,
+        potential=derivative / grid.dv,
+        total_energy=total_energy,
+    )
 
 
 @dataclass(frozen=True)
@@ -113,18 +140,12 @@ class PBEExchangeCorrelation:
         if grid is None:
             msg = "PBE (GGA) requires a real-space grid to evaluate the density gradient"
             raise ValueError(msg)
-        rho = mx.maximum(mx.array(density), density_floor)
-
-        def total_energy(field: mx.array) -> mx.array:
-            return mx.sum(self._energy_density(field, grid, density_floor)) * grid.dv
-
-        potential = mx.grad(total_energy)(rho) / grid.dv
-        energy_density = self._energy_density(rho, grid, density_floor)
-        return XCResult(
-            name=self.name,
-            energy_density=energy_density,
-            potential=potential,
-            total_energy=mx.sum(energy_density) * grid.dv,
+        return _evaluate_pbe(
+            self.name,
+            self._energy_density,
+            density,
+            grid,
+            density_floor,
         )
 
 
@@ -173,16 +194,10 @@ class ProductionPBEExchangeCorrelation:
         if grid is None:
             msg = "production PBE requires a real-space grid"
             raise ValueError(msg)
-        rho = mx.maximum(mx.array(density), density_floor)
-
-        def total_energy(field: mx.array) -> mx.array:
-            return mx.sum(self._energy_density(field, grid, density_floor)) * grid.dv
-
-        energy_density = self._energy_density(rho, grid, density_floor)
-        potential = mx.grad(total_energy)(rho) / grid.dv
-        return XCResult(
-            name=self.name,
-            energy_density=energy_density,
-            potential=potential,
-            total_energy=mx.sum(energy_density) * grid.dv,
+        return _evaluate_pbe(
+            self.name,
+            self._energy_density,
+            density,
+            grid,
+            density_floor,
         )

--- a/src/mlx_atomistic/dft/optimization.py
+++ b/src/mlx_atomistic/dft/optimization.py
@@ -18,7 +18,7 @@ from mlx_atomistic.dft.system import DFTSystem
 from mlx_atomistic.dft.xc import DiracExchange, ExchangeCorrelationFunctional
 
 GeometryOptimizer = Literal["lbfgs", "steepest_descent"]
-GeometryRelaxationMode = Literal["ions", "cell", "ions_cell"]
+GeometryRelaxationMode = Literal["ions"]
 GeometryStatus = Literal[
     "converged",
     "max_steps",
@@ -30,7 +30,11 @@ GeometryStatus = Literal[
 
 @dataclass(frozen=True)
 class GeometryOptimizationConfig:
-    """Configuration for fixed-cell ion-position relaxation."""
+    """Configuration for fixed-cell ion-position relaxation.
+
+    Variable-cell and coupled ion/cell relaxation requests fail closed during
+    configuration validation.
+    """
 
     max_steps: int = 25
     force_tolerance: float = 1e-3
@@ -44,13 +48,11 @@ class GeometryOptimizationConfig:
     scf_config: SCFConfig | None = None
     reuse_scf_state: bool = True
     relaxation_mode: GeometryRelaxationMode = "ions"
-    stress_tolerance: float = 1e-3
-    cell_step_size: float = 0.02
 
     def __post_init__(self) -> None:
         self._validate_step_controls()
         self._validate_line_search_controls()
-        self._validate_modes()
+        self._validate_optimizer_and_relaxation_mode()
 
     def _validate_step_controls(self) -> None:
         if self.max_steps <= 0:
@@ -80,18 +82,15 @@ class GeometryOptimizationConfig:
             msg = "max_line_search_iterations must be positive"
             raise ValueError(msg)
 
-    def _validate_modes(self) -> None:
+    def _validate_optimizer_and_relaxation_mode(self) -> None:
         if self.optimizer not in {"lbfgs", "steepest_descent"}:
             msg = "optimizer must be 'lbfgs' or 'steepest_descent'"
             raise ValueError(msg)
-        if self.relaxation_mode not in {"ions", "cell", "ions_cell"}:
-            msg = "relaxation_mode must be 'ions', 'cell', or 'ions_cell'"
-            raise ValueError(msg)
-        if self.stress_tolerance <= 0.0:
-            msg = "stress_tolerance must be positive"
-            raise ValueError(msg)
-        if self.cell_step_size <= 0.0:
-            msg = "cell_step_size must be positive"
+        if self.relaxation_mode != "ions":
+            msg = (
+                "only relaxation_mode='ions' is supported; "
+                "variable-cell relaxation is not implemented"
+            )
             raise ValueError(msg)
 
 
@@ -774,8 +773,6 @@ def _config_summary(config: GeometryOptimizationConfig) -> dict[str, Any]:
         "optimizer": config.optimizer,
         "reuse_scf_state": config.reuse_scf_state,
         "relaxation_mode": config.relaxation_mode,
-        "stress_tolerance": config.stress_tolerance,
-        "cell_step_size": config.cell_step_size,
         "scf_config": None if config.scf_config is None else _scf_config_summary(config.scf_config),
     }
 

--- a/src/mlx_atomistic/dft/periodic_forces.py
+++ b/src/mlx_atomistic/dft/periodic_forces.py
@@ -23,6 +23,8 @@ from mlx_atomistic.dft.periodic_gth import (
     periodic_gth_local_forces,
 )
 
+_FORCE_KPOINT_MATERIALIZATION_BATCH_SIZE = 8
+
 
 @dataclass(frozen=True)
 class PeriodicForceResult:
@@ -132,7 +134,7 @@ def _periodic_nonlocal_forces(
     projector_cache: _GTHProjectorCache,
 ) -> mx.array:
     force = mx.zeros((system.ion_count, 3), dtype=mx.float32)
-    for point in owned:
+    for point_index, point in enumerate(owned, start=1):
         compact = point.eigen._compact_coefficients
         if not isinstance(compact, _CompactLaneState):
             msg = "periodic forces require compact occupied k-point states"
@@ -146,8 +148,13 @@ def _periodic_nonlocal_forces(
         point_force = operator._forces_compact(
             compact,
             occupations=[2.0] * compact.vector_count,
+            evaluate=False,
         )
         force = force + float(point.integration_weight) * point_force
+        # Bound the lazy projector graph without serializing every k-point.
+        if point_index % _FORCE_KPOINT_MATERIALIZATION_BATCH_SIZE == 0:
+            mx.eval(force)
+    if len(owned) % _FORCE_KPOINT_MATERIALIZATION_BATCH_SIZE:
         mx.eval(force)
     return force
 

--- a/src/mlx_atomistic/dft/periodic_gth.py
+++ b/src/mlx_atomistic/dft/periodic_gth.py
@@ -921,6 +921,7 @@ class PeriodicGTHNonlocalOperator:
         coefficients: _CompactLaneState,
         *,
         occupations: Sequence[float],
+        evaluate: bool = True,
     ) -> mx.array:
         """Return analytic per-ion nonlocal forces for compact orbitals."""
 
@@ -989,7 +990,8 @@ class PeriodicGTHNonlocalOperator:
             )
             forces.append(-derivative_energy)
         result = mx.stack(forces, axis=0).astype(mx.float32)
-        mx.eval(result)
+        if evaluate:
+            mx.eval(result)
         return result
 
     def forces(

--- a/src/mlx_atomistic/prep/gpcrmd.py
+++ b/src/mlx_atomistic/prep/gpcrmd.py
@@ -222,6 +222,7 @@ class GPCRmdMLXCompatibilityReport:
     unsupported_physics: tuple[str, ...]
     runtime_risk: dict[str, Any]
     next_engine_slice: str
+    validation_gaps: tuple[str, ...] = field(default_factory=tuple)
     warnings: tuple[str, ...] = field(default_factory=tuple)
     extra_fields: dict[str, Any] = field(default_factory=dict)
 
@@ -233,6 +234,7 @@ class GPCRmdMLXCompatibilityReport:
             "supported_now": list(self.supported_now),
             "missing_input": list(self.missing_input),
             "unsupported_physics": list(self.unsupported_physics),
+            "validation_gaps": list(self.validation_gaps),
             "runtime_risk": dict(self.runtime_risk),
             "next_engine_slice": self.next_engine_slice,
             "warnings": list(self.warnings),
@@ -286,6 +288,7 @@ class GPCRmdReadinessInventory:
     protocol_requirements: dict[str, Any]
     first_engine_blockers: tuple[dict[str, Any], ...]
     missing_input: tuple[str, ...]
+    validation_gaps: tuple[str, ...] = field(default_factory=tuple)
 
     def to_json_dict(self) -> dict[str, Any]:
         return {
@@ -305,6 +308,7 @@ class GPCRmdReadinessInventory:
             "first_engine_blockers": [
                 dict(item) for item in self.first_engine_blockers
             ],
+            "validation_gaps": list(self.validation_gaps),
             "missing_input": list(self.missing_input),
         }
 
@@ -1228,8 +1232,9 @@ def gpcrmd_mlx_compatibility_report(
     target = inspection.target
     missing_input = _missing_input_items(inspection)
     unsupported_physics = _unsupported_physics_items(target)
+    validation_gaps = _validation_gap_items(target)
     runtime_risk = _runtime_risk(target)
-    runnable_now = not missing_input and not unsupported_physics
+    runnable_now = not missing_input and not unsupported_physics and not validation_gaps
     return GPCRmdMLXCompatibilityReport(
         target_id=target.target_id,
         dynamics_id=target.dynamics_id,
@@ -1237,8 +1242,13 @@ def gpcrmd_mlx_compatibility_report(
         supported_now=_supported_now_items(target),
         missing_input=tuple(missing_input),
         unsupported_physics=tuple(unsupported_physics),
+        validation_gaps=tuple(validation_gaps),
         runtime_risk=runtime_risk,
-        next_engine_slice=_next_engine_slice(missing_input, unsupported_physics),
+        next_engine_slice=_next_engine_slice(
+            missing_input,
+            unsupported_physics,
+            validation_gaps,
+        ),
         warnings=(
             "GPCRmd reference trajectories are comparison context, not MLX-generated results.",
             "This report is metadata-level until topology/parameter files are parsed.",
@@ -1266,6 +1276,7 @@ def gpcrmd_mlx_readiness_inventory(
         exceptions=_exception_inventory(target),
         protocol_requirements=_protocol_inventory(target),
         first_engine_blockers=tuple(_first_engine_blockers(compatibility)),
+        validation_gaps=compatibility.validation_gaps,
         missing_input=compatibility.missing_input,
     )
 
@@ -1507,8 +1518,7 @@ def _protocol_inventory(target: GPCRmdTarget) -> dict[str, Any]:
     requirements = ["nvt_thermostat"]
     blockers: list[str] = []
     if "npt" in target.ensemble.lower():
-        requirements.append("barostat")
-        blockers.append("npt_barostat")
+        requirements.append("monte_carlo_barostat")
     if target.time_step_fs >= 3.0:
         requirements.append("4_fs_constraint_or_hmr_policy")
         blockers.append("hmr_or_virtual_site_policy_required")
@@ -1519,8 +1529,10 @@ def _protocol_inventory(target: GPCRmdTarget) -> dict[str, Any]:
         "frame_stride_ns": target.frame_stride_ns,
         "accumulated_time_us": target.accumulated_time_us,
         "software": target.software,
+        "runtime_status": "proof-level",
         "requirements": requirements,
         "blockers": blockers,
+        "validation_gaps": _validation_gap_items(target),
     }
 
 
@@ -1567,10 +1579,6 @@ def _first_engine_blockers(
                 "policy before runtime"
             ),
         },
-        "npt_barostat": {
-            "first_slice": "Slice 8 plus Slice 9",
-            "reason": "pressure control requires virial diagnostics and the selected barostat path",
-        },
     }
     return [
         {
@@ -1585,11 +1593,15 @@ def _first_engine_blockers(
 
 def _unsupported_physics_items(target: GPCRmdTarget) -> list[str]:
     unsupported: list[str] = []
-    if "npt" in target.ensemble.lower():
-        unsupported.append("npt_barostat")
     if target.time_step_fs >= 3.0:
         unsupported.append("hmr_or_virtual_site_policy_required")
     return unsupported
+
+
+def _validation_gap_items(target: GPCRmdTarget) -> list[str]:
+    if "npt" in target.ensemble.lower():
+        return ["npt_workload_certification"]
+    return []
 
 
 def _requires_mesh_pme(target: GPCRmdTarget) -> bool:
@@ -1620,6 +1632,8 @@ def _supported_now_items(target: GPCRmdTarget) -> tuple[str, ...]:
     ]
     if target.solvent_type.upper() == "TIP3P":
         supported.append("tip3p_metadata")
+    if "npt" in target.ensemble.lower():
+        supported.append("monte_carlo_npt_runtime_proof")
     molecule_names = {name.lower() for name in target.molecule_counts}
     if target.periodic_box_expected and "water" in molecule_names:
         if _requires_mesh_pme(target):
@@ -1629,7 +1643,11 @@ def _supported_now_items(target: GPCRmdTarget) -> tuple[str, ...]:
     return tuple(supported)
 
 
-def _next_engine_slice(missing_input: Sequence[str], unsupported_physics: Sequence[str]) -> str:
+def _next_engine_slice(
+    missing_input: Sequence[str],
+    unsupported_physics: Sequence[str],
+    validation_gaps: Sequence[str],
+) -> str:
     if missing_input:
         return "download_or_mount_complete_gpcrmd_package_before_import"
     if "pme_mesh_periodic_electrostatics" in unsupported_physics:
@@ -1646,6 +1664,8 @@ def _next_engine_slice(missing_input: Sequence[str], unsupported_physics: Sequen
         return "parse_gpcrmd_constraints_hmr_or_virtual_sites_policy"
     if unsupported_physics:
         return "resolve_unsupported_gpcrmd_physics"
+    if "npt_workload_certification" in validation_gaps:
+        return "validate_gpcrmd_npt_workload"
     return "run_short_mlx_nvt_probe"
 
 
@@ -1726,6 +1746,7 @@ def _compatibility_with_prepared_force_terms(
     runnable_now = (
         not compatibility.missing_input
         and not unsupported_physics
+        and not compatibility.validation_gaps
         and not prepared_blockers
     )
     supported_now = list(compatibility.supported_now)
@@ -1746,7 +1767,11 @@ def _compatibility_with_prepared_force_terms(
         next_engine_slice=(
             "ready_for_bounded_mlx_execution"
             if runnable_now
-            else _next_engine_slice(compatibility.missing_input, unsupported_physics)
+            else _next_engine_slice(
+                compatibility.missing_input,
+                unsupported_physics,
+                compatibility.validation_gaps,
+            )
         ),
         warnings=(
             "GPCRmd reference trajectories are comparison context, not MLX-generated results.",
@@ -3078,6 +3103,7 @@ def _baseline_mismatch(name: str, parsed: object, expected: object) -> str:
 def _import_blockers(report: GPCRmdMLXCompatibilityReport) -> list[str]:
     blockers = [f"missing_input:{item}" for item in report.missing_input]
     blockers.extend(f"unsupported_physics:{item}" for item in report.unsupported_physics)
+    blockers.extend(f"validation_gap:{item}" for item in report.validation_gaps)
     if report.runnable_now:
         blockers.append("gpcrmd_topology_parameter_parser_not_implemented")
     return blockers

--- a/src/mlx_atomistic/prep/runner.py
+++ b/src/mlx_atomistic/prep/runner.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import os
 import time
+from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -63,7 +65,7 @@ from mlx_atomistic.protocols import (
     ProtocolCompatibilityError,
     protocol_readiness_report,
     run_minimize_then_nvt,
-    validate_gpcrmd_protocol_request,
+    validate_md_protocol_request,
 )
 from mlx_atomistic.runtime import get_platform_boundary_report
 from mlx_atomistic.steering import SteeredCOMBiasPotential, simulate_steered_nvt
@@ -75,6 +77,15 @@ TRAJECTORY_NAME = "trajectory.npz"
 STEERED_TRAJECTORY_NAME = "steered_trajectory.npz"
 GPCRMD_RUN_REPORT_NAME = "gpcrmd_mlx_run_report.json"
 PRESSURE_DIAGNOSTIC_ATOM_LIMIT = 50_000
+_PROTOCOL_OVERRIDE_FIELDS = frozenset(
+    {
+        "ensemble",
+        "proof_mode",
+        "barostat",
+        "npt_barostat",
+        "membrane_barostat",
+    }
+)
 # The fixed-cell task cache changed the short-run optimum, but the decisive
 # matched 750-step JAC run remained faster at 5.5 A (18.036 versus 18.472 s at
 # 4.0 A) because it rebuilt 15 fewer times. Both runs preserved cutoff physics.
@@ -929,6 +940,7 @@ def run_mlx(
     neighbor_check_interval: int = 1,
     eager_nonbonded_pair_limit: int | None = DEFAULT_EAGER_NONBONDED_PAIR_LIMIT,
     rescale_initial_velocities: bool = True,
+    protocol_overrides: Mapping[str, Any] | None = None,
     metadata_overrides: dict[str, Any] | None = None,
     runtime_electrostatics_model: str | None = None,
     reporters: RuntimeReporter | list[RuntimeReporter] | tuple[RuntimeReporter, ...] | None = None,
@@ -958,8 +970,12 @@ def run_mlx(
             prepared_system,
             require_production=require_production,
         )
-    protocol_report = validate_gpcrmd_protocol_request(
+    effective_protocol, protocol_identity = _protocol_with_overrides(
         prepared_system.metadata.protocol_metadata,
+        protocol_overrides,
+    )
+    protocol_report = validate_md_protocol_request(
+        effective_protocol,
         raise_on_blockers=True,
     )
     selected_barostat_mode = (
@@ -984,7 +1000,7 @@ def run_mlx(
         arrays=artifact.arrays,
     )
     protocol_readiness = protocol_readiness_report(
-        prepared_system.metadata.protocol_metadata,
+        effective_protocol,
     )
     platform_boundary = _platform_boundary_metadata()
     if diagnostic_interval is None:
@@ -1093,6 +1109,13 @@ def run_mlx(
         ),
     )
     if checkpoint is not None:
+        checkpoint_protocol_identity = checkpoint.metadata.get("protocol_identity")
+        if (
+            checkpoint_protocol_identity is not None
+            and checkpoint_protocol_identity != protocol_identity
+        ):
+            msg = "resume checkpoint protocol identity does not match the requested run"
+            raise ValueError(msg)
         _restore_checkpoint_neighbor_state(
             checkpoint,
             neighbor_manager=neighbor_manager,
@@ -1324,6 +1347,7 @@ def run_mlx(
                 ),
                 "resumed_from": None if checkpoint is None else str(resume_checkpoint),
                 "run_metadata": dict(metadata_overrides or {}),
+                "protocol_identity": protocol_identity,
                 "platform_readiness": {
                     "artifact": artifact_readiness.to_dict(),
                     "protocol": protocol_readiness.to_dict(),
@@ -1417,6 +1441,7 @@ def run_mlx(
         if metadata_overrides:
             metadata.update(metadata_overrides)
         metadata.update(protocol_report.metadata)
+        metadata["protocol_identity"] = protocol_identity
         if use_npt:
             metadata["kind"] = "mlx_atomistic.prep_npt"
             metadata["barostat_attempts"] = result.barostat_attempts
@@ -1475,6 +1500,37 @@ def run_mlx(
                     file_format=output_format,
                 )
     return result
+
+
+def _protocol_with_overrides(
+    source_protocol: Mapping[str, Any],
+    overrides: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    source = deepcopy(dict(source_protocol))
+    requested = {} if overrides is None else deepcopy(dict(overrides))
+    unknown = sorted(set(requested) - _PROTOCOL_OVERRIDE_FIELDS)
+    if unknown:
+        msg = "unsupported protocol override fields: " + ", ".join(unknown)
+        raise ValueError(msg)
+    effective = {**source, **requested}
+    source_decision = validate_md_protocol_request(source)
+    validation_decision = validate_md_protocol_request(effective)
+    differences = {
+        name: {
+            "source": deepcopy(source.get(name)),
+            "validation": deepcopy(effective[name]),
+        }
+        for name in sorted(requested)
+        if source.get(name) != effective[name]
+    }
+    return effective, {
+        "kind": "project_defined_validation" if overrides is not None else "source",
+        "source_protocol": source,
+        "source_protocol_resolved": deepcopy(source_decision.metadata),
+        "validation_protocol": deepcopy(effective),
+        "validation_protocol_resolved": deepcopy(validation_decision.metadata),
+        "protocol_diff": differences,
+    }
 
 
 def _trajectory_topology_path(
@@ -2139,7 +2195,7 @@ def run_steered_mlx(
         prepared_dir = None
         prepared_system = prepared
         artifact = _artifact_from_prepared_system(prepared_system, require_production=False)
-    protocol_report = validate_gpcrmd_protocol_request(
+    protocol_report = validate_md_protocol_request(
         prepared_system.metadata.protocol_metadata,
         raise_on_blockers=True,
     )

--- a/src/mlx_atomistic/protocols.py
+++ b/src/mlx_atomistic/protocols.py
@@ -26,7 +26,7 @@ from mlx_atomistic.units import MDUnitSystem
 
 NVT_PROOF_MODE = "short_nvt"
 NPT_PROOF_MODE = "short_npt"
-SUPPORTED_GPCRMD_PROOF_ENSEMBLE = "nvt"
+DEFAULT_PROOF_ENSEMBLE = "nvt"
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,7 @@ class MinimizeThenNVTProtocol:
     ) -> ProtocolCompatibilityReport:
         """Return the fail-closed compatibility decision for this NVT runner."""
 
-        report = validate_gpcrmd_protocol_request(
+        report = validate_md_protocol_request(
             {
                 "ensemble": self.ensemble,
                 "proof_mode": self.proof_mode,
@@ -125,7 +125,7 @@ class ProtocolResult:
     protocol_metadata: dict[str, Any] = field(default_factory=dict)
 
 
-def validate_gpcrmd_protocol_request(
+def validate_md_protocol_request(
     protocol_metadata: Mapping[str, Any] | None = None,
     *,
     ensemble: str | None = None,
@@ -135,15 +135,15 @@ def validate_gpcrmd_protocol_request(
     membrane_barostat: str | bool | None = None,
     raise_on_blockers: bool = False,
 ) -> ProtocolCompatibilityReport:
-    """Validate the current GPCRmd proof protocol gate.
+    """Validate the shared MLX molecular-dynamics proof protocol gate.
 
     The proof gate accepts NVT and the first orthorhombic Monte Carlo NPT path.
     """
 
     metadata = dict(protocol_metadata or {})
-    requested_ensemble = str(
-        _first_present(ensemble, metadata.get("ensemble"), "NVT")
-    ).strip()
+    raw_ensemble = _first_present(ensemble, metadata.get("ensemble"))
+    ensemble_was_explicit = raw_ensemble is not None
+    requested_ensemble = str(_first_present(raw_ensemble, "NVT")).strip()
     requested_proof_mode = _first_present(proof_mode, metadata.get("proof_mode"))
     requested_barostat = _first_present(
         barostat,
@@ -165,9 +165,8 @@ def validate_gpcrmd_protocol_request(
     normalized_proof_mode = (
         "" if requested_proof_mode is None else str(requested_proof_mode).strip().lower()
     )
-    npt_barostat_requested = (
-        "npt" in normalized_ensemble or _is_requested(requested_npt_barostat)
-    )
+    npt_barostat_flag = _is_requested(requested_npt_barostat)
+    npt_barostat_requested = normalized_ensemble == "npt" or npt_barostat_flag
     barostat_requested = _is_requested(requested_barostat)
     membrane_barostat_requested = _is_requested(requested_membrane_barostat)
     requested_barostat_name = str(requested_barostat).strip().lower().replace("-", "_")
@@ -188,10 +187,14 @@ def validate_gpcrmd_protocol_request(
     )
     blockers: list[str] = []
 
+    if normalized_ensemble not in {"nvt", "npt"}:
+        blockers.append("unsupported_ensemble")
+    if ensemble_was_explicit and normalized_ensemble == "nvt" and npt_barostat_flag:
+        blockers.append("ensemble_barostat_mismatch")
     if npt_barostat_requested:
         if not monte_carlo_npt:
             blockers.append("barostat")
-    elif normalized_ensemble != SUPPORTED_GPCRMD_PROOF_ENSEMBLE:
+    elif normalized_ensemble != DEFAULT_PROOF_ENSEMBLE:
         blockers.append("unsupported_ensemble")
     expected_proof_mode = NPT_PROOF_MODE if npt_barostat_requested else NVT_PROOF_MODE
     if not normalized_proof_mode:
@@ -238,17 +241,48 @@ def validate_gpcrmd_protocol_request(
             "membrane_barostat": membrane_barostat_requested,
             "barostat_mode": "membrane"
             if membrane_barostat_requested
+            or requested_barostat_name in {"membrane", "semi_isotropic", "semiisotropic"}
             else requested_barostat_name
-            if requested_barostat_name in {"anisotropic", "membrane", "semi_isotropic"}
+            if requested_barostat_name == "anisotropic"
             else "isotropic"
             if monte_carlo_npt
             else "none",
+            "required_entry_point": (
+                "simulate_npt" if normalized_output_ensemble == "NPT" else "simulate_nvt"
+            ),
             "unsupported_protocol_blockers": list(blocker_tuple),
         },
     )
     if blocker_tuple and raise_on_blockers:
         raise ProtocolCompatibilityError(report)
     return report
+
+
+def validate_gpcrmd_protocol_request(
+    protocol_metadata: Mapping[str, Any] | None = None,
+    *,
+    ensemble: str | None = None,
+    proof_mode: str | None = None,
+    barostat: str | bool | None = None,
+    npt_barostat: bool | None = None,
+    membrane_barostat: str | bool | None = None,
+    raise_on_blockers: bool = False,
+) -> ProtocolCompatibilityReport:
+    """Validate a GPCRmd request through the shared MD protocol gate.
+
+    This compatibility name remains available for callers that predate the
+    shared `validate_md_protocol_request` entry point.
+    """
+
+    return validate_md_protocol_request(
+        protocol_metadata,
+        ensemble=ensemble,
+        proof_mode=proof_mode,
+        barostat=barostat,
+        npt_barostat=npt_barostat,
+        membrane_barostat=membrane_barostat,
+        raise_on_blockers=raise_on_blockers,
+    )
 
 
 def protocol_readiness_report(
@@ -262,7 +296,7 @@ def protocol_readiness_report(
 ) -> ReadinessReport:
     """Return the protocol gate as a shared readiness report."""
 
-    report = validate_gpcrmd_protocol_request(
+    report = validate_md_protocol_request(
         protocol_metadata,
         ensemble=ensemble,
         proof_mode=proof_mode,
@@ -470,5 +504,6 @@ __all__ = [
     "ProtocolResult",
     "protocol_readiness_report",
     "run_minimize_then_nvt",
+    "validate_md_protocol_request",
     "validate_gpcrmd_protocol_request",
 ]

--- a/src/mlx_atomistic/protocols.py
+++ b/src/mlx_atomistic/protocols.py
@@ -79,9 +79,9 @@ class MinimizeThenNVTProtocol:
         *,
         raise_on_blockers: bool = False,
     ) -> ProtocolCompatibilityReport:
-        """Return the fail-closed GPCRmd proof compatibility decision."""
+        """Return the fail-closed compatibility decision for this NVT runner."""
 
-        return validate_gpcrmd_protocol_request(
+        report = validate_gpcrmd_protocol_request(
             {
                 "ensemble": self.ensemble,
                 "proof_mode": self.proof_mode,
@@ -89,8 +89,25 @@ class MinimizeThenNVTProtocol:
                 "npt_barostat": self.npt_barostat,
                 "membrane_barostat": self.membrane_barostat,
             },
-            raise_on_blockers=raise_on_blockers,
+            raise_on_blockers=False,
         )
+        if report.accepted and report.ensemble == "NPT":
+            blocker = "npt_requires_simulate_npt"
+            report = ProtocolCompatibilityReport(
+                accepted=False,
+                ensemble=report.ensemble,
+                proof_mode=report.proof_mode,
+                barostat=report.barostat,
+                blockers=(blocker,),
+                metadata={
+                    **report.metadata,
+                    "required_entry_point": "simulate_npt",
+                    "unsupported_protocol_blockers": [blocker],
+                },
+            )
+        if report.blockers and raise_on_blockers:
+            raise ProtocolCompatibilityError(report)
+        return report
 
     def protocol_metadata(self) -> dict[str, Any]:
         """Return normalized metadata for accepted NVT proof runs."""

--- a/src/mlx_atomistic/runtime.py
+++ b/src/mlx_atomistic/runtime.py
@@ -175,7 +175,7 @@ def get_platform_boundary_report(
             status="proof-level",
             local_concepts=(
                 "MinimizeThenNVTProtocol",
-                "validate_gpcrmd_protocol_request",
+                "validate_md_protocol_request",
                 "simulate_nve/simulate_nvt/simulate_npt",
                 "NoseHooverThermostat",
             ),

--- a/tests/test_checkpoint_restart.py
+++ b/tests/test_checkpoint_restart.py
@@ -403,26 +403,17 @@ def test_production_pme_checkpoint_split_matches_uninterrupted_run(tmp_path):
 def test_production_pme_npt_checkpoint_split_matches_uninterrupted_run(tmp_path):
     from mlx_atomistic.prep.runner import run_mlx
 
-    fixture = _production_pme_checkpoint_fixture()
+    source = _production_pme_checkpoint_fixture()
     prepared = replace(
-        fixture,
-        molecule_ids=np.zeros((fixture.atom_count,), dtype=np.int32),
-        metadata=replace(
-            fixture.metadata,
-            protocol_metadata={
-                **fixture.metadata.protocol_metadata,
-                "ensemble": "NPT",
-                "proof_mode": "short_npt",
-                "barostat": "anisotropic",
-                "npt_barostat": True,
-                "center_of_mass_motion": {
-                    "enabled": True,
-                    "force": "CMMotionRemover",
-                    "frequency_steps": 1,
-                },
-            },
-        ),
+        source,
+        molecule_ids=np.zeros((source.atom_count,), dtype=np.int32),
     )
+    protocol_overrides = {
+        "ensemble": "NPT",
+        "proof_mode": "short_npt",
+        "barostat": "anisotropic",
+        "npt_barostat": True,
+    }
     common = {
         "require_production": True,
         "sample_interval": 1,
@@ -440,6 +431,7 @@ def test_production_pme_npt_checkpoint_split_matches_uninterrupted_run(tmp_path)
         "minimize_steps": 0,
         "equilibration_steps": 0,
         "eager_nonbonded_pair_limit": 0,
+        "protocol_overrides": protocol_overrides,
     }
     continuous = run_mlx(
         prepared,
@@ -489,6 +481,16 @@ def test_production_pme_npt_checkpoint_split_matches_uninterrupted_run(tmp_path)
     assert continuous_record.metadata["barostat_interval"] == 2
     assert continuous_record.metadata["barostat_mode"] == "anisotropic"
     assert continuous_record.metadata["barostat_axes"] == [True, True, True]
+    protocol_identity = continuous_record.metadata["protocol_identity"]
+    assert protocol_identity["kind"] == "project_defined_validation"
+    assert "ensemble" not in protocol_identity["source_protocol"]
+    assert protocol_identity["source_protocol_resolved"]["ensemble"] == "NVT"
+    assert protocol_identity["validation_protocol"]["ensemble"] == "NPT"
+    assert protocol_identity["validation_protocol_resolved"]["ensemble"] == "NPT"
+    assert protocol_identity["protocol_diff"]["ensemble"] == {
+        "source": None,
+        "validation": "NPT",
+    }
     for name in ("sampled_positions", "sampled_velocities", "cell_history"):
         combined = np.concatenate(
             (
@@ -507,6 +509,7 @@ def test_production_pme_npt_checkpoint_split_matches_uninterrupted_run(tmp_path)
     resumed_checkpoint = load_simulation_checkpoint(
         tmp_path / "npt-resumed-checkpoint.npz"
     )
+    assert resumed_checkpoint.metadata["protocol_identity"] == protocol_identity
     assert first_checkpoint.metadata["fixed_cell"] is False
     assert first_checkpoint.cell_history_cursor == 3
     assert first_checkpoint.neighbor_reference_positions.shape == (3, 3)
@@ -515,7 +518,7 @@ def test_production_pme_npt_checkpoint_split_matches_uninterrupted_run(tmp_path)
     assert resumed_checkpoint.cell_history_cursor == 6
     np.testing.assert_array_equal(
         first_checkpoint.molecule_ids,
-        np.zeros((fixture.atom_count,), dtype=np.int32),
+        np.zeros((source.atom_count,), dtype=np.int32),
     )
     assert resumed_checkpoint.barostat["attempts"] == continuous.barostat_attempts
     assert resumed_checkpoint.barostat["final_pme_plan_fingerprints"]
@@ -524,8 +527,36 @@ def test_production_pme_npt_checkpoint_split_matches_uninterrupted_run(tmp_path)
         assert result.nonbonded_report["pme_execution_plan_count"] == 1
         assert np.all(np.isfinite(np.asarray(result.pressure)))
 
+    with pytest.raises(ValueError, match="protocol identity"):
+        run_mlx(
+            prepared,
+            out=tmp_path / "npt-mismatched-resume.npz",
+            resume_checkpoint=split_checkpoint,
+            steps=1,
+            **{
+                **common,
+                "barostat_mode": "isotropic",
+                "protocol_overrides": {
+                    **protocol_overrides,
+                    "barostat": "monte_carlo",
+                },
+            },
+        )
 
-def test_npt_checkpoint_preserves_final_cell_for_restart_continuation(tmp_path):
+
+@pytest.mark.parametrize(
+    ("mode", "mode_options"),
+    [
+        ("isotropic", {}),
+        ("anisotropic", {"axes": (True, True, True)}),
+        ("membrane", {"membrane_plane": "xy", "normal_axis": "z"}),
+    ],
+)
+def test_npt_checkpoint_preserves_final_cell_for_restart_continuation(
+    tmp_path,
+    mode,
+    mode_options,
+):
     positions = np.array(
         [[1.0, 1.0, 1.0], [2.1, 1.0, 1.0], [1.0, 2.2, 1.0]],
         dtype=np.float32,
@@ -540,8 +571,8 @@ def test_npt_checkpoint_preserves_final_cell_for_restart_continuation(tmp_path):
         interval=2,
         seed=4,
         max_log_volume_scale=0.01,
-        mode="anisotropic",
-        axes=(True, True, True),
+        mode=mode,
+        **mode_options,
     )
 
     continuous = simulate_npt(
@@ -590,13 +621,13 @@ def test_npt_checkpoint_preserves_final_cell_for_restart_continuation(tmp_path):
         },
         barostat=first.barostat_metadata,
         molecule_ids=molecule_ids,
-        neighbor_policy={"ensemble": "NPT", "barostat": "monte_carlo"},
+        neighbor_policy={"ensemble": "NPT", "barostat": mode},
         force_terms=("lj",),
         diagnostic_cursor=first.final_state.step,
         cell_history_cursor=3,
         metadata={
             "ensemble": "NPT",
-            "barostat": "monte_carlo",
+            "barostat": mode,
             "barostat_attempts": first.barostat_attempts,
             "barostat_accepted": first.barostat_accepted,
         },
@@ -658,13 +689,14 @@ def test_npt_checkpoint_preserves_final_cell_for_restart_continuation(tmp_path):
 
     assert checkpoint.step == first.final_state.step
     assert checkpoint.thermostat["rng_step_offset"] == first.final_state.step
-    assert checkpoint.neighbor_policy == {"ensemble": "NPT", "barostat": "monte_carlo"}
+    assert checkpoint.neighbor_policy == {"ensemble": "NPT", "barostat": mode}
     assert checkpoint.cell_history_cursor == 3
     np.testing.assert_array_equal(checkpoint.molecule_ids, molecule_ids)
     assert checkpoint.metadata["ensemble"] == "NPT"
     assert checkpoint.metadata["barostat_attempts"] == 1
     assert resumed.barostat_attempts == continuous.barostat_attempts
     assert resumed.barostat_accepted == continuous.barostat_accepted
+    assert resumed.barostat_metadata["mode"] == mode
     assert resumed.barostat_metadata["axis_attempts"] == continuous.barostat_metadata[
         "axis_attempts"
     ]

--- a/tests/test_dft_optimization.py
+++ b/tests/test_dft_optimization.py
@@ -30,6 +30,11 @@ def test_geometry_optimization_config_validation():
         GeometryOptimizationConfig(line_search_shrink=1.0)
     with pytest.raises(ValueError, match="optimizer"):
         GeometryOptimizationConfig(optimizer="bad")  # type: ignore[arg-type]
+    for mode in ("cell", "ions_cell"):
+        with pytest.raises(ValueError, match="variable-cell relaxation is not implemented"):
+            GeometryOptimizationConfig(
+                relaxation_mode=mode,  # type: ignore[arg-type]
+            )
 
 
 @pytest.mark.slow

--- a/tests/test_dft_periodic.py
+++ b/tests/test_dft_periodic.py
@@ -324,6 +324,37 @@ def test_periodic_gth_nonlocal_operator_is_cell_translation_invariant():
     assert shifted_energy == pytest.approx(first_energy, abs=2e-5)
 
 
+def test_periodic_gth_nonlocal_force_can_defer_materialization(monkeypatch):
+    grid = RealSpaceGrid((6, 6, 6), (6.0, 6.0, 6.0))
+    basis = PlaneWaveBasis.from_reduced_kpoint(grid, 2.0, (0.25, 0.0, 0.0))
+    coefficients = basis._state_from_compact(
+        mx.eye(1, basis.active_count, dtype=mx.float32).astype(mx.complex64)
+    )
+    operator = PeriodicGTHNonlocalOperator(
+        _silicon_gth(),
+        basis,
+        ((1.0, 2.0, 3.0),),
+    )
+    original_eval = mx.eval
+    evaluations = []
+
+    def record_eval(*values):
+        evaluations.append(len(values))
+        return original_eval(*values)
+
+    monkeypatch.setattr(mx, "eval", record_eval)
+    deferred = operator._forces_compact(
+        coefficients,
+        occupations=[2.0],
+        evaluate=False,
+    )
+
+    assert evaluations == []
+    eager = operator._forces_compact(coefficients, occupations=[2.0])
+    assert evaluations == [1]
+    np.testing.assert_array_equal(np.asarray(deferred), np.asarray(eager))
+
+
 def test_periodic_gth_nonlocal_forces_match_fixed_orbital_energy_derivative():
     grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
     basis = PlaneWaveBasis.from_reduced_kpoint(

--- a/tests/test_dft_periodic.py
+++ b/tests/test_dft_periodic.py
@@ -20,6 +20,7 @@ from mlx_atomistic.dft import (
     PseudopotentialData,
     PseudopotentialFormat,
     RealSpaceGrid,
+    RuntimeObserver,
     gth_local_potential_grid,
     gth_local_reciprocal_coefficients,
     periodic_ewald_energy,
@@ -30,6 +31,12 @@ from mlx_atomistic.dft import (
     solve_periodic_eigenproblem,
 )
 from mlx_atomistic.dft.kpoints import KPoint, KPointMesh
+
+
+def test_runtime_observer_is_available_from_public_dft_api():
+    observer = RuntimeObserver(detail_events=False)
+
+    assert observer.detail_events is False
 
 
 def test_plane_wave_basis_mask_and_metadata_are_deterministic():
@@ -526,3 +533,5 @@ def test_weighted_periodic_scf_conserves_electrons_without_dense_fallback():
     assert all(item.eigen.to_dict()["dense_full_hamiltonian"] is False for item in result.kpoints)
     assert all(item.eigen.converged for item in result.kpoints)
     assert np.isfinite(result.total_energy)
+    assert set(result.timings) == {"effective_potential", "eigensolver", "total"}
+    assert 0.0 < result.timings["effective_potential"] <= result.timings["total"]

--- a/tests/test_dft_periodic_bands.py
+++ b/tests/test_dft_periodic_bands.py
@@ -17,6 +17,7 @@ from mlx_atomistic.dft import (
     PeriodicSCFConfig,
     PseudopotentialData,
     PseudopotentialFormat,
+    RuntimeObserver,
     fold_band_path_to_supercell,
     run_periodic_band_structure,
     run_periodic_scf,
@@ -143,6 +144,52 @@ def test_periodic_short_path_matches_portable_frozen_density(converged_gamma_scf
     assert from_density.density_source == "frozen_density"
     assert all(point.basis.active_count > 2 for point in from_density.points)
     assert all(point.eigen.converged for point in from_density.points)
+
+
+def test_periodic_band_path_reuses_exact_kpoint_eigensolve(
+    converged_gamma_scf,
+    monkeypatch,
+):
+    from mlx_atomistic.dft import _periodic_band
+
+    system, scf_result = converged_gamma_scf
+    path = BandPath(
+        [
+            KPoint((0.0, 0.0, 0.0), label="first", coordinate_system="reduced"),
+            KPoint((0.1, 0.0, 0.0), coordinate_system="reduced"),
+            KPoint((0.0, 0.0, 0.0), label="repeat", coordinate_system="reduced"),
+        ]
+    )
+    solve_calls = 0
+    original_solve = _periodic_band.solve_periodic_eigenproblem
+
+    def counted_solve(*args, **kwargs):
+        nonlocal solve_calls
+        solve_calls += 1
+        return original_solve(*args, **kwargs)
+
+    monkeypatch.setattr(_periodic_band, "solve_periodic_eigenproblem", counted_solve)
+    events: list[dict[str, object]] = []
+    bands = run_periodic_band_structure(
+        system,
+        scf_result,
+        path,
+        n_bands=2,
+        config=_solver_config(),
+        observer=RuntimeObserver(callback=events.append),
+    )
+
+    completed = [
+        event
+        for event in events
+        if event["event"] == "band_kpoint" and event["status"] == "completed"
+    ]
+    assert solve_calls == 2
+    assert bands.points[0].basis is bands.points[2].basis
+    assert bands.points[0].eigen is bands.points[2].eigen
+    assert bands.points[2].requested_kpoint.label == "repeat"
+    assert len(completed) == 3
+    assert completed[2]["reused_from_point_index"] == 0
 
 
 def test_periodic_guard_bands_are_solved_but_not_published(converged_gamma_scf):

--- a/tests/test_gpcrmd_registry.py
+++ b/tests/test_gpcrmd_registry.py
@@ -687,6 +687,27 @@ def test_gpcrmd_small_periodic_fixture_uses_ewald_reference_without_pme_blocker(
     assert report.next_engine_slice == "run_short_mlx_nvt_probe"
 
 
+def test_gpcrmd_npt_is_proof_level_with_a_separate_validation_gap(tmp_path: Path):
+    target = replace(_small_periodic_soluble_target(), ensemble="NPT")
+    cache = tmp_path / "complete-cache"
+    _write_complete_cache(cache, target)
+
+    inspection = inspect_gpcrmd_cache(cache, targets=[target])
+    report = gpcrmd_mlx_compatibility_report(inspection)
+    inventory = gpcrmd_mlx_readiness_inventory(inspection).to_json_dict()
+
+    assert report.runnable_now is False
+    assert report.unsupported_physics == ()
+    assert report.validation_gaps == ("npt_workload_certification",)
+    assert "monte_carlo_npt_runtime_proof" in report.supported_now
+    assert report.next_engine_slice == "validate_gpcrmd_npt_workload"
+    assert inventory["validation_gaps"] == ["npt_workload_certification"]
+    assert inventory["protocol_requirements"]["runtime_status"] == "proof-level"
+    assert inventory["protocol_requirements"]["blockers"] == []
+    assert inventory["protocol_requirements"]["validation_gaps"] == ["npt_workload_certification"]
+    assert "npt_barostat" not in {item["name"] for item in inventory["first_engine_blockers"]}
+
+
 def test_gpcrmd_reference_trajectory_alone_cannot_pass_compatibility(tmp_path: Path):
     target = default_gpcrmd_targets()[0]
     cache = tmp_path / "trajectory-only"

--- a/tests/test_md_phase1_end_to_end.py
+++ b/tests/test_md_phase1_end_to_end.py
@@ -12,7 +12,7 @@ from mlx_atomistic.md import (
     simulate_nvt,
 )
 from mlx_atomistic.minimize import minimize_energy
-from mlx_atomistic.protocols import validate_gpcrmd_protocol_request
+from mlx_atomistic.protocols import validate_md_protocol_request
 
 pytestmark = [pytest.mark.slow, pytest.mark.integration]
 
@@ -126,7 +126,7 @@ def test_phase1_minimize_nose_hoover_nvt_anisotropic_npt_records_finite_state():
             axes=(True, False, True),
         ),
     )
-    protocol_report = validate_gpcrmd_protocol_request(
+    protocol_report = validate_md_protocol_request(
         {"ensemble": "NPT", "barostat": "monte_carlo"},
         raise_on_blockers=True,
     )

--- a/tests/test_npt.py
+++ b/tests/test_npt.py
@@ -20,7 +20,7 @@ from mlx_atomistic.md import (
 )
 from mlx_atomistic.neighbors import NeighborListManager
 from mlx_atomistic.pme import PMEConfig
-from mlx_atomistic.protocols import validate_gpcrmd_protocol_request
+from mlx_atomistic.protocols import validate_md_protocol_request
 from mlx_atomistic.topology import Topology
 
 
@@ -1384,7 +1384,7 @@ def test_barostat_acceptance_uses_molecule_count_and_proposal_ratio():
 
 
 def test_protocol_gate_accepts_first_monte_carlo_npt_path():
-    report = validate_gpcrmd_protocol_request(
+    report = validate_md_protocol_request(
         {"ensemble": "NPT", "barostat": "monte_carlo"},
         raise_on_blockers=True,
     )
@@ -1397,7 +1397,7 @@ def test_protocol_gate_accepts_first_monte_carlo_npt_path():
 
 
 def test_protocol_gate_accepts_membrane_monte_carlo_npt_path():
-    report = validate_gpcrmd_protocol_request(
+    report = validate_md_protocol_request(
         {"ensemble": "NPT", "barostat": "monte_carlo", "membrane_barostat": "xy"},
         raise_on_blockers=True,
     )
@@ -1409,7 +1409,7 @@ def test_protocol_gate_accepts_membrane_monte_carlo_npt_path():
 
 
 def test_protocol_gate_rejects_npt_with_nvt_proof_mode():
-    report = validate_gpcrmd_protocol_request(
+    report = validate_md_protocol_request(
         {"ensemble": "NPT", "barostat": "monte_carlo", "proof_mode": "short_nvt"},
     )
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -100,6 +100,23 @@ def test_run_minimize_then_nvt_fails_closed_before_npt_force_evaluation():
     assert exc_info.value.blockers == ("barostat", "unsupported_proof_mode")
 
 
+def test_minimize_then_nvt_protocol_rejects_supported_npt_runtime_request():
+    protocol = MinimizeThenNVTProtocol(
+        ensemble="NPT",
+        proof_mode="short_npt",
+        barostat="monte_carlo",
+        npt_barostat=True,
+    )
+
+    report = protocol.compatibility_report()
+
+    assert report.accepted is False
+    assert report.blockers == ("npt_requires_simulate_npt",)
+    assert report.metadata["required_entry_point"] == "simulate_npt"
+    with pytest.raises(ProtocolCompatibilityError, match="npt_requires_simulate_npt"):
+        protocol.compatibility_report(raise_on_blockers=True)
+
+
 def test_run_minimize_then_nvt_exposes_nvt_protocol_metadata():
     positions, velocities, masses, cell, potential = _small_periodic_fixture()
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -9,6 +9,7 @@ from mlx_atomistic.protocols import (
     protocol_readiness_report,
     run_minimize_then_nvt,
     validate_gpcrmd_protocol_request,
+    validate_md_protocol_request,
 )
 
 
@@ -43,6 +44,66 @@ def test_gpcrmd_protocol_gate_accepts_short_nvt_metadata():
     assert report.metadata["barostat_status"] == "not_required_for_nvt_proof"
     assert report.metadata["npt_barostat"] is False
     assert report.metadata["membrane_barostat"] is False
+    assert report.metadata["required_entry_point"] == "simulate_nvt"
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"ensemble": "NVT"},
+        {
+            "ensemble": "NPT",
+            "proof_mode": "short_npt",
+            "barostat": "anisotropic",
+            "npt_barostat": True,
+        },
+        {
+            "ensemble": "NPT",
+            "proof_mode": "short_npt",
+            "barostat": "monte_carlo",
+            "membrane_barostat": "xy",
+        },
+    ],
+)
+def test_gpcrmd_compatibility_name_matches_shared_md_gate(metadata):
+    shared = validate_md_protocol_request(metadata)
+    compatibility = validate_gpcrmd_protocol_request(metadata)
+
+    assert compatibility == shared
+    assert shared.metadata["required_entry_point"] == (
+        "simulate_npt" if shared.ensemble == "NPT" else "simulate_nvt"
+    )
+
+
+def test_shared_protocol_gate_normalizes_semiisotropic_as_membrane_geometry():
+    report = validate_md_protocol_request(
+        {
+            "ensemble": "NPT",
+            "proof_mode": "short_npt",
+            "barostat": "semiisotropic",
+        }
+    )
+
+    assert report.accepted is True
+    assert report.metadata["barostat_mode"] == "membrane"
+    assert report.metadata["required_entry_point"] == "simulate_npt"
+
+
+@pytest.mark.parametrize(
+    ("metadata", "blocker"),
+    [
+        ({"ensemble": "not-npt", "barostat": "monte_carlo"}, "unsupported_ensemble"),
+        (
+            {"ensemble": "NVT", "barostat": "monte_carlo", "npt_barostat": True},
+            "ensemble_barostat_mismatch",
+        ),
+    ],
+)
+def test_shared_protocol_gate_rejects_ambiguous_ensemble_requests(metadata, blocker):
+    report = validate_md_protocol_request(metadata)
+
+    assert report.accepted is False
+    assert blocker in report.blockers
 
 
 def test_protocol_readiness_report_uses_shared_schema():


### PR DESCRIPTION
## Summary

- Fail closed when fixed-cell DFT geometry optimization receives unsupported variable-cell modes, and remove inert cell/stress configuration knobs.
- Separate proof-level Monte Carlo NPT runtime support from GPCRmd workload-certification gaps without weakening production readiness.
- Route NVT and NPT proof requests through one shared MD protocol gate while preserving the previous GPCRmd compatibility entry point.
- Allow project-defined NPT transfer protocols without rewriting prepared source metadata, and bind their raw, resolved, and effective identities to trajectories and checkpoints.
- Reject resumed transfer runs when their protocol identity changes.
- Retain the measured periodic DFT PBE, force-materialization, timing, and repeated-band-point improvements.
- Record repository evidence ordering and parallel-worktree ownership rules.

## Why

The public configuration, readiness metadata, and canonical documentation had drifted from the implemented runtime. Variable-cell DFT settings were accepted but unused, GPCRmd classified all NPT requests as unsupported physics even though a proof-level runtime exists, and transfer tests could only obtain NPT behavior by mutating source protocol metadata. Checkpoints also lacked an explicit binding to the source-versus-validation protocol decision.

## User impact

Unsupported DFT relaxation requests now fail immediately with a precise error. GPCRmd reports distinguish implementation support from missing workload certification while production readiness remains fail closed. NVT and NPT callers receive an explicit runtime entry point. Project-defined NPT validation keeps source metadata immutable and preserves the exact protocol identity across restart.

## Validation

- Targeted protocol, NPT, checkpoint/restart, and end-to-end CPU tests passed.
- `ruff check src` passed.
- API generation produced 59 pages.
- Narrative synchronization produced 34 pages.
- `git diff --check` passed.

The complete local suite cannot collect in the current headless macOS sandbox because an unchanged import-time test initializes MLX Metal. Linux `mlx-cpu` CI remains the routine full correctness reference.
