### PR TITLE
Reject unsupported nonorthogonal DFT grids

### DIFF
--- a/src/mlx_atomistic/dft/grids.py
+++ b/src/mlx_atomistic/dft/grids.py
@@ -34,6 +34,9 @@ class RealSpaceGrid:
     def __init__(self, shape: Sequence[int], cell: Cell | Sequence[float]):
         object.__setattr__(self, "shape", _shape_tuple(shape))
         parsed_cell = cell if isinstance(cell, Cell) else Cell.orthorhombic(cell)
+        if not parsed_cell.is_orthorhombic:
+            msg = "DFT real-space grids currently require an orthorhombic cell"
+            raise ValueError(msg)
         object.__setattr__(self, "cell", parsed_cell)
         lengths = np.array(parsed_cell.lengths, dtype=np.float64)
         if np.any(lengths <= 0.0):

--- a/tests/test_dft.py
+++ b/tests/test_dft.py
@@ -3,6 +3,7 @@ import json
 import numpy as np
 import pytest
 
+from mlx_atomistic.core import Cell
 from mlx_atomistic.dft import (
     DenseHamiltonianReference,
     DFTSystem,
@@ -51,6 +52,19 @@ def test_real_and_reciprocal_grid_geometry():
     assert reciprocal.g2.shape == grid.shape
     assert bool(np.array(reciprocal.zero_mask)[0, 0, 0])
     assert float(np.array(reciprocal.g2)[0, 0, 0]) == pytest.approx(0.0)
+
+
+def test_real_space_grid_rejects_nonorthogonal_cells_until_supported():
+    cell = Cell.triclinic(
+        (
+            (8.0, 0.0, 0.0),
+            (1.5, 7.5, 0.0),
+            (0.5, 1.0, 9.0),
+        )
+    )
+
+    with pytest.raises(ValueError, match="require an orthorhombic cell"):
+        RealSpaceGrid((4, 4, 4), cell)
 
 
 def test_fft_round_trip_preserves_real_field():


### PR DESCRIPTION
## Summary
- reject nonorthogonal Cell inputs at the DFT RealSpaceGrid boundary
- prevent silent use of orthorhombic volume, coordinate, and reciprocal formulas
- add a focused regression test

## Validation
- UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run ruff check src/mlx_atomistic/dft/grids.py tests/test_dft.py
- UV_CACHE_DIR=/tmp/mlx-atomistic-uv-cache uv run python -m pytest -q tests/test_dft.py
- git diff --check