### PR TITLE
feat(dft): verify metallic Aluminum EOS

### DIFF
--- a/docs/benchmarks/dft-material-validation.md
+++ b/docs/benchmarks/dft-material-validation.md
@@ -14,6 +14,7 @@ calculation.
 | Diamond C, 8 atoms, PBE/GTH-q4, 40 Ha, 6×6×6, 7 volumes | `a₀ = 3.574441 Å`, `B₀ = 438.100 GPa`, Δ = `1.268 meV/atom` | All-electron PBE: lattice `0.075%` and bulk modulus `1.080%` relative error | Verified for the accepted 40 Ha workload. A 40→50 Ha central three-volume screen changed the curve by `0.438 meV/atom`; no full 50 Ha curve is required. |
 | Rock-salt MgO, 8 atoms, PBE, Mg-q2/O-q6, 70 Ha, 6×6×6, 7 volumes | `a₀ = 4.259503 Å`, `B₀ = 146.914 GPa`, Δ = `1.060 meV/atom` | All-electron PBE: lattice `0.123%` and bulk modulus `1.387%` relative error | Core EOS properties validated. The strict whole-report gate remains failed because `B₀′ = 3.39995` differs from `4.09093` by `16.89%`, above the locked `15%` threshold; this is retained as a likely Mg-q2 transferability limit. |
 | MgO periodic forces at the accepted EOS cell | 21 of 24 atom/axis comparisons pass `1e-4 Ha/bohr`; maximum deviation `2.246e-4 Ha/bohr` | Analytic force versus 48 reconverged ±0.01 bohr SCFs | Accepted with a known float32 total-energy precision limit. The three failures are O 6-x and O 7-y/z; the threshold was not weakened. |
+| fcc Al, 4 atoms, PBE/GTH-q3, Fermi-Dirac `0.00225 Ha`, 15 Ha, reduced 15×15×15, 11 bands, 7 volumes | `a₀ = 4.039885 Å`, `B₀ = 76.631 GPa`, `B₀′ = 4.58384`, Δ = `0.230 meV/atom` | All-electron PBE: lattice `0.024%`, bulk modulus `1.137%`, and `B₀′` `0.851%` relative error | Verified for this metallic EOS workload. The accepted mesh has 120 weighted representatives; the result does not establish broad Aluminum chemistry or metal transferability. |
 
 ## Evidence Boundary
 
@@ -23,15 +24,13 @@ semantics. Raw SCF, EOS, band, and force reports remain under gitignored
 `results/`. Quantum ESPRESSO and CP2K are reference families only and are not
 installed, imported, or executed by the MLX runtime or routine CI.
 
-These rows prove the listed fixed workloads. They do not establish metallic or
-spin-polarized chemistry, broad pseudopotential transferability, cell
-relaxation, or universal periodic DFT accuracy.
+These rows prove the listed fixed workloads. Aluminum closes one simple-metal
+case, but the rows do not establish broad metallic chemistry, spin-polarized
+chemistry, pseudopotential transferability, or cell relaxation. They do not
+establish universal periodic DFT accuracy.
 
-The periodic runtime now has a numerically validated Fermi-Dirac occupation and
-free-energy path, including weighted k-points, odd electron counts, checkpoints,
-and analytic-force occupation propagation. A bounded four-atom fcc Aluminum
-smoke test uses the CP2K `Al GTH-PBE-q3` parameters to exercise a real metallic
-band manifold. It is an execution test, not an accuracy row. The repository
-does not yet contain a source-bound metal energy reference that matches the
-local GTH pseudopotential and Fermi-Dirac protocol. Capability and material
-accuracy remain separate claims.
+The periodic runtime has a numerically validated Fermi-Dirac occupation and
+free-energy path, including weighted k-points, odd electron counts,
+checkpoints, and analytic-force occupation propagation. The Aluminum row adds
+a source-bound material validation for that path. Capability and broader
+material accuracy remain separate claims.

--- a/docs/dft-metallic-validation.md
+++ b/docs/dft-metallic-validation.md
@@ -1,0 +1,183 @@
+# DFT Metallic Validation
+
+This document is the completed scientific specification and evidence summary
+for Phase 1 of the [DFT roadmap](./dft-roadmap.md). It closes one
+material-level metallic validation without expanding the runtime beyond the
+existing unpolarized PBE/GTH and Fermi-Dirac capability.
+
+## Objective
+
+Promote fcc Aluminum from an execution smoke test to a source-bound metallic
+equation-of-state validation. The accepted workload must exercise a global
+chemical potential, fractional occupations, electronic entropy, and the
+Helmholtz free energy `F = E - TS` over a converged weighted k-point mesh.
+
+The work must also make the dense metallic mesh practical. It may add general
+k-point construction and explicit symmetry-reduction utilities, but it must
+not add a reference engine, automatic space-group detection, a C++ extension,
+or a new dependency.
+
+## Source Contract
+
+The primary source is the Materials Cloud ACWF verification dataset, record
+`yf0rj-w3r97`, DOI `10.24435/materialscloud:s4-3h`. The downloaded archive has
+MD5 `6bd97a883b439507d0be4638c1bc7514`. Only the compact Aluminum values and
+their provenance are committed; the source archive remains external.
+
+The exact source records are:
+
+- `Al-FCC.xsf`, SHA-256
+  `c4446a6d46475e4cca8067169330284c17c031b97477010b2a433bbf85be25ac`;
+- `results-unaries-verification-PBE-v1-AE-average.json`, SHA-256
+  `d7844caa127eae860fe5087ead42f80d1b6b5eb952a686ff4b912ddaed7db48b`;
+- `results-unaries-verification-PBE-v1-cp2k_TZV2P.json`, SHA-256
+  `3a787c7197cc50e003b38494c4b489b72eeb553e8ca0da3a4505ed08f96e9b6e`.
+
+The all-electron FLEUR/WIEN2k average is the primary scientific target:
+
+- equilibrium volume: `16.49535905981626 A^3/atom`;
+- conventional fcc lattice: `4.040861093109186 A`;
+- bulk modulus: `0.4837908557795412 eV/A^3`;
+- bulk derivative: `4.623179033235038`.
+
+CP2K Quickstep is the same-pseudopotential-family diagnostic. Its
+`TZV2P-MOLOPT-PBE-GTH-q3` basis uses `Al GTH-PBE-q3` and gives:
+
+- equilibrium volume: `16.437017660642258 A^3/atom`;
+- conventional fcc lattice: `4.036091509687826 A`;
+- bulk modulus: `0.48951774655729935 eV/A^3`;
+- bulk derivative: `4.514335571200874`.
+
+Against the all-electron target, that CP2K fit has a project Delta factor of
+`0.9954359681 meV/atom` and passes the existing excellent thresholds. Absolute
+energies are not comparable because CP2K uses a Gaussian orbital basis while
+the MLX runtime uses plane waves.
+
+The historical protocol is reconstructed from the ACWF 1.0 release line. The
+`v1.0.1` tag resolves to commit
+`c08c3f2f7babcb78c7b0a1ddaa28f2fb1d0d8d39` and records PBE, a
+`0.06 A^-1` maximum k-point spacing, Fermi-Dirac smearing at `710.5 K`, 20
+additional molecular orbitals, and `Al GTH-PBE-q3`. This reconstruction is
+protocol evidence, not a substitute for the source result files above.
+
+## Local Protocol
+
+The source primitive cell is represented locally as the equivalent four-atom
+conventional cubic cell because the current DFT grid is orthorhombic. The
+seven volumes are the source lattice scaled by volume factors
+`0.94, 0.96, 0.98, 1.00, 1.02, 1.04, 1.06` around
+`4.040422065345 A`.
+
+The locked physics is:
+
+- unpolarized PBE-PW92;
+- `Al GTH-PBE-q3`, extracted and fingerprinted from the CP2K database;
+- 12 valence electrons per conventional cell;
+- Fermi-Dirac width `0.00225 Ha`, equivalent to the ACWF electronic
+  temperature within the recorded precision;
+- the stationary Helmholtz free energy as the EOS energy;
+- a Gamma-centered mesh with maximum conventional-cell reciprocal spacing no
+  greater than `0.06 A^-1`.
+
+A numerical CP2K GPW grid cutoff is not transferable to a plane-wave kinetic
+cutoff. The local cutoff, FFT shape, band capacity, and k-point density are
+therefore admitted by representation-appropriate convergence gates rather
+than by copying unlike numeric inputs.
+
+## Efficient K-Point Contract
+
+The runtime will retain explicit weighted `KPointMesh` as the integration
+contract and add two composable utilities:
+
+1. a Gamma-centered regular grid, distinct from the existing even half-shifted
+   `MonkhorstPackGrid`;
+2. deterministic reduction by caller-supplied reciprocal-space symmetry
+   operations.
+
+The reducer must validate finite reduced coordinates, integer unimodular
+operations, mesh closure, unique transformed matches, and equal weights within
+each orbit. It aggregates orbit weights and never infers that a symmetry is
+valid for a Hamiltonian.
+
+For conventional fcc Aluminum, the 48 signed permutation operations of the
+cubic point group reduce the source-density `27 x 27 x 27` Gamma-centered mesh
+from 19,683 explicit points to 560 weighted representatives, a 97.2% lane
+reduction. The odd mesh keeps the maximum reciprocal spacing below
+`0.06 A^-1` at every EOS volume. A full-mesh path remains available as the
+correctness oracle.
+
+## Acceptance Criteria
+
+Numerical admission requires every retained point to pass:
+
+- converged SCF and finite free energy, internal energy, entropy, and chemical
+  potential;
+- electron-count error no greater than `1e-4` per cell;
+- maximum orbital residual no greater than `1e-6`;
+- maximum orthonormality error no greater than `1e-4`;
+- maximum occupation of the highest computed band no greater than `1e-6`;
+- consistency of `F = E - TS` within `5e-6 Ha`.
+
+Cutoff and k-point admission reuse the existing EOS convergence thresholds:
+maximum curve change `1 meV/atom`, lattice change `0.1%`, bulk-modulus change
+`3%`, and bulk-derivative change `10%`. The final seven-point fit must pass the
+existing verified material thresholds: Delta no greater than `3 meV/atom`,
+lattice error `0.5%`, bulk-modulus error `10%`, and bulk-derivative error `15%`.
+Thresholds are fixed before the production run and are not relaxed afterward.
+
+The symmetry path must reproduce a full-grid invariant quadrature exactly and
+a bounded full-versus-reduced SCF within the established numerical gates. The
+final report records complete wall time, peak memory, explicit point count,
+representative count, and work counters. Existing fixed-occupation and
+time-reversal tests must not regress.
+
+## Accepted Result
+
+The admitted profile is `c15-k15-b11`: a `15 Ha` plane-wave cutoff, `36 x 36 x
+36` FFT grid, `15 x 15 x 15` Gamma-centered k-point mesh reduced to 120 weighted
+representatives, 11 bands, and the locked `0.00225 Ha` Fermi-Dirac width. The
+band-capacity gate was evaluated on the denser locked `27 x 27 x 27` mesh at
+the largest EOS volume. Ten bands failed because the highest occupation was
+`2.93e-6`; 11 bands passed at `1.30e-18`.
+
+The selected seven-volume fit gives:
+
+- conventional fcc lattice: `4.039885108 A`;
+- bulk modulus: `76.630636 GPa`;
+- bulk derivative: `4.583841965`;
+- Delta factor against the all-electron reference: `0.229587 meV/atom`.
+
+The corresponding relative errors are `0.0242%` for the lattice, `1.14%` for
+the bulk modulus, and `0.851%` for the bulk derivative. All locked numerical,
+convergence, and scientific gates pass. A bounded `4 x 4 x 4` full-grid oracle
+and its ten-representative symmetry reduction differ by `8.45e-6 Ha/atom`,
+below the fixed `5e-5 Ha/atom` gate.
+
+On an Apple M5 Max connected to AC power with Low Power Mode disabled, the
+accepted seven-point curve took `48.03 s` complete wall time. Individual
+points took `6.37-7.62 s`; maximum process physical memory was `3.06 GB`.
+These measurements are current-verified for this workload and power state,
+not a cross-device performance claim. Raw reports remain under gitignored
+`results/`.
+
+## Delivery Plan
+
+1. Commit the compact, hash-guarded Aluminum reference bundle and portable
+   workload preparation contract.
+2. Add and test Gamma-centered meshes and explicit reciprocal-symmetry
+   reduction without changing existing `MonkhorstPackGrid` behavior.
+3. Add a bounded Aluminum point runner and fail-early admission ladder for band
+   capacity, cutoff, k-point density, and the seven-volume EOS.
+4. Run the ladder on Metal, retain only generated evidence under `results/`,
+   and promote the smallest profile that passes every locked gate.
+5. Commit the accepted scientific summary, runtime measurement, known
+   boundary, and roadmap status; keep raw calculations gitignored.
+
+All five delivery steps are complete.
+
+## Out Of Scope
+
+This phase does not add spin polarization, general cells, stress, ionic
+relaxation, projected observables, new exchange-correlation functionals,
+automatic crystal-symmetry discovery, or broad Aluminum chemistry. Those
+claims remain governed by later roadmap phases.

--- a/docs/dft-production-core.md
+++ b/docs/dft-production-core.md
@@ -95,7 +95,7 @@ boundary.
 
 | Feature | Local Status | Reference Family |
 | --- | --- | --- |
-| Plane-wave SCF core | verified for fixed-occupation bulk-Si EOS; Fermi-Dirac path numerically validated | CP2K Quickstep, QE PWscf |
+| Plane-wave SCF core | verified for fixed-occupation bulk-Si EOS and one Fermi-Dirac fcc-Al EOS | CP2K Quickstep, QE PWscf |
 | UPF/GTH pseudopotentials and nonlocal projectors | proof-level | QE UPF, CP2K GTH |
 | Geometry relaxation and finite-difference stress | proof-level | CP2K MOTION/GEO_OPT, QE relax |
 | Static reference comparison | supported | static CP2K/QE fixture summaries |
@@ -103,15 +103,11 @@ boundary.
 | PH/EPW/NEB/TDDFT/MPI/offload suite breadth | deferred | QE and CP2K production suites |
 | Importing, wrapping, building, or running CP2K/QE | anti-goal | external executables |
 
-Plane-wave SCF core is `verified` only for the bulk-silicon PBE equation of state
-against an all-electron (FLEUR/WIEN2k) reference (Lejaeghere Δ factor
-1.942 meV/atom); broader chemistry stays proof-level, and the separate
+Plane-wave SCF has source-bound equation-of-state validation for bulk Silicon
+and simple-metal fcc Aluminum. Aluminum uses a matching GTH family,
+Fermi-Dirac convention, converged weighted k-point mesh, and Helmholtz
+free-energy definition. Broader chemistry stays proof-level, and the separate
 MLX-versus-QE PWscf cross-engine parity is still diagnostic, not closed.
-Periodic Fermi-Dirac occupations remove the former fixed-occupation algorithmic
-blocker for metals and odd electron counts. They do not, by themselves,
-establish a material-level metallic accuracy claim; that requires a
-source-bound metal workload with matching pseudopotential, smearing convention,
-k-point mesh, and free-energy definition.
 
 `dft_qm_scope_readiness_report()` returns a shared readiness payload for these
 features. Deferred, anti-goal, and unknown features report blockers before any

--- a/docs/dft-roadmap.md
+++ b/docs/dft-roadmap.md
@@ -10,10 +10,9 @@ reference engines remain validation surfaces.
 The retained periodic path provides PBE-PW92, reciprocal-space GTH operators,
 weighted k-points, block-Davidson eigensolves, fixed and Fermi-Dirac
 occupations, frozen-density bands, analytic fixed-cell forces, and atomic
-checkpoint/resume. Material-level verification remains narrow: Silicon and
-Carbon have accepted equation-of-state workloads, while MgO retains a declared
-force and transferability boundary. Metallic execution is covered, but a
-matched metallic accuracy reference is not yet closed.
+checkpoint/resume. Material-level verification remains narrow: Silicon,
+Carbon, and simple-metal Aluminum have accepted equation-of-state workloads,
+while MgO retains a declared force and transferability boundary.
 
 ## Program Boundary
 
@@ -33,7 +32,7 @@ only when its implementation and material-level evidence both pass.
 | Exchange-correlation | PBE-PW92 production envelope | Implemented; verified material set is narrow | Every material phase |
 | Pseudopotentials | Broad, fingerprinted GTH transferability | GTH periodic path exists; broad transferability is not closed | Phase 7 |
 | Crystal geometry | Ordinary full-rank periodic cells | DFT grids and Ewald path remain orthorhombic | Phase 3 |
-| Electronic states | Insulators, simple metals, and collinear magnets | Insulators verified; metals execute; periodic spin is absent | Phases 1 and 5 |
+| Electronic states | Insulators, simple metals, and collinear magnets | Insulators and one simple metal are verified; periodic spin is absent | Phases 1 and 5 |
 | Electronic observables | Energy, density, occupations, bands, total DOS, and Fermi level | Energy, density, occupations, and bands exist | Phase 6 |
 | Mechanical observables | Analytic forces and validated stress | Forces exist with a retained MgO boundary; periodic stress is absent | Phase 4 |
 | Structural workflows | Fixed-cell ionic and variable-cell relaxation | Only the legacy teaching path relaxes ions | Phases 2 and 4 |
@@ -79,23 +78,26 @@ pseudopotential transferability expands across every phase
 
 ## Phase 1: Close Metallic Scientific Validation
 
-Status: active research; no product-code change starts before protocol lock.
+Status: complete. The source-bound Aluminum workload passes every locked gate.
 
-- Lock one Aluminum reference protocol with the same structure,
-  pseudopotential identity, Fermi-Dirac width, k-point mesh, cutoff, and
-  free-energy definition used locally.
+- Lock one Aluminum reference protocol with the same structure, functional,
+  pseudopotential identity, Fermi-Dirac width, and free-energy definition used
+  locally. Converge the representation-specific basis and k-point integration
+  rather than equating unlike CP2K Gaussian-grid and local plane-wave cutoffs.
 - Retain source fingerprints and parsed inputs so the comparison is
   reproducible without placing a reference engine on the MLX runtime path.
 - Validate electron count, chemical potential, occupations, free energy, and
   at least one material observable such as an equation-of-state curve.
 
-Exit gate: a source-bound metallic report passes declared numerical and
-scientific thresholds. The current Aluminum smoke remains execution evidence
-until this gate closes.
+The bounded scientific contract and delivery plan are recorded in
+[DFT Metallic Validation](./dft-metallic-validation.md).
+
+Exit gate: closed. The accepted profile and current-verified measurements are
+recorded in the linked evidence summary. Phase 2 is the next active phase.
 
 ## Phase 2: Add Periodic Fixed-Cell Ionic Relaxation
 
-Status: planned after Phase 1 scientific closure.
+Status: next; protocol research and specification are not yet locked.
 
 - Add a periodic optimizer that consumes converged analytic forces.
 - Reuse SCF density and compact eigenspaces between accepted ionic steps.

--- a/scripts/sync_site_docs.py
+++ b/scripts/sync_site_docs.py
@@ -27,6 +27,7 @@ NARRATIVE_TARGETS = {
     "production-md.md": "mm/production-md.md",
     "real-mm-core.md": "mm/real-mm-core.md",
     "dft-geometry-optimization.md": "dft/dft-geometry-optimization.md",
+    "dft-metallic-validation.md": "dft/dft-metallic-validation.md",
     "dft-numerics.md": "dft/dft-numerics.md",
     "dft-production-core.md": "dft/dft-production-core.md",
     "dft-pseudopotentials.md": "dft/dft-pseudopotentials.md",

--- a/src/mlx_atomistic/benchmarks/data/aluminum_eos_references.json
+++ b/src/mlx_atomistic/benchmarks/data/aluminum_eos_references.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "mlx-atomistic.aluminum-eos-references.v1",
+  "material": {
+    "cell": "fcc-aluminum",
+    "functional": "PBE",
+    "spin": "unpolarized"
+  },
+  "protocol": {
+    "central_conventional_lattice_angstrom": 4.040422065345,
+    "volume_factors": [
+      0.94,
+      0.96,
+      0.98,
+      1.0,
+      1.02,
+      1.04,
+      1.06
+    ],
+    "reference_method": "ACWF verification-PBE-v1",
+    "local_method": "Fermi-Dirac Helmholtz free energy",
+    "smearing_width_hartree": 0.00225,
+    "maximum_kpoint_spacing_inverse_angstrom": 0.06,
+    "method_difference": "The primary target is the all-electron EOS fit. The CP2K context uses the same GTH-PBE-q3 pseudopotential family with a TZV2P Gaussian orbital basis and a GPW integration grid; the local calculation uses a separately converged plane-wave basis and Gamma-centered weighted mesh. Absolute energies and unlike numeric cutoffs are not compared."
+  },
+  "sources": {
+    "archive": {
+      "record": "yf0rj-w3r97",
+      "url": "https://archive.materialscloud.org/records/yf0rj-w3r97",
+      "doi": "10.24435/materialscloud:s4-3h",
+      "file": "ACWF-verification-data-and-scripts.zip",
+      "md5": "6bd97a883b439507d0be4638c1bc7514"
+    },
+    "structure": {
+      "file": "Al-FCC.xsf",
+      "sha256": "c4446a6d46475e4cca8067169330284c17c031b97477010b2a433bbf85be25ac"
+    },
+    "all_electron_file": {
+      "file": "results-unaries-verification-PBE-v1-AE-average.json",
+      "sha256": "d7844caa127eae860fe5087ead42f80d1b6b5eb952a686ff4b912ddaed7db48b"
+    },
+    "cp2k_file": {
+      "file": "results-unaries-verification-PBE-v1-cp2k_TZV2P.json",
+      "sha256": "3a787c7197cc50e003b38494c4b489b72eeb553e8ca0da3a4505ed08f96e9b6e"
+    },
+    "protocol_reconstruction": {
+      "repository": "https://github.com/aiidateam/aiida-common-workflows",
+      "release": "v1.0.1",
+      "commit": "c08c3f2f7babcb78c7b0a1ddaa28f2fb1d0d8d39"
+    }
+  },
+  "references": {
+    "all_electron_average": {
+      "role": "primary",
+      "source": "Materials Cloud ACWF curated FLEUR/WIEN2k average",
+      "primitive_cell_atoms": 1,
+      "fit": {
+        "equilibrium_volume_angstrom3": 16.49535905981626,
+        "bulk_modulus_ev_angstrom3": 0.4837908557795412,
+        "bulk_derivative": 4.623179033235038
+      }
+    },
+    "cp2k_gth": {
+      "role": "same-pseudopotential-family",
+      "source": "Materials Cloud ACWF CP2K Quickstep TZV2P/GTH",
+      "primitive_cell_atoms": 1,
+      "fit": {
+        "equilibrium_volume_angstrom3": 16.437017660642258,
+        "bulk_modulus_ev_angstrom3": 0.48951774655729935,
+        "bulk_derivative": 4.514335571200874
+      },
+      "eos_volume_energy_ev": [
+        [15.500584138516746, -56.403618325988],
+        [15.830383801037938, -56.412287842685],
+        [16.160183463560365, -56.416984850579],
+        [16.48998312608165, -56.418121909537],
+        [16.81978278860265, -56.4160706297],
+        [17.149582451124544, -56.411166430269],
+        [17.479382113646345, -56.403712807909]
+      ]
+    }
+  },
+  "local_pseudopotential": {
+    "name": "Al GTH-PBE-q3",
+    "extracted_entry_sha256": "06adc20c53ad6ff2eb7e1111c4b2437bd70ad520cdd6e5735dbb9cd09c1d381d"
+  },
+  "license": {
+    "identifier": "CC-BY-4.0",
+    "attribution": "Bosoni et al., How to verify the precision of density-functional-theory implementations via reproducible and universal workflows, Nature Reviews Physics 6, 45-58 (2024)."
+  }
+}

--- a/src/mlx_atomistic/benchmarks/dft_aluminum.py
+++ b/src/mlx_atomistic/benchmarks/dft_aluminum.py
@@ -1,0 +1,326 @@
+"""Prepare and run the bounded fcc Aluminum metallic validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from mlx_atomistic._artifact_identity import canonical_json_bytes, sha256_bytes
+from mlx_atomistic.benchmarks.dft_aluminum_eos import load_aluminum_eos_references
+from mlx_atomistic.benchmarks.dft_silicon import parse_gth_entry
+from mlx_atomistic.dft import (
+    GammaCenteredGrid,
+    KPoint,
+    KPointMesh,
+    cubic_reciprocal_symmetry_operations,
+    reduce_kpoint_mesh_by_symmetry,
+)
+
+WORKLOAD_SCHEMA = "mlx-atomistic.dft-aluminum-workload.v1"
+TARGET_ID = "fcc-aluminum-conventional-pbe-gth-q3"
+GTH_ELEMENT = "Al"
+GTH_NAME = "GTH-PBE-q3"
+KPOINT_MESH_SIZES = (7, 11, 15, 19, 23, 27)
+
+ALUMINUM_FRACTIONAL_POSITIONS = (
+    (0.0, 0.0, 0.0),
+    (0.0, 0.5, 0.5),
+    (0.5, 0.0, 0.5),
+    (0.5, 0.5, 0.0),
+)
+
+
+def _write_exact(path: Path, payload: bytes) -> None:
+    if path.exists():
+        if path.read_bytes() != payload:
+            raise ValueError(f"refusing to replace mismatched existing file: {path}")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_bytes(payload)
+    temporary.replace(path)
+
+
+def _reduced_mesh_payload(size: int) -> dict[str, Any]:
+    full = GammaCenteredGrid((size, size, size))
+    reduced = reduce_kpoint_mesh_by_symmetry(
+        full,
+        cubic_reciprocal_symmetry_operations(),
+    )
+    return {
+        "size": [size, size, size],
+        "centering": "gamma",
+        "full_point_count": len(full.points),
+        "representative_point_count": len(reduced.points),
+        "points": [
+            {"vector": list(point.vector), "weight": point.weight} for point in reduced.points
+        ],
+    }
+
+
+def _unsigned_workload(
+    *,
+    resource_sha256: str,
+    source_sha256: str,
+    reduced_meshes: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    references = load_aluminum_eos_references()
+    return {
+        "schema_version": WORKLOAD_SCHEMA,
+        "target_id": TARGET_ID,
+        "resource": {
+            "path": "resources/Al-GTH-PBE-q3.gth",
+            "sha256": resource_sha256,
+            "source_database_sha256": source_sha256,
+            "element": GTH_ELEMENT,
+            "name": GTH_NAME,
+            "functional": "PBE",
+            "valence_charge": 3,
+        },
+        "system": {
+            "name": "fcc-aluminum-conventional-cubic",
+            "atom_count": 4,
+            "symbols": [GTH_ELEMENT] * 4,
+            "fractional_positions": [list(row) for row in ALUMINUM_FRACTIONAL_POSITIONS],
+            "electron_count": 12,
+            "spin_mode": "unpolarized",
+            "occupancy_per_band": 2,
+        },
+        "physics": {
+            "exchange_correlation": "PBE-PW92",
+            "pseudopotential": "Al GTH-PBE-q3",
+            "occupation": "Fermi-Dirac",
+            "smearing_width_hartree": 0.00225,
+            "energy_observable": "Helmholtz free energy F=E-TS",
+            "kpoint_centering": "gamma",
+            "kpoint_symmetry": "caller-verified full cubic point group",
+        },
+        "solver": {
+            "scf": {
+                "max_iterations": 100,
+                "min_iterations": 2,
+                "density_tolerance": 1.0e-6,
+                "energy_tolerance_hartree": 8.0e-6,
+                "orbital_tolerance": 1.0e-6,
+                "mixing_beta": 0.2,
+                "mixer": "diis",
+                "adaptive_eigensolver_tolerance": True,
+                "initial_eigensolver_tolerance": 1.0e-2,
+                "eigensolver_tolerance_scale": 0.1,
+            },
+            "davidson": {
+                "max_iterations": 56,
+                "tolerance": 1.0e-6,
+                "max_subspace_size": 64,
+                "preconditioner_floor": 0.25,
+            },
+        },
+        "numerical_gates": {
+            "electron_count_abs_per_cell": 1.0e-4,
+            "orbital_residual_max": 1.0e-6,
+            "orthonormality_max": 1.0e-4,
+            "highest_band_occupation_max": 1.0e-6,
+            "free_energy_identity_abs_hartree": 5.0e-6,
+        },
+        "validation": {
+            "central_conventional_lattice_angstrom": references["protocol"][
+                "central_conventional_lattice_angstrom"
+            ],
+            "volume_factors": references["protocol"]["volume_factors"],
+            "band_capacity_candidates": [8, 9, 10, 11, 12, 16, 20, 26],
+            "cutoff_candidates_hartree": [15.0, 20.0, 25.0, 30.0],
+            "fft_shape_by_cutoff": {"15": 36, "20": 40, "25": 44, "30": 48},
+            "kpoint_mesh_sizes": list(KPOINT_MESH_SIZES),
+            "maximum_kpoint_spacing_inverse_angstrom": 0.06,
+            "screen_volume_indices": [2, 3, 4],
+            "full_volume_indices": list(range(7)),
+            "full_grid_oracle_size": 4,
+            "memory_limit_bytes": 40_000_000_000,
+            "point_timeout_seconds": 900.0,
+        },
+        "reduced_kpoint_meshes": dict(reduced_meshes),
+    }
+
+
+def prepare_aluminum_workload(
+    *,
+    gth_source: str | Path,
+    out: str | Path,
+) -> dict[str, Any]:
+    """Extract Aluminum GTH data and prepare a portable metallic workload."""
+
+    source = Path(gth_source).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"GTH source does not exist: {source}")
+    entry = parse_gth_entry(source, element=GTH_ELEMENT, name=GTH_NAME)
+    if entry.valence_charge != 3.0:
+        raise ValueError("Al GTH-PBE-q3 must represent three valence electrons")
+    resource = ("\n".join(entry.source_lines) + "\n").encode()
+    references = load_aluminum_eos_references()
+    expected_resource_sha256 = references["local_pseudopotential"]["extracted_entry_sha256"]
+    if sha256_bytes(resource) != expected_resource_sha256:
+        raise ValueError("Al GTH-PBE-q3 source entry does not match the locked reference")
+
+    output = Path(out)
+    resource_path = output / "resources" / "Al-GTH-PBE-q3.gth"
+    _write_exact(resource_path, resource)
+    reduced_meshes = {str(size): _reduced_mesh_payload(size) for size in KPOINT_MESH_SIZES}
+    unsigned = _unsigned_workload(
+        resource_sha256=sha256_bytes(resource),
+        source_sha256=sha256_bytes(source.read_bytes()),
+        reduced_meshes=reduced_meshes,
+    )
+    manifest = {
+        **unsigned,
+        "workload_fingerprint": sha256_bytes(canonical_json_bytes(unsigned)),
+    }
+    manifest_path = output / "manifest.json"
+    _write_exact(manifest_path, canonical_json_bytes(manifest))
+    return {
+        "status": "prepared",
+        "target_id": TARGET_ID,
+        "manifest": str(manifest_path),
+        "gth_path": str(resource_path),
+        "gth_sha256": sha256_bytes(resource),
+        "workload_fingerprint": manifest["workload_fingerprint"],
+        "kpoint_representatives": {
+            size: reduced_meshes[str(size)]["representative_point_count"]
+            for size in KPOINT_MESH_SIZES
+        },
+    }
+
+
+def _validate_reduced_meshes(payload: Mapping[str, Any]) -> None:
+    meshes = payload.get("reduced_kpoint_meshes", {})
+    if set(meshes) != {str(size) for size in KPOINT_MESH_SIZES}:
+        raise ValueError("Aluminum workload k-point ladder mismatch")
+    for size in KPOINT_MESH_SIZES:
+        mesh = meshes[str(size)]
+        if mesh.get("size") != [size, size, size]:
+            raise ValueError("Aluminum workload k-point mesh size mismatch")
+        if mesh.get("full_point_count") != size**3:
+            raise ValueError("Aluminum workload full k-point count mismatch")
+        points = mesh.get("points", [])
+        if mesh.get("representative_point_count") != len(points):
+            raise ValueError("Aluminum workload representative count mismatch")
+        weight = sum(float(point["weight"]) for point in points)
+        if not np.isclose(weight, 1.0, atol=1.0e-12):
+            raise ValueError("Aluminum workload k-point weights are not normalized")
+
+
+def load_aluminum_workload(path: str | Path) -> tuple[dict[str, Any], Path]:
+    """Load and strictly validate a prepared Aluminum workload."""
+
+    manifest_path = Path(path).resolve()
+    payload = json.loads(manifest_path.read_text())
+    if payload.get("schema_version") != WORKLOAD_SCHEMA or payload.get("target_id") != TARGET_ID:
+        raise ValueError("unsupported Aluminum workload schema or target")
+    expected = payload.get("workload_fingerprint")
+    unsigned = {key: value for key, value in payload.items() if key != "workload_fingerprint"}
+    if expected != sha256_bytes(canonical_json_bytes(unsigned)):
+        raise ValueError("Aluminum workload fingerprint mismatch")
+    relative = payload.get("resource", {}).get("path")
+    if relative != "resources/Al-GTH-PBE-q3.gth":
+        raise ValueError("Aluminum workload resource path mismatch")
+    resource = (manifest_path.parent / relative).resolve()
+    if not resource.is_relative_to(manifest_path.parent) or not resource.is_file():
+        raise ValueError("Aluminum workload resource is missing or unconfined")
+    if (
+        resource.is_symlink()
+        or sha256_bytes(resource.read_bytes()) != payload["resource"]["sha256"]
+    ):
+        raise ValueError("Aluminum workload resource hash mismatch")
+    if payload.get("system", {}).get("fractional_positions") != [
+        list(row) for row in ALUMINUM_FRACTIONAL_POSITIONS
+    ]:
+        raise ValueError("Aluminum workload structure mismatch")
+    _validate_reduced_meshes(payload)
+    return payload, resource
+
+
+def kpoint_mesh_from_workload(workload: Mapping[str, Any], size: int) -> KPointMesh:
+    """Rebuild one fingerprinted reduced k-point mesh from a workload."""
+
+    try:
+        payload = workload["reduced_kpoint_meshes"][str(int(size))]
+    except KeyError as error:
+        raise ValueError(f"Aluminum workload does not contain k-point mesh {size}") from error
+    return KPointMesh(
+        [
+            KPoint(
+                point["vector"],
+                weight=float(point["weight"]),
+                coordinate_system="reduced",
+            )
+            for point in payload["points"]
+        ]
+    )
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(" ".join(f"{key}={value}" for key, value in payload.items()))
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the Aluminum workload preparation and validation CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--gth-source", type=Path, required=True)
+    prepare.add_argument("--out", type=Path, required=True)
+    prepare.add_argument("--json", action="store_true")
+
+    point = subparsers.add_parser("eos-point")
+    point.add_argument("--manifest", type=Path, required=True)
+    point.add_argument("--profile", required=True)
+    point.add_argument("--volume-index", type=int, required=True)
+    point.add_argument("--out", type=Path, required=True)
+    point.add_argument("--initial-density", type=Path)
+    point.add_argument("--json", action="store_true")
+
+    validate = subparsers.add_parser("validate-eos")
+    validate.add_argument("--manifest", type=Path, required=True)
+    validate.add_argument("--out", type=Path, required=True)
+    validate.add_argument("--dry-run", action="store_true")
+    validate.add_argument("--summarize-only", action="store_true")
+    validate.add_argument("--json", action="store_true")
+
+    args = parser.parse_args(argv)
+    if args.command == "prepare":
+        payload = prepare_aluminum_workload(gth_source=args.gth_source, out=args.out)
+    elif args.command == "eos-point":
+        from mlx_atomistic.benchmarks.dft_aluminum_eos_runner import run_aluminum_eos_point
+
+        payload = run_aluminum_eos_point(
+            manifest_path=args.manifest,
+            profile=args.profile,
+            volume_index=args.volume_index,
+            out=args.out,
+            initial_density_path=args.initial_density,
+        )
+    else:
+        from mlx_atomistic.benchmarks.dft_aluminum_eos_runner import (
+            run_aluminum_eos_validation,
+        )
+
+        payload = run_aluminum_eos_validation(
+            manifest_path=args.manifest,
+            out=args.out,
+            dry_run=args.dry_run,
+            summarize_only=args.summarize_only,
+        )
+    _print_payload(payload, as_json=args.json)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mlx_atomistic/benchmarks/dft_aluminum_eos.py
+++ b/src/mlx_atomistic/benchmarks/dft_aluminum_eos.py
@@ -1,4 +1,4 @@
-"""Scientific equation-of-state validation for rock-salt magnesium oxide."""
+"""Scientific equation-of-state validation for periodic fcc Aluminum."""
 
 from __future__ import annotations
 
@@ -20,24 +20,24 @@ from mlx_atomistic.benchmarks.dft_eos import (
     reference_fit,
 )
 
-REFERENCE_SCHEMA = "mlx-atomistic.mgo-eos-references.v1"
-REFERENCE_SHA256 = "ad4e262690181b6f009e5683eadb8402ee47c73acee32ca96873c95cf1c3e5ea"
-EOS_REPORT_SCHEMA = "mlx-atomistic.mgo-eos-report.v1"
+REFERENCE_SCHEMA = "mlx-atomistic.aluminum-eos-references.v1"
+REFERENCE_SHA256 = "eebfe487557fcff52b1934ced8924844c307e0cfe30c739987e36734890a6788"
+EOS_REPORT_SCHEMA = "mlx-atomistic.aluminum-eos-report.v1"
 
 
 def _reference_path() -> Path:
-    return Path(__file__).with_name("data") / "mgo_eos_references.json"
+    return Path(__file__).with_name("data") / "aluminum_eos_references.json"
 
 
-def load_mgo_eos_references() -> dict[str, Any]:
-    """Load the pinned, source-attributed rock-salt MgO reference bundle."""
+def load_aluminum_eos_references() -> dict[str, Any]:
+    """Load the pinned, source-attributed fcc Aluminum reference bundle."""
 
     return load_eos_reference_bundle(
         _reference_path(),
         expected_sha256=REFERENCE_SHA256,
         expected_schema=REFERENCE_SCHEMA,
         expected_material={
-            "cell": "rocksalt-mgo",
+            "cell": "fcc-aluminum",
             "functional": "PBE",
             "spin": "unpolarized",
         },
@@ -49,21 +49,21 @@ def validation_lattice_constants(
 ) -> list[float]:
     """Return the seven conventional-cell lattice constants for validation."""
 
-    payload = load_mgo_eos_references() if references is None else references
+    payload = load_aluminum_eos_references() if references is None else references
     return cubic_validation_lattice_constants(payload)
 
 
-def fit_cubic_mgo_eos(
+def fit_cubic_aluminum_eos(
     lattice_constants_angstrom: Sequence[float],
-    total_energies_hartree: Sequence[float],
+    free_energies_hartree: Sequence[float],
     *,
-    atom_count: int = 8,
+    atom_count: int = 4,
 ) -> dict[str, Any]:
-    """Fit a conventional cubic-cell rock-salt MgO EOS."""
+    """Fit a conventional cubic-cell Aluminum EOS from free energies."""
 
     return fit_cubic_eos(
         lattice_constants_angstrom,
-        total_energies_hartree,
+        free_energies_hartree,
         atom_count=atom_count,
     )
 
@@ -79,8 +79,8 @@ __all__ = [
     "compare_fit_to_reference",
     "delta_factor_mev_per_atom",
     "fit_birch_murnaghan",
-    "fit_cubic_mgo_eos",
-    "load_mgo_eos_references",
+    "fit_cubic_aluminum_eos",
+    "load_aluminum_eos_references",
     "reference_fit",
     "validation_lattice_constants",
 ]

--- a/src/mlx_atomistic/benchmarks/dft_aluminum_eos_runner.py
+++ b/src/mlx_atomistic/benchmarks/dft_aluminum_eos_runner.py
@@ -1,0 +1,1107 @@
+"""Bounded metallic convergence and EOS validation for fcc Aluminum."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from functools import lru_cache
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import numpy as np
+
+from mlx_atomistic._artifact_identity import canonical_json_bytes, sha256_bytes
+from mlx_atomistic.benchmarks.dft_aluminum import (
+    kpoint_mesh_from_workload,
+    load_aluminum_workload,
+)
+from mlx_atomistic.benchmarks.dft_aluminum_eos import (
+    EOS_REPORT_SCHEMA,
+    HARTREE_TO_EV,
+    REFERENCE_SHA256,
+    compare_eos_convergence,
+    compare_fit_to_reference,
+    fit_cubic_aluminum_eos,
+    load_aluminum_eos_references,
+    reference_fit,
+    validation_lattice_constants,
+)
+from mlx_atomistic.benchmarks.dft_silicon import ANGSTROM_TO_BOHR
+
+POINT_SCHEMA = "mlx-atomistic.aluminum-eos-point.v1"
+SCREEN_INDICES = (2, 3, 4)
+FULL_INDICES = tuple(range(7))
+SCREEN_MESH_SIZE = 11
+SHAPE_THRESHOLD_MEV_PER_ATOM = 1.0
+SYMMETRY_ENERGY_THRESHOLD_HARTREE_PER_ATOM = 5.0e-5
+SYMMETRY_ORACLE_BANDS = 12
+_PROFILE_RE = re.compile(
+    r"^c(?P<cutoff>\d+)-k(?P<mesh>\d+)(?:-(?P<mode>full|reduced))?-b(?P<bands>\d+)$"
+)
+
+
+def _write_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_bytes(canonical_json_bytes(dict(payload)))
+    temporary.replace(path)
+
+
+def _profile_name(
+    cutoff: int,
+    mesh: int,
+    bands: int,
+    *,
+    mode: str | None = None,
+) -> str:
+    suffix = "" if mode is None else f"-{mode}"
+    return f"c{cutoff}-k{mesh}{suffix}-b{bands}"
+
+
+def _profile_settings(manifest: Mapping[str, Any], profile: str) -> dict[str, Any]:
+    match = _PROFILE_RE.fullmatch(profile)
+    if match is None:
+        raise ValueError(f"invalid Aluminum EOS profile: {profile}")
+    cutoff = int(match.group("cutoff"))
+    mesh = int(match.group("mesh"))
+    bands = int(match.group("bands"))
+    mode = match.group("mode")
+    validation = manifest["validation"]
+    if float(cutoff) not in validation["cutoff_candidates_hartree"]:
+        raise ValueError(f"unsupported Aluminum cutoff profile: {profile}")
+    if bands not in validation["band_capacity_candidates"]:
+        raise ValueError(f"unsupported Aluminum band profile: {profile}")
+    if mode is None:
+        if mesh not in validation["kpoint_mesh_sizes"]:
+            raise ValueError(f"unsupported Aluminum k-point profile: {profile}")
+        mode = "reduced"
+    elif mesh != int(validation["full_grid_oracle_size"]):
+        raise ValueError("full/reduced oracle profiles require the locked oracle mesh")
+    fft_size = int(validation["fft_shape_by_cutoff"][str(cutoff)])
+    return {
+        "cutoff_hartree": float(cutoff),
+        "fft_shape": [fft_size, fft_size, fft_size],
+        "kpoint_mesh_size": mesh,
+        "kpoint_mode": mode,
+        "n_bands": bands,
+        "max_batch_transient_bytes": 1024 * 1024**2,
+        "timeout_seconds": float(validation["point_timeout_seconds"]),
+        "memory_limit_bytes": int(validation["memory_limit_bytes"]),
+    }
+
+
+def _implementation_fingerprint() -> str:
+    contract = {
+        "schema_version": "mlx-atomistic.aluminum-eos-point-execution.v1",
+        "point_schema": POINT_SCHEMA,
+        "profile_source": inspect.getsource(_profile_settings),
+        "scf_config_source": inspect.getsource(_scf_config),
+        "point_execution_source": inspect.getsource(run_aluminum_eos_point),
+    }
+    return sha256_bytes(canonical_json_bytes(contract))
+
+
+@lru_cache(maxsize=1)
+def _runtime_fingerprint() -> str:
+    from mlx_atomistic.benchmarks.dft_runtime_contract import build_source_fingerprints
+
+    return str(build_source_fingerprints()["runtime_fingerprint"])
+
+
+def _point_spec(
+    *,
+    manifest: Mapping[str, Any],
+    profile: str,
+    volume_index: int,
+    initial_density_sha256: str | None = None,
+) -> dict[str, Any]:
+    settings = _profile_settings(manifest, profile)
+    values = {
+        "workload_fingerprint": manifest["workload_fingerprint"],
+        "runtime_fingerprint": _runtime_fingerprint(),
+        "eos_implementation_fingerprint": _implementation_fingerprint(),
+        "reference_sha256": REFERENCE_SHA256,
+        "profile": profile,
+        "volume_index": volume_index,
+        "lattice_constant_angstrom": validation_lattice_constants()[volume_index],
+        "initial_density_sha256": initial_density_sha256,
+        **settings,
+    }
+    return {**values, "point_fingerprint": sha256_bytes(canonical_json_bytes(values))}
+
+
+def _scf_config(
+    manifest: Mapping[str, Any],
+    *,
+    max_batch_transient_bytes: int,
+) -> Any:
+    from mlx_atomistic.dft import (
+        PeriodicDavidsonConfig,
+        PeriodicFermiDiracSmearing,
+        PeriodicSCFConfig,
+    )
+
+    scf = manifest["solver"]["scf"]
+    davidson = manifest["solver"]["davidson"]
+    return PeriodicSCFConfig(
+        max_iterations=int(scf["max_iterations"]),
+        min_iterations=int(scf["min_iterations"]),
+        density_tolerance=float(scf["density_tolerance"]),
+        energy_tolerance=float(scf["energy_tolerance_hartree"]),
+        orbital_tolerance=float(scf["orbital_tolerance"]),
+        mixing_beta=float(scf["mixing_beta"]),
+        mixer=str(scf["mixer"]),
+        max_batch_transient_bytes=max_batch_transient_bytes,
+        adaptive_eigensolver_tolerance=bool(scf["adaptive_eigensolver_tolerance"]),
+        initial_eigensolver_tolerance=float(scf["initial_eigensolver_tolerance"]),
+        eigensolver_tolerance_scale=float(scf["eigensolver_tolerance_scale"]),
+        smearing=PeriodicFermiDiracSmearing(
+            width_hartree=float(manifest["physics"]["smearing_width_hartree"])
+        ),
+        davidson=PeriodicDavidsonConfig(
+            max_iterations=int(davidson["max_iterations"]),
+            tolerance=float(davidson["tolerance"]),
+            max_subspace_size=int(davidson["max_subspace_size"]),
+            preconditioner_floor=float(davidson["preconditioner_floor"]),
+        ),
+    )
+
+
+def _mesh_for_profile(manifest: Mapping[str, Any], settings: Mapping[str, Any]) -> Any:
+    from mlx_atomistic.dft import (
+        GammaCenteredGrid,
+        cubic_reciprocal_symmetry_operations,
+        reduce_kpoint_mesh_by_symmetry,
+    )
+
+    size = int(settings["kpoint_mesh_size"])
+    mode = settings["kpoint_mode"]
+    if size in manifest["validation"]["kpoint_mesh_sizes"]:
+        if mode != "reduced":
+            raise ValueError("production Aluminum meshes must use fingerprinted reduction")
+        return kpoint_mesh_from_workload(manifest, size)
+    full = GammaCenteredGrid((size, size, size))
+    if mode == "full":
+        return full
+    return reduce_kpoint_mesh_by_symmetry(
+        full,
+        cubic_reciprocal_symmetry_operations(),
+    )
+
+
+def run_aluminum_eos_point(
+    *,
+    manifest_path: str | Path,
+    profile: str,
+    volume_index: int,
+    out: str | Path,
+    initial_density_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Run one isolated Aluminum EOS point and persist compact evidence."""
+
+    import mlx.core as mx
+
+    from mlx_atomistic.benchmarks.dft_runtime_contract import collect_host_provenance
+    from mlx_atomistic.dft import PeriodicDFTSystem, read_gth, run_periodic_scf
+    from mlx_atomistic.dft._runtime_observer import RuntimeObserver
+
+    if volume_index not in FULL_INDICES:
+        raise ValueError("Aluminum EOS volume_index must lie in [0, 6]")
+    manifest, resource = load_aluminum_workload(manifest_path)
+    settings = _profile_settings(manifest, profile)
+    lattice_angstrom = validation_lattice_constants()[volume_index]
+    initial_density = None
+    initial_density_sha256 = None
+    if initial_density_path is not None:
+        density_path = Path(initial_density_path)
+        if density_path.is_symlink() or not density_path.is_file():
+            raise ValueError("initial density must be a regular existing file")
+        density_bytes = density_path.read_bytes()
+        initial_density_sha256 = sha256_bytes(density_bytes)
+        initial_density = np.load(density_path, allow_pickle=False)
+    spec = _point_spec(
+        manifest=manifest,
+        profile=profile,
+        volume_index=volume_index,
+        initial_density_sha256=initial_density_sha256,
+    )
+    lattice_bohr = lattice_angstrom * ANGSTROM_TO_BOHR
+    fractional = np.asarray(manifest["system"]["fractional_positions"], dtype=np.float64)
+    system = PeriodicDFTSystem(
+        (lattice_bohr, lattice_bohr, lattice_bohr),
+        settings["fft_shape"],
+        fractional * lattice_bohr,
+        read_gth(resource, element="Al", name="GTH-PBE-q3"),
+        electron_count=float(manifest["system"]["electron_count"]),
+    )
+    observer = RuntimeObserver(detail_events=False)
+    host = collect_host_provenance()
+    started = perf_counter()
+    result = run_periodic_scf(
+        system,
+        cutoff_hartree=float(settings["cutoff_hartree"]),
+        kpoint_mesh=_mesh_for_profile(manifest, settings),
+        n_bands=int(settings["n_bands"]),
+        config=_scf_config(
+            manifest,
+            max_batch_transient_bytes=int(settings["max_batch_transient_bytes"]),
+        ),
+        observer=observer,
+        initial_density=initial_density,
+    )
+    mx.synchronize()
+    elapsed = perf_counter() - started
+
+    electron_error = abs(float(result.electron_count) - float(manifest["system"]["electron_count"]))
+    maximum_overlap = max(float(item.eigen.orthonormality_error) for item in result.owned_kpoints)
+    maximum_residual = max(
+        float(np.max(np.asarray(item.eigen.residuals))) for item in result.owned_kpoints
+    )
+    occupations = [
+        tuple(float(value) for value in point.occupations or ()) for point in result.kpoints
+    ]
+    if not occupations or any(len(values) != int(settings["n_bands"]) for values in occupations):
+        raise RuntimeError("Aluminum metallic result did not publish band occupations")
+    highest_band_occupation = max(values[-1] for values in occupations)
+    fractional_occupation_count = sum(
+        1 for values in occupations for value in values if 1.0e-6 < value < 2.0 - 1.0e-6
+    )
+    width = float(manifest["physics"]["smearing_width_hartree"])
+    internal_energy = float(result.internal_energy)
+    entropy = float(result.electronic_entropy)
+    free_energy_identity_error = abs(
+        float(result.total_energy) - (internal_energy - width * entropy)
+    )
+    gates = manifest["numerical_gates"]
+    numerical_passed = bool(
+        result.converged
+        and np.isfinite(
+            [
+                result.total_energy,
+                internal_energy,
+                entropy,
+                result.chemical_potential,
+            ]
+        ).all()
+        and electron_error <= float(gates["electron_count_abs_per_cell"])
+        and maximum_overlap <= float(gates["orthonormality_max"])
+        and maximum_residual <= float(gates["orbital_residual_max"])
+        and highest_band_occupation <= float(gates["highest_band_occupation_max"])
+        and free_energy_identity_error <= float(gates["free_energy_identity_abs_hartree"])
+        and fractional_occupation_count > 0
+    )
+    observation = observer.snapshot()
+    density_output = Path(out).with_name("density.npy")
+    density_temporary = density_output.with_name(f".{density_output.name}.tmp")
+    density_output.parent.mkdir(parents=True, exist_ok=True)
+    with density_temporary.open("wb") as handle:
+        np.save(handle, np.asarray(result.density), allow_pickle=False)
+    density_temporary.replace(density_output)
+    density_sha256 = sha256_bytes(density_output.read_bytes())
+    payload = {
+        "schema_version": POINT_SCHEMA,
+        "status": "ok" if numerical_passed else "failed",
+        "numerical_passed": numerical_passed,
+        "point": spec,
+        "method": {
+            "functional": manifest["physics"]["exchange_correlation"],
+            "pseudopotential": manifest["physics"]["pseudopotential"],
+            "occupation": manifest["physics"]["occupation"],
+            "smearing_width_hartree": width,
+            "energy_observable": manifest["physics"]["energy_observable"],
+            "atoms": int(manifest["system"]["atom_count"]),
+            "electrons": int(manifest["system"]["electron_count"]),
+            "bands": int(settings["n_bands"]),
+        },
+        "host": host,
+        "result": {
+            "free_energy_hartree": float(result.total_energy),
+            "internal_energy_hartree": internal_energy,
+            "electronic_entropy": entropy,
+            "chemical_potential_hartree": float(result.chemical_potential),
+            "free_energy_identity_error_hartree": free_energy_identity_error,
+            "converged": bool(result.converged),
+            "scf_iterations": int(result.iterations),
+            "electron_count": float(result.electron_count),
+            "electron_count_error": electron_error,
+            "maximum_orbital_residual": maximum_residual,
+            "maximum_orthonormality_error": maximum_overlap,
+            "highest_band_occupation": highest_band_occupation,
+            "fractional_occupation_count": fractional_occupation_count,
+            "density_residual": float(result.density_residual),
+            "energy_delta_hartree": (
+                None if result.energy_delta is None else float(result.energy_delta)
+            ),
+            "explicit_kpoint_count": len(result.kpoints),
+            "representative_kpoint_count": len(result.owned_kpoints),
+            "elapsed_wall_seconds": elapsed,
+            "timings_ms": dict(result.timings),
+            "observation": {
+                "total_elapsed_seconds": observation["total_elapsed_seconds"],
+                "phase_seconds": observation["phase_seconds"],
+                "work_counters": observation["work_counters"],
+                "memory": observation["memory"],
+            },
+            "density_artifact": {
+                "path": density_output.name,
+                "sha256": density_sha256,
+                "shape": list(result.density.shape),
+            },
+        },
+    }
+    _write_atomic(Path(out), payload)
+    return payload
+
+
+def _ordered_rows(
+    rows: Sequence[Mapping[str, Any]],
+    profile: str,
+    indices: Sequence[int],
+) -> list[Mapping[str, Any]]:
+    selected = [
+        row
+        for row in rows
+        if row["point"]["profile"] == profile and int(row["point"]["volume_index"]) in indices
+    ]
+    return sorted(selected, key=lambda row: int(row["point"]["volume_index"]))
+
+
+def _shape_comparison(
+    baseline_rows: Sequence[Mapping[str, Any]],
+    candidate_rows: Sequence[Mapping[str, Any]],
+    *,
+    atom_count: int,
+) -> dict[str, Any]:
+    first = sorted(baseline_rows, key=lambda row: int(row["point"]["volume_index"]))
+    second = sorted(candidate_rows, key=lambda row: int(row["point"]["volume_index"]))
+    expected = list(SCREEN_INDICES)
+    if (
+        len(first) != 3
+        or len(second) != 3
+        or [row["point"]["volume_index"] for row in first] != expected
+        or [row["point"]["volume_index"] for row in second] != expected
+        or not all(row.get("numerical_passed") is True for row in [*first, *second])
+    ):
+        return {"status": "blocked", "blocker": "shape_comparison_incomplete", "passed": False}
+    first_energy = np.asarray([row["result"]["free_energy_hartree"] for row in first])
+    second_energy = np.asarray([row["result"]["free_energy_hartree"] for row in second])
+    maximum = float(
+        np.max(np.abs((second_energy - second_energy[1]) - (first_energy - first_energy[1])))
+        * HARTREE_TO_EV
+        * 1000.0
+        / atom_count
+    )
+    return {
+        "status": "ok" if maximum <= SHAPE_THRESHOLD_MEV_PER_ATOM else "failed",
+        "passed": maximum <= SHAPE_THRESHOLD_MEV_PER_ATOM,
+        "scope": "central_three_volume_free_energy_shape",
+        "metrics": {"curve_max_mev_per_atom": maximum},
+        "thresholds": {"curve_max_mev_per_atom": SHAPE_THRESHOLD_MEV_PER_ATOM},
+    }
+
+
+def _fit_profile(
+    rows: Sequence[Mapping[str, Any]],
+    profile: str,
+    *,
+    atom_count: int,
+) -> dict[str, Any]:
+    ordered = _ordered_rows(rows, profile, FULL_INDICES)
+    if len(ordered) != 7 or not all(row.get("numerical_passed") is True for row in ordered):
+        return {"status": "blocked", "blocker": "seven_point_profile_incomplete_or_failed"}
+    return fit_cubic_aluminum_eos(
+        [float(row["point"]["lattice_constant_angstrom"]) for row in ordered],
+        [float(row["result"]["free_energy_hartree"]) for row in ordered],
+        atom_count=atom_count,
+    )
+
+
+def _load_matching_point(path: Path, expected: Mapping[str, Any]) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text())
+    point = payload.get("point", {})
+    if (
+        payload.get("schema_version") != POINT_SCHEMA
+        or not isinstance(point, dict)
+        or point.get("point_fingerprint") != expected["point_fingerprint"]
+    ):
+        raise ValueError(f"refusing mismatched Aluminum EOS point artifact: {path}")
+    return payload
+
+
+def _run_bounded_point(
+    *,
+    manifest_path: Path,
+    output: Path,
+    spec: Mapping[str, Any],
+    initial_density_path: Path | None = None,
+    root_name: str = "points",
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    profile = str(spec["profile"])
+    index = int(spec["volume_index"])
+    point_root = output / root_name / profile / f"v{index}"
+    report_path = point_root / "report.json"
+    existing = _load_matching_point(report_path, spec)
+    if existing is not None:
+        return existing, None
+    point_root.mkdir(parents=True, exist_ok=True)
+    trace_path = point_root / "memory.json"
+    command = [
+        sys.executable,
+        "scripts/run_bounded_process.py",
+        "--max-bytes",
+        str(spec["memory_limit_bytes"]),
+        "--poll-seconds",
+        "0.25",
+        "--timeout-seconds",
+        str(spec["timeout_seconds"]),
+        "--trace-out",
+        str(trace_path),
+        "--",
+        sys.executable,
+        "-m",
+        "mlx_atomistic.benchmarks.dft_aluminum",
+        "eos-point",
+        "--manifest",
+        str(manifest_path),
+        "--profile",
+        profile,
+        "--volume-index",
+        str(index),
+        "--out",
+        str(report_path),
+    ]
+    if initial_density_path is not None:
+        command.extend(["--initial-density", str(initial_density_path)])
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    (point_root / "stdout.txt").write_text(completed.stdout)
+    (point_root / "stderr.txt").write_text(completed.stderr)
+    if completed.returncode != 0 or not report_path.is_file():
+        trace = json.loads(trace_path.read_text()) if trace_path.is_file() else {}
+        return None, {
+            "blocker": f"point_execution_failed:{profile}:v{index}",
+            "returncode": completed.returncode,
+            "timed_out": trace.get("bounded_process_timed_out"),
+            "memory_exceeded": trace.get("bounded_process_exceeded"),
+            "peak_physical_bytes": trace.get("bounded_process_peak_physical_bytes"),
+            "stdout": str(point_root / "stdout.txt"),
+            "stderr": str(point_root / "stderr.txt"),
+        }
+    return _load_matching_point(report_path, spec), None
+
+
+def _plan_spec(
+    manifest: Mapping[str, Any],
+    profile: str,
+    index: int,
+    initial_density_path: Path | None = None,
+) -> dict[str, Any]:
+    digest = (
+        None if initial_density_path is None else sha256_bytes(initial_density_path.read_bytes())
+    )
+    return _point_spec(
+        manifest=manifest,
+        profile=profile,
+        volume_index=index,
+        initial_density_sha256=digest,
+    )
+
+
+def _ensure_profile_indices(
+    *,
+    manifest_path: Path,
+    manifest: Mapping[str, Any],
+    output: Path,
+    rows: list[dict[str, Any]],
+    profile: str,
+    indices: Sequence[int],
+) -> dict[str, Any] | None:
+    known = {(str(row["point"]["profile"]), int(row["point"]["volume_index"])): row for row in rows}
+    failure = _ensure_profile_point(
+        manifest_path=manifest_path,
+        manifest=manifest,
+        output=output,
+        rows=rows,
+        known=known,
+        profile=profile,
+        index=3,
+    )
+    if failure is not None:
+        return failure
+    center_key = (profile, 3)
+    center = known[center_key]
+    if center.get("numerical_passed") is not True:
+        return None
+    density_path = output / "points" / profile / "v3" / "density.npy"
+    if not density_path.is_file():
+        return {"blocker": f"density_seed_missing:{profile}"}
+    for index in indices:
+        if index == 3:
+            continue
+        failure = _ensure_profile_point(
+            manifest_path=manifest_path,
+            manifest=manifest,
+            output=output,
+            rows=rows,
+            known=known,
+            profile=profile,
+            index=index,
+            density_path=density_path,
+        )
+        if failure is not None:
+            return failure
+    return None
+
+
+def _ensure_profile_point(
+    *,
+    manifest_path: Path,
+    manifest: Mapping[str, Any],
+    output: Path,
+    rows: list[dict[str, Any]],
+    known: dict[tuple[str, int], dict[str, Any]],
+    profile: str,
+    index: int,
+    density_path: Path | None = None,
+) -> dict[str, Any] | None:
+    key = (profile, index)
+    spec = _plan_spec(manifest, profile, index, density_path)
+    if key in known:
+        if known[key]["point"]["point_fingerprint"] != spec["point_fingerprint"]:
+            raise ValueError(f"refusing stale Aluminum EOS point: {profile}:v{index}")
+        return None
+    report, failure = _run_bounded_point(
+        manifest_path=manifest_path,
+        output=output,
+        spec=spec,
+        initial_density_path=density_path,
+    )
+    if failure is not None:
+        return failure
+    if report is None:
+        return {"blocker": f"point_artifact_missing:{profile}:v{index}"}
+    rows.append(report)
+    known[key] = report
+    return None
+
+
+def _existing_rows(output: Path) -> list[dict[str, Any]]:
+    rows = []
+    for path in sorted((output / "points").glob("*/v*/report.json")):
+        payload = json.loads(path.read_text())
+        if payload.get("schema_version") == POINT_SCHEMA:
+            rows.append(payload)
+    return rows
+
+
+def _failure_report(
+    output: Path,
+    *,
+    blocker: str,
+    rows: Sequence[Mapping[str, Any]],
+    detail: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": EOS_REPORT_SCHEMA,
+        "status": "failed",
+        "admitted": False,
+        "blockers": [blocker],
+        "completed_point_count": len(rows),
+        "detail": None if detail is None else dict(detail),
+    }
+    _write_atomic(output / "report.json", payload)
+    return payload
+
+
+def _symmetry_comparison(
+    rows: Sequence[Mapping[str, Any]],
+    full_profile: str,
+    reduced_profile: str,
+    *,
+    atom_count: int,
+) -> dict[str, Any]:
+    full = _ordered_rows(rows, full_profile, (3,))
+    reduced = _ordered_rows(rows, reduced_profile, (3,))
+    if (
+        len(full) != 1
+        or len(reduced) != 1
+        or full[0].get("numerical_passed") is not True
+        or reduced[0].get("numerical_passed") is not True
+    ):
+        return {"status": "blocked", "passed": False, "blocker": "symmetry_oracle_failed"}
+    error = (
+        abs(
+            float(full[0]["result"]["free_energy_hartree"])
+            - float(reduced[0]["result"]["free_energy_hartree"])
+        )
+        / atom_count
+    )
+    return {
+        "status": "ok" if error <= SYMMETRY_ENERGY_THRESHOLD_HARTREE_PER_ATOM else "failed",
+        "passed": error <= SYMMETRY_ENERGY_THRESHOLD_HARTREE_PER_ATOM,
+        "free_energy_abs_hartree_per_atom": error,
+        "threshold_hartree_per_atom": SYMMETRY_ENERGY_THRESHOLD_HARTREE_PER_ATOM,
+        "full_point_count": int(full[0]["result"]["explicit_kpoint_count"]),
+        "reduced_point_count": int(reduced[0]["result"]["explicit_kpoint_count"]),
+    }
+
+
+def _selected_runtime_summary(
+    rows: Sequence[Mapping[str, Any]],
+    profile: str,
+    output: Path,
+) -> dict[str, Any]:
+    selected = _ordered_rows(rows, profile, FULL_INDICES)
+    physical_peaks = []
+    runtime_temporary_peaks = []
+    runtime_persistent_payloads = []
+    for row in selected:
+        volume_index = int(row["point"]["volume_index"])
+        trace_path = output / "points" / profile / f"v{volume_index}" / "memory.json"
+        if trace_path.is_file():
+            trace = json.loads(trace_path.read_text())
+            value = trace.get("bounded_process_peak_physical_bytes")
+            if value is not None:
+                physical_peaks.append(int(value))
+        memory = row["result"]["observation"]["memory"]
+        temporary = memory.get("peak_temporary_bytes")
+        if temporary is not None:
+            runtime_temporary_peaks.append(int(temporary))
+        persistent = sum(
+            int(memory.get(field) or 0)
+            for field in (
+                "persistent_coefficient_bytes",
+                "persistent_projector_bytes",
+                "shared_full_grid_bytes",
+            )
+        )
+        runtime_persistent_payloads.append(persistent)
+    power_states = sorted(
+        {
+            (
+                row["host"].get("power_source"),
+                row["host"].get("low_power_mode"),
+                row["host"].get("thermal_pressure"),
+            )
+            for row in selected
+        },
+        key=str,
+    )
+    return {
+        "complete_wall_seconds": sum(
+            float(row["result"]["elapsed_wall_seconds"]) for row in selected
+        ),
+        "maximum_process_physical_bytes": max(physical_peaks, default=None),
+        "maximum_runtime_peak_temporary_bytes": max(
+            runtime_temporary_peaks,
+            default=None,
+        ),
+        "maximum_runtime_persistent_payload_bytes": max(
+            runtime_persistent_payloads,
+            default=None,
+        ),
+        "point_walls_seconds": [float(row["result"]["elapsed_wall_seconds"]) for row in selected],
+        "host_power_states": [
+            {
+                "power_source": state[0],
+                "low_power_mode": state[1],
+                "thermal_pressure": state[2],
+            }
+            for state in power_states
+        ],
+        "host_power_state_consistent": len(power_states) == 1,
+    }
+
+
+def _dry_run_plan(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    validation = manifest["validation"]
+    cutoffs = [int(value) for value in validation["cutoff_candidates_hartree"]]
+    meshes = [int(value) for value in validation["kpoint_mesh_sizes"]]
+    bands = [int(value) for value in validation["band_capacity_candidates"]]
+    return {
+        "schema_version": EOS_REPORT_SCHEMA,
+        "status": "planned",
+        "decision_ladder": [
+            "validate 4x4x4 full versus cubic-symmetry-reduced SCF",
+            "admit the first complete band capacity at the densest mesh and largest volume",
+            "screen adjacent cutoff pairs over volume indices 2,3,4",
+            "screen adjacent Gamma-centered k-point pairs over volume indices 2,3,4",
+            "complete selected, upper-cutoff, and upper-kpoint seven-volume curves",
+            "compare the selected EOS with the all-electron ACWF reference",
+        ],
+        "cutoff_candidates_hartree": cutoffs,
+        "kpoint_mesh_sizes": meshes,
+        "band_capacity_candidates": bands,
+        "screen_bands": "selected by adjacent capacity convergence",
+        "screen_mesh_size": SCREEN_MESH_SIZE,
+        "maximum_point_count": 57,
+        "memory_limit_bytes": validation["memory_limit_bytes"],
+        "point_timeout_seconds": validation["point_timeout_seconds"],
+    }
+
+
+def run_aluminum_eos_validation(
+    *,
+    manifest_path: str | Path,
+    out: str | Path,
+    dry_run: bool = False,
+    summarize_only: bool = False,
+) -> dict[str, Any]:
+    """Run the fail-early Aluminum metallic admission ladder."""
+
+    if dry_run and summarize_only:
+        raise ValueError("--dry-run and --summarize-only are mutually exclusive")
+    manifest_file = Path(manifest_path).resolve()
+    manifest, _resource = load_aluminum_workload(manifest_file)
+    output = Path(out)
+    if dry_run:
+        payload = _dry_run_plan(manifest)
+        _write_atomic(output / "plan.json", payload)
+        return payload
+    rows = _existing_rows(output)
+    if summarize_only:
+        report_path = output / "report.json"
+        report = json.loads(report_path.read_text()) if report_path.is_file() else {}
+        payload = {
+            "schema_version": EOS_REPORT_SCHEMA,
+            "status": "passed" if report.get("admitted") is True else "partial",
+            "admitted": report.get("admitted") is True,
+            "scientifically_verified": report.get("scientifically_verified") is True,
+            "evidence_status": "complete" if report.get("admitted") is True else "partial",
+            "completed_point_count": len(rows),
+        }
+        _write_atomic(output / "summary.json", payload)
+        return payload
+
+    validation = manifest["validation"]
+    atom_count = int(manifest["system"]["atom_count"])
+    oracle_size = int(validation["full_grid_oracle_size"])
+    oracle_cutoff = int(validation["cutoff_candidates_hartree"][0])
+    oracle_bands = SYMMETRY_ORACLE_BANDS
+    if oracle_bands not in validation["band_capacity_candidates"]:
+        raise ValueError("locked symmetry-oracle band count is not in the workload ladder")
+    full_oracle = _profile_name(oracle_cutoff, oracle_size, oracle_bands, mode="full")
+    reduced_oracle = _profile_name(oracle_cutoff, oracle_size, oracle_bands, mode="reduced")
+    for profile in (full_oracle, reduced_oracle):
+        failure = _ensure_profile_indices(
+            manifest_path=manifest_file,
+            manifest=manifest,
+            output=output,
+            rows=rows,
+            profile=profile,
+            indices=(3,),
+        )
+        if failure is not None:
+            return _failure_report(
+                output, blocker=str(failure["blocker"]), rows=rows, detail=failure
+            )
+    symmetry = _symmetry_comparison(rows, full_oracle, reduced_oracle, atom_count=atom_count)
+    if symmetry.get("passed") is not True:
+        return _failure_report(output, blocker="symmetry_oracle_failed", rows=rows, detail=symmetry)
+
+    cutoffs = [int(value) for value in validation["cutoff_candidates_hartree"]]
+    meshes = [int(value) for value in validation["kpoint_mesh_sizes"]]
+    bands = [int(value) for value in validation["band_capacity_candidates"]]
+    selected_bands = None
+    band_checks = []
+    capacity_rows = []
+    capacity_mesh = meshes[-1]
+    capacity_volume = FULL_INDICES[-1]
+    capacity_density = output / "points" / reduced_oracle / "v3" / "density.npy"
+    for candidate_bands in bands:
+        profile = _profile_name(cutoffs[0], capacity_mesh, candidate_bands)
+        spec = _plan_spec(
+            manifest,
+            profile,
+            capacity_volume,
+            capacity_density,
+        )
+        report, failure = _run_bounded_point(
+            manifest_path=manifest_file,
+            output=output,
+            spec=spec,
+            initial_density_path=capacity_density,
+            root_name="capacity",
+        )
+        if failure is not None:
+            return _failure_report(
+                output, blocker=str(failure["blocker"]), rows=rows, detail=failure
+            )
+        if report is None:
+            return _failure_report(
+                output,
+                blocker=f"capacity_point_artifact_missing:{profile}",
+                rows=rows,
+            )
+        capacity_rows.append(report)
+        passed = report.get("numerical_passed") is True
+        band_checks.append(
+            {
+                "bands": candidate_bands,
+                "passed": passed,
+                "highest_band_occupation": report["result"]["highest_band_occupation"],
+                "maximum_orbital_residual": report["result"]["maximum_orbital_residual"],
+            }
+        )
+        if passed:
+            selected_bands = candidate_bands
+            break
+    if selected_bands is None:
+        return _failure_report(output, blocker="band_capacity_exhausted", rows=rows)
+
+    cutoff_choice: tuple[int, int] | None = None
+    cutoff_screen: dict[str, Any] | None = None
+    for lower, upper in zip(cutoffs, cutoffs[1:], strict=True):
+        profiles = (
+            _profile_name(lower, SCREEN_MESH_SIZE, selected_bands),
+            _profile_name(upper, SCREEN_MESH_SIZE, selected_bands),
+        )
+        for profile in profiles:
+            failure = _ensure_profile_indices(
+                manifest_path=manifest_file,
+                manifest=manifest,
+                output=output,
+                rows=rows,
+                profile=profile,
+                indices=SCREEN_INDICES,
+            )
+            if failure is not None:
+                return _failure_report(
+                    output, blocker=str(failure["blocker"]), rows=rows, detail=failure
+                )
+        comparison = _shape_comparison(
+            _ordered_rows(rows, profiles[0], SCREEN_INDICES),
+            _ordered_rows(rows, profiles[1], SCREEN_INDICES),
+            atom_count=atom_count,
+        )
+        if comparison.get("passed") is True:
+            cutoff_choice = (lower, upper)
+            cutoff_screen = comparison
+            break
+    if cutoff_choice is None or cutoff_screen is None:
+        return _failure_report(output, blocker="cutoff_screen_exhausted", rows=rows)
+
+    kpoint_choice: tuple[int, int] | None = None
+    kpoint_screen: dict[str, Any] | None = None
+    for lower, upper in zip(meshes, meshes[1:], strict=True):
+        profiles = (
+            _profile_name(cutoff_choice[0], lower, selected_bands),
+            _profile_name(cutoff_choice[0], upper, selected_bands),
+        )
+        for profile in profiles:
+            failure = _ensure_profile_indices(
+                manifest_path=manifest_file,
+                manifest=manifest,
+                output=output,
+                rows=rows,
+                profile=profile,
+                indices=SCREEN_INDICES,
+            )
+            if failure is not None:
+                return _failure_report(
+                    output, blocker=str(failure["blocker"]), rows=rows, detail=failure
+                )
+        comparison = _shape_comparison(
+            _ordered_rows(rows, profiles[0], SCREEN_INDICES),
+            _ordered_rows(rows, profiles[1], SCREEN_INDICES),
+            atom_count=atom_count,
+        )
+        if comparison.get("passed") is True:
+            kpoint_choice = (lower, upper)
+            kpoint_screen = comparison
+            break
+    if kpoint_choice is None or kpoint_screen is None:
+        return _failure_report(output, blocker="kpoint_screen_exhausted", rows=rows)
+
+    cutoff_index = cutoffs.index(cutoff_choice[0])
+    kpoint_index = meshes.index(kpoint_choice[0])
+    cutoff_history = []
+    kpoint_history = []
+    while True:
+        selected_cutoff = cutoffs[cutoff_index]
+        selected_kpoint = meshes[kpoint_index]
+        selected_profile = _profile_name(
+            selected_cutoff,
+            selected_kpoint,
+            selected_bands,
+        )
+        failure = _ensure_profile_indices(
+            manifest_path=manifest_file,
+            manifest=manifest,
+            output=output,
+            rows=rows,
+            profile=selected_profile,
+            indices=FULL_INDICES,
+        )
+        if failure is not None:
+            return _failure_report(
+                output, blocker=str(failure["blocker"]), rows=rows, detail=failure
+            )
+        selected_fit = _fit_profile(rows, selected_profile, atom_count=atom_count)
+        if selected_fit.get("status") != "ok":
+            return _failure_report(
+                output,
+                blocker="selected_profile_not_admissible",
+                rows=rows,
+                detail=selected_fit,
+            )
+        if kpoint_index + 1 >= len(meshes):
+            return _failure_report(output, blocker="kpoint_convergence_exhausted", rows=rows)
+        upper_kpoint = meshes[kpoint_index + 1]
+        upper_kpoint_profile = _profile_name(
+            selected_cutoff,
+            upper_kpoint,
+            selected_bands,
+        )
+        failure = _ensure_profile_indices(
+            manifest_path=manifest_file,
+            manifest=manifest,
+            output=output,
+            rows=rows,
+            profile=upper_kpoint_profile,
+            indices=FULL_INDICES,
+        )
+        if failure is not None:
+            return _failure_report(
+                output, blocker=str(failure["blocker"]), rows=rows, detail=failure
+            )
+        upper_kpoint_fit = _fit_profile(
+            rows,
+            upper_kpoint_profile,
+            atom_count=atom_count,
+        )
+        if upper_kpoint_fit.get("status") != "ok":
+            return _failure_report(
+                output,
+                blocker="upper_kpoint_profile_not_admissible",
+                rows=rows,
+                detail=upper_kpoint_fit,
+            )
+        kpoint_convergence = compare_eos_convergence(selected_fit, upper_kpoint_fit)
+        kpoint_history.append(
+            {
+                "selected_mesh": [selected_kpoint] * 3,
+                "upper_mesh": [upper_kpoint] * 3,
+                "comparison": kpoint_convergence,
+            }
+        )
+        if kpoint_convergence.get("passed") is not True:
+            kpoint_index += 1
+            continue
+        if cutoff_index + 1 >= len(cutoffs):
+            return _failure_report(output, blocker="cutoff_convergence_exhausted", rows=rows)
+        upper_cutoff = cutoffs[cutoff_index + 1]
+        upper_cutoff_profile = _profile_name(
+            upper_cutoff,
+            selected_kpoint,
+            selected_bands,
+        )
+        failure = _ensure_profile_indices(
+            manifest_path=manifest_file,
+            manifest=manifest,
+            output=output,
+            rows=rows,
+            profile=upper_cutoff_profile,
+            indices=FULL_INDICES,
+        )
+        if failure is not None:
+            return _failure_report(
+                output, blocker=str(failure["blocker"]), rows=rows, detail=failure
+            )
+        upper_cutoff_fit = _fit_profile(
+            rows,
+            upper_cutoff_profile,
+            atom_count=atom_count,
+        )
+        if upper_cutoff_fit.get("status") != "ok":
+            return _failure_report(
+                output,
+                blocker="upper_cutoff_profile_not_admissible",
+                rows=rows,
+                detail=upper_cutoff_fit,
+            )
+        cutoff_convergence = compare_eos_convergence(selected_fit, upper_cutoff_fit)
+        cutoff_history.append(
+            {
+                "selected_cutoff_hartree": selected_cutoff,
+                "upper_cutoff_hartree": upper_cutoff,
+                "comparison": cutoff_convergence,
+            }
+        )
+        if cutoff_convergence.get("passed") is not True:
+            cutoff_index += 1
+            continue
+        break
+
+    references = load_aluminum_eos_references()
+    scientific = compare_fit_to_reference(
+        selected_fit,
+        reference_fit(references["references"]["all_electron_average"]),
+    )
+    blockers = []
+    if cutoff_convergence.get("passed") is not True:
+        blockers.append("cutoff_convergence_failed")
+    if kpoint_convergence.get("passed") is not True:
+        blockers.append("kpoint_convergence_failed")
+    if scientific.get("verified") is not True:
+        blockers.append("all_electron_reference_thresholds_failed")
+    admitted = not blockers
+    payload = {
+        "schema_version": EOS_REPORT_SCHEMA,
+        "status": "passed" if admitted else "failed",
+        "admitted": admitted,
+        "scientifically_verified": admitted and scientific.get("verified") is True,
+        "blockers": blockers,
+        "workload_fingerprint": manifest["workload_fingerprint"],
+        "accepted_workload": {
+            "profile": selected_profile,
+            "cutoff_hartree": selected_cutoff,
+            "fft_shape": _profile_settings(manifest, selected_profile)["fft_shape"],
+            "kpoint_mesh": [selected_kpoint] * 3,
+            "representative_kpoint_count": manifest["reduced_kpoint_meshes"][str(selected_kpoint)][
+                "representative_point_count"
+            ],
+            "bands": selected_bands,
+            "smearing_width_hartree": manifest["physics"]["smearing_width_hartree"],
+            "energy_observable": manifest["physics"]["energy_observable"],
+            "volume_point_count": 7,
+        },
+        "symmetry_oracle": symmetry,
+        "cutoff_screen": cutoff_screen,
+        "kpoint_screen": kpoint_screen,
+        "band_capacity": {
+            "selected_bands": selected_bands,
+            "checks": band_checks,
+            "scope": "densest locked mesh at the largest EOS volume",
+            "mesh": [capacity_mesh] * 3,
+            "volume_index": capacity_volume,
+            "highest_band_occupation_max": manifest["numerical_gates"][
+                "highest_band_occupation_max"
+            ],
+        },
+        "selected_fit": selected_fit,
+        "cutoff_convergence": cutoff_convergence,
+        "cutoff_convergence_history": cutoff_history,
+        "kpoint_convergence": kpoint_convergence,
+        "kpoint_convergence_history": kpoint_history,
+        "scientific_comparison": scientific,
+        "runtime": _selected_runtime_summary(rows, selected_profile, output),
+        "reference_bundle": {
+            "sha256": REFERENCE_SHA256,
+            "license": references["license"],
+            "primary": references["references"]["all_electron_average"],
+            "same_pseudopotential_family": references["references"]["cp2k_gth"],
+        },
+        "completed_point_count": len(rows) + len(capacity_rows),
+        "point_fingerprints": sorted(
+            str(row["point"]["point_fingerprint"]) for row in [*rows, *capacity_rows]
+        ),
+    }
+    _write_atomic(output / "report.json", payload)
+    return payload

--- a/src/mlx_atomistic/benchmarks/dft_carbon_eos.py
+++ b/src/mlx_atomistic/benchmarks/dft_carbon_eos.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -14,9 +12,11 @@ from mlx_atomistic.benchmarks.dft_eos import (
     birch_murnaghan_energy,
     compare_eos_convergence,
     compare_fit_to_reference,
+    cubic_validation_lattice_constants,
     delta_factor_mev_per_atom,
     fit_birch_murnaghan,
     fit_cubic_eos,
+    load_eos_reference_bundle,
     reference_fit,
 )
 
@@ -32,29 +32,16 @@ def _reference_path() -> Path:
 def load_carbon_eos_references() -> dict[str, Any]:
     """Load the pinned, source-attributed diamond-carbon reference bundle."""
 
-    raw = _reference_path().read_bytes()
-    if hashlib.sha256(raw).hexdigest() != REFERENCE_SHA256:
-        raise ValueError("carbon EOS reference bundle hash mismatch")
-    payload = json.loads(raw)
-    if payload.get("schema_version") != REFERENCE_SCHEMA:
-        raise ValueError("unsupported carbon EOS reference schema")
-    if payload.get("material") != {
-        "cell": "diamond-carbon",
-        "functional": "PBE",
-        "spin": "unpolarized",
-    }:
-        raise ValueError("carbon EOS reference material identity mismatch")
-    if payload.get("protocol", {}).get("volume_factors") != [
-        0.94,
-        0.96,
-        0.98,
-        1.0,
-        1.02,
-        1.04,
-        1.06,
-    ]:
-        raise ValueError("carbon EOS reference volume protocol mismatch")
-    return payload
+    return load_eos_reference_bundle(
+        _reference_path(),
+        expected_sha256=REFERENCE_SHA256,
+        expected_schema=REFERENCE_SCHEMA,
+        expected_material={
+            "cell": "diamond-carbon",
+            "functional": "PBE",
+            "spin": "unpolarized",
+        },
+    )
 
 
 def validation_lattice_constants(
@@ -63,11 +50,7 @@ def validation_lattice_constants(
     """Return the seven conventional-cell lattice constants for validation."""
 
     payload = load_carbon_eos_references() if references is None else references
-    protocol = payload["protocol"]
-    center = float(protocol["central_conventional_lattice_angstrom"])
-    return [
-        center * float(volume_factor) ** (1.0 / 3.0) for volume_factor in protocol["volume_factors"]
-    ]
+    return cubic_validation_lattice_constants(payload)
 
 
 def fit_cubic_carbon_eos(

--- a/src/mlx_atomistic/benchmarks/dft_eos.py
+++ b/src/mlx_atomistic/benchmarks/dft_eos.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -29,6 +32,41 @@ CONVERGENCE_THRESHOLDS = {
     "bulk_modulus_relative": 0.03,
     "bulk_derivative_relative": 0.10,
 }
+DEFAULT_VOLUME_FACTORS = (0.94, 0.96, 0.98, 1.0, 1.02, 1.04, 1.06)
+
+
+def load_eos_reference_bundle(
+    path: str | Path,
+    *,
+    expected_sha256: str,
+    expected_schema: str,
+    expected_material: Mapping[str, str],
+    expected_volume_factors: Sequence[float] = DEFAULT_VOLUME_FACTORS,
+) -> dict[str, Any]:
+    """Load one hash-pinned material EOS reference bundle."""
+
+    raw = Path(path).read_bytes()
+    if hashlib.sha256(raw).hexdigest() != expected_sha256:
+        raise ValueError("EOS reference bundle hash mismatch")
+    payload = json.loads(raw)
+    if payload.get("schema_version") != expected_schema:
+        raise ValueError("unsupported EOS reference schema")
+    if payload.get("material") != dict(expected_material):
+        raise ValueError("EOS reference material identity mismatch")
+    if payload.get("protocol", {}).get("volume_factors") != list(expected_volume_factors):
+        raise ValueError("EOS reference volume protocol mismatch")
+    return payload
+
+
+def cubic_validation_lattice_constants(references: Mapping[str, Any]) -> list[float]:
+    """Return conventional cubic lattice constants from volume-scale factors."""
+
+    protocol = references["protocol"]
+    center = float(protocol["central_conventional_lattice_angstrom"])
+    return [
+        center * float(volume_factor) ** (1.0 / 3.0)
+        for volume_factor in protocol["volume_factors"]
+    ]
 
 
 def _relative_error(value: float, reference: float) -> float:

--- a/src/mlx_atomistic/benchmarks/dft_silicon_eos.py
+++ b/src/mlx_atomistic/benchmarks/dft_silicon_eos.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -17,9 +15,11 @@ from mlx_atomistic.benchmarks.dft_eos import (
     birch_murnaghan_energy,
     compare_eos_convergence,
     compare_fit_to_reference,
+    cubic_validation_lattice_constants,
     delta_factor_mev_per_atom,
     fit_birch_murnaghan,
     fit_cubic_eos,
+    load_eos_reference_bundle,
     reference_fit,
 )
 
@@ -35,28 +35,16 @@ def _reference_path() -> Path:
 def load_silicon_eos_references() -> dict[str, Any]:
     """Load the pinned, source-attributed silicon EOS reference bundle."""
 
-    path = _reference_path()
-    raw = path.read_bytes()
-    digest = hashlib.sha256(raw).hexdigest()
-    if digest != REFERENCE_SHA256:
-        msg = "silicon EOS reference bundle hash mismatch"
-        raise ValueError(msg)
-    payload = json.loads(raw)
-    if payload.get("schema_version") != REFERENCE_SCHEMA:
-        msg = "unsupported silicon EOS reference schema"
-        raise ValueError(msg)
-    if payload.get("material") != {
-        "cell": "diamond-silicon",
-        "functional": "PBE",
-        "spin": "unpolarized",
-    }:
-        msg = "silicon EOS reference material identity mismatch"
-        raise ValueError(msg)
-    factors = payload.get("protocol", {}).get("volume_factors")
-    if factors != [0.94, 0.96, 0.98, 1.0, 1.02, 1.04, 1.06]:
-        msg = "silicon EOS reference volume protocol mismatch"
-        raise ValueError(msg)
-    return payload
+    return load_eos_reference_bundle(
+        _reference_path(),
+        expected_sha256=REFERENCE_SHA256,
+        expected_schema=REFERENCE_SCHEMA,
+        expected_material={
+            "cell": "diamond-silicon",
+            "functional": "PBE",
+            "spin": "unpolarized",
+        },
+    )
 
 
 def validation_lattice_constants(
@@ -65,11 +53,7 @@ def validation_lattice_constants(
     """Return the seven conventional-cell lattice constants for validation."""
 
     payload = load_silicon_eos_references() if references is None else references
-    protocol = payload["protocol"]
-    center = float(protocol["central_conventional_lattice_angstrom"])
-    return [
-        center * float(volume_factor) ** (1.0 / 3.0) for volume_factor in protocol["volume_factors"]
-    ]
+    return cubic_validation_lattice_constants(payload)
 
 
 def fit_cubic_silicon_eos(

--- a/src/mlx_atomistic/dft/__init__.py
+++ b/src/mlx_atomistic/dft/__init__.py
@@ -35,6 +35,7 @@ from mlx_atomistic.dft.grids import RealSpaceGrid, ReciprocalGrid
 from mlx_atomistic.dft.kpoints import (
     BandPath,
     BandStructureResult,
+    GammaCenteredGrid,
     KPoint,
     KPointMesh,
     MonkhorstPackGrid,
@@ -42,6 +43,8 @@ from mlx_atomistic.dft.kpoints import (
     TimeReversalOwnershipEntry,
     admit_time_reversal_bases,
     build_time_reversal_ownership,
+    cubic_reciprocal_symmetry_operations,
+    reduce_kpoint_mesh_by_symmetry,
     run_band_structure,
 )
 from mlx_atomistic.dft.mixing import LinearMixer, PulayDIISMixer
@@ -175,6 +178,7 @@ __all__ = [
     "EigensolverConfig",
     "ExchangeCorrelationFunctional",
     "FermiDiracOccupations",
+    "GammaCenteredGrid",
     "FixedOccupations",
     "FoldedBandPath",
     "GeometryOptimizationConfig",
@@ -248,6 +252,7 @@ __all__ = [
     "center_center_energy",
     "center_center_forces",
     "build_time_reversal_ownership",
+    "cubic_reciprocal_symmetry_operations",
     "compare_reference_case",
     "density_from_orbitals",
     "dft_qm_scope_readiness_report",
@@ -287,6 +292,7 @@ __all__ = [
     "reciprocal_to_real",
     "read_gth",
     "read_upf",
+    "reduce_kpoint_mesh_by_symmetry",
     "run_band_structure",
     "run_periodic_band_structure",
     "run_periodic_scf",

--- a/src/mlx_atomistic/dft/kpoints.py
+++ b/src/mlx_atomistic/dft/kpoints.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
+from itertools import permutations, product
 from typing import Any
 
 import mlx.core as mx
@@ -677,6 +678,212 @@ class MonkhorstPackGrid(KPointMesh):
             points.append(KPoint(vector, weight=1.0 / total, coordinate_system="reduced"))
         KPointMesh.__init__(self, points)
         object.__setattr__(self, "size", parsed)
+
+
+@dataclass(frozen=True)
+class GammaCenteredGrid(KPointMesh):
+    """Regular reduced-coordinate mesh that includes the Γ point.
+
+    Args:
+        size: Number of points along each reciprocal lattice vector.
+    """
+
+    size: tuple[int, int, int] = (1, 1, 1)
+
+    def __init__(self, size: Sequence[int]):
+        parsed = tuple(int(value) for value in size)
+        if len(parsed) != 3 or any(value <= 0 for value in parsed):
+            msg = "GammaCenteredGrid size must contain three positive integers"
+            raise ValueError(msg)
+        points = []
+        total = int(np.prod(parsed))
+        for indices in np.ndindex(parsed):
+            vector = tuple(
+                (index if index <= count // 2 else index - count) / count
+                for index, count in zip(indices, parsed, strict=True)
+            )
+            points.append(KPoint(vector, weight=1.0 / total, coordinate_system="reduced"))
+        KPointMesh.__init__(self, points)
+        object.__setattr__(self, "size", parsed)
+
+
+def cubic_reciprocal_symmetry_operations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    """Return the 48 signed axis permutations of the full cubic point group.
+
+    Returns:
+        Integer reciprocal-coordinate operations, including inversion.
+    """
+
+    operations = []
+    for axes in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            operation = np.zeros((3, 3), dtype=np.int64)
+            for row, column in enumerate(axes):
+                operation[row, column] = signs[row]
+            operations.append(tuple(tuple(int(value) for value in row) for row in operation))
+    return tuple(operations)
+
+
+def _reduced_coordinate_key(
+    vector: Sequence[float] | np.ndarray,
+    *,
+    atol: float,
+) -> tuple[int, int, int]:
+    wrapped = np.remainder(np.asarray(vector, dtype=np.float64), 1.0)
+    wrapped[np.abs(wrapped - 1.0) <= atol] = 0.0
+    return tuple(int(value) for value in np.rint(wrapped / atol))
+
+
+def _validated_reciprocal_operations(
+    operations: Sequence[Sequence[Sequence[int | float]]],
+    *,
+    atol: float,
+) -> tuple[np.ndarray, ...]:
+    if not operations:
+        raise ValueError("reciprocal symmetry reduction requires at least one operation")
+    validated: list[np.ndarray] = []
+    seen: set[tuple[int, ...]] = set()
+    for index, operation in enumerate(operations):
+        values = np.asarray(operation, dtype=np.float64)
+        if values.shape != (3, 3) or not np.isfinite(values).all():
+            msg = f"reciprocal symmetry operation {index} must be a finite 3 x 3 matrix"
+            raise ValueError(msg)
+        rounded = np.rint(values)
+        if not np.allclose(values, rounded, rtol=0.0, atol=atol):
+            msg = f"reciprocal symmetry operation {index} must contain integers"
+            raise ValueError(msg)
+        integer = rounded.astype(np.int64)
+        determinant = int(round(float(np.linalg.det(integer))))
+        if abs(determinant) != 1:
+            msg = f"reciprocal symmetry operation {index} must be unimodular"
+            raise ValueError(msg)
+        key = tuple(int(value) for value in integer.flat)
+        if key not in seen:
+            seen.add(key)
+            validated.append(integer)
+    return tuple(validated)
+
+
+def _reduced_mesh_lookup(
+    vectors: Sequence[Sequence[float]],
+    *,
+    atol: float,
+) -> dict[tuple[int, int, int], int]:
+    lookup: dict[tuple[int, int, int], int] = {}
+    for index, vector in enumerate(vectors):
+        key = _reduced_coordinate_key(vector, atol=atol)
+        if key in lookup:
+            msg = (
+                "ambiguous duplicate k-points modulo the reciprocal lattice: "
+                f"{lookup[key]} and {index}"
+            )
+            raise ValueError(msg)
+        lookup[key] = index
+    return lookup
+
+
+def _reciprocal_symmetry_orbit(
+    representative: int,
+    vectors: Sequence[Sequence[float]],
+    lookup: Mapping[tuple[int, int, int], int],
+    symmetry: Sequence[np.ndarray],
+    *,
+    atol: float,
+) -> set[int]:
+    orbit = {representative}
+    pending = [representative]
+    while pending:
+        current = pending.pop()
+        vector = np.asarray(vectors[current], dtype=np.float64)
+        for operation in symmetry:
+            transformed = operation @ vector
+            match = lookup.get(_reduced_coordinate_key(transformed, atol=atol))
+            if match is None:
+                msg = f"k-point mesh is not closed under reciprocal symmetry: point {current}"
+                raise ValueError(msg)
+            difference = transformed - np.asarray(vectors[match], dtype=np.float64)
+            difference -= np.rint(difference)
+            if float(np.max(np.abs(difference))) > atol:
+                raise ValueError("reciprocal symmetry coordinate match exceeded tolerance")
+            if match not in orbit:
+                orbit.add(match)
+                pending.append(match)
+    return orbit
+
+
+def reduce_kpoint_mesh_by_symmetry(
+    kpoint_mesh: KPointMesh,
+    operations: Sequence[Sequence[Sequence[int | float]]],
+    *,
+    coordinate_atol: float = 1.0e-10,
+    weight_rtol: float = 1.0e-12,
+    weight_atol: float = 1.0e-15,
+) -> KPointMesh:
+    """Aggregate a reduced-coordinate mesh into explicit symmetry orbits.
+
+    This function validates the mesh action but cannot prove that the supplied
+    operations are symmetries of a particular cell, ionic structure, or
+    Hamiltonian. Callers must establish that scientific precondition.
+
+    Args:
+        kpoint_mesh: Full weighted reduced-coordinate mesh.
+        operations: Integer unimodular matrices acting on reduced k-point
+            column vectors.
+        coordinate_atol: Absolute modulo-lattice matching tolerance.
+        weight_rtol: Relative tolerance for symmetry-related input weights.
+        weight_atol: Absolute tolerance for symmetry-related input weights.
+
+    Returns:
+        Deterministic representative points with orbit-aggregated weights.
+
+    Raises:
+        ValueError: If inputs are invalid, duplicated, not closed under the
+            operations, or have unequal weights inside an orbit.
+    """
+
+    if not np.isfinite(coordinate_atol) or coordinate_atol <= 0.0:
+        raise ValueError("coordinate_atol must be finite and positive")
+    if not np.isfinite(weight_rtol) or weight_rtol < 0.0:
+        raise ValueError("weight_rtol must be finite and non-negative")
+    if not np.isfinite(weight_atol) or weight_atol < 0.0:
+        raise ValueError("weight_atol must be finite and non-negative")
+    symmetry = _validated_reciprocal_operations(operations, atol=coordinate_atol)
+    vectors, weights = _validated_reduced_mesh(kpoint_mesh.points)
+    lookup = _reduced_mesh_lookup(vectors, atol=coordinate_atol)
+
+    remaining = set(range(len(vectors)))
+    reduced = []
+    while remaining:
+        representative = min(remaining)
+        orbit = _reciprocal_symmetry_orbit(
+            representative,
+            vectors,
+            lookup,
+            symmetry,
+            atol=coordinate_atol,
+        )
+        reference_weight = weights[representative]
+        if any(
+            not np.isclose(
+                weights[index],
+                reference_weight,
+                rtol=weight_rtol,
+                atol=weight_atol,
+            )
+            for index in orbit
+        ):
+            msg = "symmetry-related k-points must have equal input weights"
+            raise ValueError(msg)
+        reduced.append(
+            KPoint(
+                vectors[representative],
+                weight=sum(weights[index] for index in orbit),
+                label=kpoint_mesh.points[representative].label,
+                coordinate_system="reduced",
+            )
+        )
+        remaining.difference_update(orbit)
+    return KPointMesh(reduced)
 
 
 @dataclass(frozen=True)

--- a/tests/test_dft_aluminum_eos.py
+++ b/tests/test_dft_aluminum_eos.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import mlx_atomistic.benchmarks.dft_aluminum as aluminum_workload
+from mlx_atomistic.benchmarks.dft_aluminum import (
+    ALUMINUM_FRACTIONAL_POSITIONS,
+    kpoint_mesh_from_workload,
+    load_aluminum_workload,
+    prepare_aluminum_workload,
+)
+from mlx_atomistic.benchmarks.dft_aluminum_eos import (
+    birch_murnaghan_energy,
+    compare_fit_to_reference,
+    fit_birch_murnaghan,
+    fit_cubic_aluminum_eos,
+    load_aluminum_eos_references,
+    reference_fit,
+    validation_lattice_constants,
+)
+from mlx_atomistic.benchmarks.dft_aluminum_eos_runner import (
+    _profile_settings,
+    _selected_runtime_summary,
+    run_aluminum_eos_point,
+    run_aluminum_eos_validation,
+)
+from mlx_atomistic.benchmarks.dft_eos import HARTREE_TO_EV
+
+
+def _gth_source(path):
+    path.write_text(
+        """Al GTH-PBE-q3 GTH-PBE
+2    1
+0.45000000    1    -7.55476126
+2
+0.48743529    2     6.95993832    -1.88883584
+2.43847659
+0.56218949    1     1.86529857
+"""
+    )
+    return path
+
+
+def test_aluminum_reference_bundle_is_pinned_and_cp2k_context_is_excellent():
+    references = load_aluminum_eos_references()
+    lattice = validation_lattice_constants(references)
+    primary = reference_fit(references["references"]["all_electron_average"])
+    cp2k = references["references"]["cp2k_gth"]
+    rows = cp2k["eos_volume_energy_ev"]
+    fit = fit_birch_murnaghan(
+        [volume for volume, _energy in rows],
+        [energy for _volume, energy in rows],
+    )
+
+    assert lattice[3] == pytest.approx(4.040422065345)
+    assert primary["equilibrium_lattice_constant_angstrom"] == pytest.approx(4.040861093109186)
+    assert fit["equilibrium_volume_angstrom3_per_atom"] == pytest.approx(
+        cp2k["fit"]["equilibrium_volume_angstrom3"], rel=2.0e-8
+    )
+    comparison = compare_fit_to_reference(
+        {**reference_fit(cp2k), "status": "ok"},
+        primary,
+    )
+    assert comparison["excellent"] is True
+    assert comparison["metrics"]["delta_mev_per_atom"] == pytest.approx(0.9954359681)
+
+
+def test_aluminum_workload_is_hash_guarded_and_persists_reduced_mesh(tmp_path, monkeypatch):
+    monkeypatch.setattr(aluminum_workload, "KPOINT_MESH_SIZES", (3,))
+    source = _gth_source(tmp_path / "GTH_POTENTIALS")
+    prepared = prepare_aluminum_workload(gth_source=source, out=tmp_path / "workload")
+    manifest, resource = load_aluminum_workload(prepared["manifest"])
+    mesh = kpoint_mesh_from_workload(manifest, 3)
+
+    assert manifest["system"]["fractional_positions"] == [
+        list(row) for row in ALUMINUM_FRACTIONAL_POSITIONS
+    ]
+    assert manifest["physics"]["smearing_width_hartree"] == 0.00225
+    assert manifest["reduced_kpoint_meshes"]["3"]["full_point_count"] == 27
+    assert len(mesh.points) == 4
+    assert sum(point.weight for point in mesh.points) == pytest.approx(1.0)
+
+    resource.write_text(resource.read_text() + "\n")
+    with pytest.raises(ValueError, match="hash mismatch"):
+        load_aluminum_workload(prepared["manifest"])
+
+
+def test_cubic_aluminum_fit_uses_four_atom_cell_free_energies():
+    references = load_aluminum_eos_references()
+    primary = reference_fit(references["references"]["all_electron_average"])
+    lattice = np.asarray(validation_lattice_constants(references))
+    energies = birch_murnaghan_energy(
+        lattice**3 / 4.0,
+        -50.0,
+        primary["equilibrium_volume_angstrom3_per_atom"],
+        primary["bulk_modulus_ev_angstrom3"],
+        primary["bulk_derivative"],
+    )
+
+    fit = fit_cubic_aluminum_eos(lattice, energies * 4.0 / HARTREE_TO_EV)
+
+    assert fit["status"] == "ok"
+    assert fit["atom_count"] == 4
+    assert fit["equilibrium_lattice_constant_angstrom"] == pytest.approx(
+        primary["equilibrium_lattice_constant_angstrom"], rel=1.0e-8
+    )
+
+
+def test_aluminum_validation_dry_run_exposes_locked_decision_ladder(tmp_path, monkeypatch):
+    monkeypatch.setattr(aluminum_workload, "KPOINT_MESH_SIZES", (3,))
+    prepared = prepare_aluminum_workload(
+        gth_source=_gth_source(tmp_path / "GTH_POTENTIALS"),
+        out=tmp_path / "workload",
+    )
+
+    plan = run_aluminum_eos_validation(
+        manifest_path=prepared["manifest"],
+        out=tmp_path / "validation",
+        dry_run=True,
+    )
+
+    assert plan["status"] == "planned"
+    assert plan["kpoint_mesh_sizes"] == [3]
+    assert plan["cutoff_candidates_hartree"] == [15, 20, 25, 30]
+    assert plan["band_capacity_candidates"] == [8, 9, 10, 11, 12, 16, 20, 26]
+    assert plan["maximum_point_count"] == 57
+
+
+def test_single_aluminum_point_persists_metallic_free_energy_evidence(tmp_path, monkeypatch):
+    import mlx.core as mx
+
+    import mlx_atomistic.benchmarks.dft_runtime_contract as runtime_contract
+    import mlx_atomistic.dft as dft
+
+    monkeypatch.setattr(aluminum_workload, "KPOINT_MESH_SIZES", (3,))
+    prepared = prepare_aluminum_workload(
+        gth_source=_gth_source(tmp_path / "GTH_POTENTIALS"),
+        out=tmp_path / "workload",
+    )
+    manifest, _resource = load_aluminum_workload(prepared["manifest"])
+    assert _profile_settings(manifest, "c15-k3-b12")["kpoint_mode"] == "reduced"
+
+    eigen = SimpleNamespace(
+        orthonormality_error=2.0e-7,
+        residuals=np.full(12, 8.0e-7),
+    )
+    occupations = (2.0, 2.0, 2.0, 2.0, 1.5, 1.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0)
+    result = SimpleNamespace(
+        converged=True,
+        total_energy=-50.00225,
+        internal_energy=-50.0,
+        electronic_entropy=1.0,
+        chemical_potential=-0.15,
+        electron_count=12.0,
+        owned_kpoints=[SimpleNamespace(eigen=eigen)],
+        kpoints=[SimpleNamespace(eigen=eigen, occupations=occupations)],
+        iterations=11,
+        density_residual=2.0e-7,
+        energy_delta=3.0e-7,
+        timings={"total": 1.0},
+        density=np.ones((4, 4, 4), dtype=np.float32),
+    )
+    monkeypatch.setattr(dft, "PeriodicDFTSystem", lambda *args, **kwargs: object())
+    monkeypatch.setattr(dft, "read_gth", lambda *args, **kwargs: object())
+    monkeypatch.setattr(dft, "run_periodic_scf", lambda *args, **kwargs: result)
+    monkeypatch.setattr(
+        runtime_contract,
+        "collect_host_provenance",
+        lambda: {
+            "power_source": "Battery Power",
+            "low_power_mode": 1,
+            "thermal_pressure": "Nominal",
+        },
+    )
+    monkeypatch.setattr(mx, "synchronize", lambda: None)
+
+    payload = run_aluminum_eos_point(
+        manifest_path=prepared["manifest"],
+        profile="c15-k3-b12",
+        volume_index=3,
+        out=tmp_path / "point.json",
+    )
+
+    assert payload["numerical_passed"] is True
+    assert payload["result"]["fractional_occupation_count"] == 3
+    assert payload["result"]["highest_band_occupation"] == 0.0
+    assert payload["result"]["free_energy_identity_error_hartree"] < 1.0e-12
+    assert payload["host"]["low_power_mode"] == 1
+    assert (tmp_path / "density.npy").is_file()
+
+
+def test_runtime_summary_separates_process_memory_from_cumulative_traffic(tmp_path):
+    point_dir = tmp_path / "points" / "selected" / "v0"
+    point_dir.mkdir(parents=True)
+    (point_dir / "memory.json").write_text('{"bounded_process_peak_physical_bytes": 3000000000}')
+    rows = [
+        {
+            "point": {"profile": "selected", "volume_index": 0},
+            "host": {
+                "power_source": "AC Power",
+                "low_power_mode": 0,
+                "thermal_pressure": None,
+            },
+            "result": {
+                "elapsed_wall_seconds": 7.0,
+                "observation": {
+                    "memory": {
+                        "peak_temporary_bytes": 80000000,
+                        "persistent_coefficient_bytes": 20000000,
+                        "persistent_projector_bytes": 15000000,
+                        "shared_full_grid_bytes": 5000000,
+                        "projector_streamed_bytes": 19000000000,
+                    }
+                },
+            },
+        }
+    ]
+
+    summary = _selected_runtime_summary(rows, "selected", tmp_path)
+
+    assert summary["maximum_process_physical_bytes"] == 3000000000
+    assert summary["maximum_runtime_peak_temporary_bytes"] == 80000000
+    assert summary["maximum_runtime_persistent_payload_bytes"] == 40000000
+    assert "projector_streamed_bytes" not in summary

--- a/tests/test_dft_kpoint_symmetry.py
+++ b/tests/test_dft_kpoint_symmetry.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlx_atomistic.dft import (
+    GammaCenteredGrid,
+    KPoint,
+    KPointMesh,
+    MonkhorstPackGrid,
+    build_time_reversal_ownership,
+    cubic_reciprocal_symmetry_operations,
+    reduce_kpoint_mesh_by_symmetry,
+)
+
+
+def test_gamma_centered_grid_is_distinct_from_even_half_shifted_mesh():
+    gamma = GammaCenteredGrid((4, 2, 1))
+    shifted = MonkhorstPackGrid((4, 2, 1))
+
+    assert len(gamma.points) == 8
+    assert sum(point.weight for point in gamma.points) == pytest.approx(1.0)
+    assert gamma.points[0].vector == (0.0, 0.0, 0.0)
+    assert shifted.points[0].vector != gamma.points[0].vector
+    assert {point.vector[0] for point in gamma.points} == {0.0, 0.25, 0.5, -0.25}
+
+
+def test_cubic_reduction_preserves_invariant_quadrature_and_time_reversal():
+    full = GammaCenteredGrid((4, 4, 4))
+    operations = cubic_reciprocal_symmetry_operations()
+    reduced = reduce_kpoint_mesh_by_symmetry(full, operations)
+
+    def invariant(point):
+        values = np.asarray(point.vector, dtype=np.float64)
+        return float(np.sum(np.cos(2.0 * np.pi * values) ** 2))
+
+    full_value = sum(point.weight * invariant(point) for point in full.points)
+    reduced_value = sum(point.weight * invariant(point) for point in reduced.points)
+
+    assert len(operations) == 48
+    assert len(reduced.points) == 10
+    assert reduced_value == pytest.approx(full_value, abs=2.0e-15)
+    assert sum(point.weight for point in reduced.points) == pytest.approx(1.0)
+    assert len(build_time_reversal_ownership(full).owned_indices) == 36
+
+
+def test_symmetry_reduction_fails_closed_on_invalid_operations_and_meshes():
+    mesh = GammaCenteredGrid((4, 2, 2))
+    with pytest.raises(ValueError, match="integers"):
+        reduce_kpoint_mesh_by_symmetry(mesh, (((1.0, 0.1, 0.0), (0, 1, 0), (0, 0, 1)),))
+    with pytest.raises(ValueError, match="unimodular"):
+        reduce_kpoint_mesh_by_symmetry(mesh, (((2, 0, 0), (0, 1, 0), (0, 0, 1)),))
+    with pytest.raises(ValueError, match="not closed"):
+        reduce_kpoint_mesh_by_symmetry(mesh, (((0, 1, 0), (1, 0, 0), (0, 0, 1)),))
+
+    unequal = KPointMesh(
+        (
+            KPoint((0.25, 0.0, 0.0), weight=0.4, coordinate_system="reduced"),
+            KPoint((-0.25, 0.0, 0.0), weight=0.6, coordinate_system="reduced"),
+        )
+    )
+    inversion = (((-1, 0, 0), (0, -1, 0), (0, 0, -1)),)
+    with pytest.raises(ValueError, match="equal input weights"):
+        reduce_kpoint_mesh_by_symmetry(unequal, inversion)


### PR DESCRIPTION
## Summary
- add source-bound fcc Aluminum metallic EOS validation with a fingerprinted ACWF reference bundle
- add Gamma-centered k-point meshes and explicit cubic symmetry reduction
- add a bounded convergence ladder for symmetry, band capacity, cutoff, k-point density, and seven-volume EOS
- update the DFT scientific ledger and roadmap after current-verified Metal execution

## Accepted evidence
- profile: 15 Ha, 15x15x15 reduced to 120 representatives, 11 bands
- Delta factor: 0.229587 meV/atom against the all-electron PBE reference
- complete accepted curve: 48.03 s on Apple M5 Max, AC Power, Low Power Mode disabled
- maximum process physical memory: 3.06 GB

## Verification
- full CPU pytest suite
- ruff check src tests scripts
- API documentation generator check
- narrative documentation sync check
- current-source Aluminum Metal validation ladder