### PR TITLE
Support full-rank periodic DFT cells

### DIFF
--- a/docs/benchmarks/dft-material-validation.md
+++ b/docs/benchmarks/dft-material-validation.md
@@ -11,6 +11,7 @@ calculation.
 | --- | --- | --- | --- |
 | Diamond Si, 8 atoms, PBE/GTH-q4, 25 Ha, 6×6×6 | `a₀ = 5.460859 Å`, `B₀ = 88.306 GPa`, `B₀′ = 4.3052`, Δ = `1.942 meV/atom` | All-electron PBE: lattice `0.166%`, bulk modulus `0.232%`, and `B₀′` `0.153%` relative error | Verified for this bulk-Si EOS workload. Broader chemistry and MLX-versus-QE PWscf parity remain proof-level or diagnostic. |
 | Diamond Si fixed-cell relaxation, 8 atoms, PBE/GTH-q4, 25 Ha, 6×6×6 | The atom displaced by `(+0.04, -0.03, +0.02) Å` converged in 7 accepted steps; final maximum force `8.832e-5 Ha/bohr`, RMS force `2.437e-5 Ha/bohr`, and final maximum step `1.480e-3 bohr` | Translation-aligned maximum error from the source-defined ideal diamond positions: `0.000312 Å` | Verified for this fixed-cell relaxation. Exact restart equivalence is CPU-tested; the Metal workload verifies accepted-step checkpoint publication. Variable-cell relaxation remains absent. |
+| 2H-Si full-rank fixed-cell relaxation, 4 atoms, PBE/GTH-q4, 25 Ha, 6×6×4 | The ideal `P63/mmc` lonsdaleite prototype converged in 3 accepted steps; final energy `-15.76211219 Ha`, maximum force `1.715e-5 Ha/bohr`, and final maximum step `1.659e-4 bohr` | Source prototype `A_hP4_194_f-001`, `z = 1/16`; maximum translation-aligned internal relaxation `0.003351 Å` | Verified for this hexagonal fixed-cell workflow and complete-matrix identity. It does not establish stress, variable-cell relaxation, or broad Silicon polytype accuracy. |
 | Diamond Si frozen-density bands, Γ-X-W-K-Γ-L | Indirect gap `0.578 eV`, valence width `11.959 eV` | Published PBE/GTH ordering and high-symmetry energies; PBE gap is not compared with the experimental `1.12 eV` gap | Accepted band-path validation from a converged 6×6×6 density; not a general band-structure certification. |
 | Diamond C, 8 atoms, PBE/GTH-q4, 40 Ha, 6×6×6, 7 volumes | `a₀ = 3.574441 Å`, `B₀ = 438.100 GPa`, Δ = `1.268 meV/atom` | All-electron PBE: lattice `0.075%` and bulk modulus `1.080%` relative error | Verified for the accepted 40 Ha workload. A 40→50 Ha central three-volume screen changed the curve by `0.438 meV/atom`; no full 50 Ha curve is required. |
 | Rock-salt MgO, 8 atoms, PBE, Mg-q2/O-q6, 70 Ha, 6×6×6, 7 volumes | `a₀ = 4.259503 Å`, `B₀ = 146.914 GPa`, Δ = `1.060 meV/atom` | All-electron PBE: lattice `0.123%` and bulk modulus `1.387%` relative error | Core EOS properties validated. The strict whole-report gate remains failed because `B₀′ = 3.39995` differs from `4.09093` by `16.89%`, above the locked `15%` threshold; this is retained as a likely Mg-q2 transferability limit. |
@@ -27,8 +28,8 @@ installed, imported, or executed by the MLX runtime or routine CI.
 
 These rows prove the listed fixed workloads. Aluminum closes one simple-metal
 case, but the rows do not establish broad metallic chemistry, spin-polarized
-chemistry, pseudopotential transferability, or cell relaxation. They do not
-establish universal periodic DFT accuracy.
+chemistry, pseudopotential transferability, or variable-cell relaxation. They
+do not establish universal periodic DFT accuracy.
 
 The periodic runtime has a numerically validated Fermi-Dirac occupation and
 free-energy path, including weighted k-points, odd electron counts,

--- a/docs/dft-general-cell-geometry.md
+++ b/docs/dft-general-cell-geometry.md
@@ -1,0 +1,154 @@
+# DFT General Periodic Cell Geometry
+
+This document records the completed scientific and engineering contract for
+Phase 3 of the [DFT roadmap](./dft-roadmap.md). It replaces the periodic
+runtime's orthorhombic-only geometry assumptions with one full-rank cell model
+while preserving the accepted orthorhombic numerical path.
+
+## Objective
+
+Allow the periodic PBE/GTH runtime to operate on any finite, right-handed
+`3 x 3` cell matrix admitted by the project-level `Cell`. This phase changes
+fixed-cell geometry only. It does not add stress or variable-cell relaxation.
+
+The implementation must extend the existing `Cell`, `RealSpaceGrid`,
+`ReciprocalGrid`, and `PeriodicDFTSystem` contracts. It must not introduce a
+second DFT-specific cell type.
+
+## Matrix Convention
+
+The direct cell matrix `A` stores lattice vectors as rows. Fractional row
+coordinates `s` map to Cartesian coordinates as
+
+```text
+r = s A
+```
+
+The reciprocal matrix is
+
+```text
+B = 2 pi (A^-1)^T
+```
+
+and therefore satisfies `A B^T = 2 pi I`. An integer FFT index row `n` maps to
+the Cartesian reciprocal vector `G = n B`; a reduced k-point `k` maps to
+`k_cartesian = k B`. Cell volume is `det(A)`, which is positive by the `Cell`
+contract.
+
+These conventions match the matrix-first reciprocal-grid construction used by
+Quantum ESPRESSO and CP2K. Those projects remain design references only and do
+not enter the MLX runtime path.
+
+## Runtime Contract
+
+`RealSpaceGrid` accepts either three orthorhombic lengths, a full matrix, or an
+existing `Cell`. Grid points remain uniformly spaced in fractional coordinates:
+
+```text
+s_ijk = ((i + 1/2) / N1, (j + 1/2) / N2, (k + 1/2) / N3)
+r_ijk = s_ijk A
+```
+
+`ReciprocalGrid` retains exact NumPy FFT integer ordering and maps those
+integers through `B`. Plane-wave cutoffs continue to apply to
+`0.5 |G + k|^2` in Cartesian reciprocal space.
+
+`PeriodicDFTSystem` preserves the complete cell matrix across immutable
+position updates, calculation fingerprints, SCF checkpoints, outer relaxation
+checkpoints, and reports. APIs that historically accept three lengths continue
+to do so.
+
+## Electrostatics And Forces
+
+The ion-ion Ewald implementation operates on direct and reciprocal lattice
+matrices rather than component-wise lengths. Direct translations are integer
+rows mapped through `A`; reciprocal vectors are integer rows mapped through
+`B`. Enumeration bounds use lattice-vector and reciprocal-vector norms and
+retain the spherical real- and reciprocal-space cutoff checks.
+
+Local and nonlocal GTH operators already consume Cartesian reciprocal vectors
+and cell volume. They require no cell-specific branch once their grids and
+bases are correct. Analytic ionic forces must remain consistent with
+finite-difference energy derivatives in a skew cell.
+
+## Compatibility Boundary
+
+The existing orthorhombic route is a compatibility oracle. Diagonal cell input
+must retain its FFT ordering, reciprocal values, basis membership,
+fingerprints, SCF energies, and forces within the existing locked tolerances.
+The general formulas must not silently replace an orthorhombic fast path where
+that would perturb an accepted float32 trajectory.
+
+Unsupported work remains fail-closed. Phase 3 does not admit singular or
+left-handed cells, variable FFT topology during one calculation, stress,
+variable-cell optimization, crystallographic symmetry reduction, or slab and
+isolated electrostatics.
+
+## Acceptance Criteria
+
+The implementation is complete only when all of the following pass:
+
+- direct/reciprocal duality and fractional/Cartesian round trips for cubic,
+  hexagonal, and low-symmetry cells;
+- exact FFT integer ordering and correct Cartesian reciprocal vectors;
+- determinant volume, uniform fractional coordinates, and density
+  normalization;
+- reduced k-point conversion through the reciprocal matrix;
+- Ewald translation invariance and analytic-versus-finite-difference forces in
+  a skew cell;
+- periodic GTH local and nonlocal energy/force execution in a skew cell;
+- SCF and checkpoint identity preserve the complete matrix;
+- existing orthorhombic targeted tests remain unchanged;
+- one source-bound hexagonal crystal and one bounded low-symmetry numerical
+  case close their declared energy and force gates.
+
+Only targeted unit and compatibility tests ran during implementation. The
+material-level calculation ran after the runtime source and protocol were
+frozen; remote CPU CI carries the full regression suite.
+
+## Accepted Result
+
+The current-verified material case is ideal 2H-Silicon in the lonsdaleite
+`A_hP4_194_f-001` prototype. The `P63/mmc` four-atom cell uses `z = 1/16`, the
+accepted Silicon lattice as its source scale, PBE-PW92, `Si GTH-PBE-q4`, a
+`25 Ha` cutoff, a `40 x 40 x 64` FFT grid, and a `6 x 6 x 4`
+Monkhorst-Pack mesh. The fixed cell remained immutable while the Phase 2
+optimizer relaxed the symmetry-allowed internal coordinate.
+
+The calculation converged in three accepted ionic steps, four SCF evaluations,
+and three line-search evaluations. The final energy was
+`-15.762112189664592 Ha`, maximum force was
+`1.715483631414827e-5 Ha/bohr`, net-force norm was
+`1.7555596748712108e-7 Ha/bohr`, and the final maximum step was
+`1.6593486505125634e-4 bohr`. The maximum translation-aligned displacement
+from the ideal source structure was `0.003351 A`.
+
+Complete wall time was `28.744 s`; peak physical memory was `4.856 GB`, and
+the memory plateau gate passed. The run used AC power with low-power mode
+disabled. Its workload fingerprint is
+`cebd61b0baeae25935cef6d27acdad46b2f9a455b0cc1c5de42839660ef74931`, and its
+runtime fingerprint is
+`625f216ce19def219758c2d49159667977619e302496c2cc050a0019a036387a`.
+
+Hexagonal and low-symmetry numerical oracles additionally lock reciprocal
+duality, FFT ordering, Ewald basis invariance, analytic force derivatives,
+GTH lattice-translation invariance, and complete matrix identity in SCF state
+metadata. The result establishes ordinary fixed full-rank cell execution; it
+does not establish stress or variable-cell relaxation.
+
+## Delivery
+
+Delivered in this phase:
+
+1. General real and reciprocal grid geometry and reduced k-point mapping.
+2. Full-matrix `PeriodicDFTSystem` construction and immutable updates.
+3. Full-rank periodic Ewald energy and analytic forces.
+4. Matrix identity through SCF, forces, checkpoints, and reports.
+5. Targeted orthorhombic compatibility and nonorthogonal correctness tests.
+6. Source-bound 2H-Silicon evidence. Repository CI remains the merge gate.
+
+## Out Of Scope
+
+Stress, cell derivatives, cell optimization, coupled ion/cell relaxation,
+phonons, spin, and new exchange-correlation or pseudopotential families remain
+separate roadmap phases.

--- a/docs/dft-production-core.md
+++ b/docs/dft-production-core.md
@@ -7,7 +7,7 @@ periodic `PeriodicDFTSystem`/`run_periodic_scf` surface supplies the
 materials-workload path: PBE-PW92, reciprocal-space GTH operators,
 Monkhorst-Pack integration, block-Davidson/Rayleigh-Ritz solves,
 fixed or Fermi-Dirac occupations, frozen-density band paths, and periodic
-forces.
+forces across ordinary fixed full-rank cells.
 
 The periodic implementation has verified results for specific workloads, but
 is not broadly chemically certified. Capability claims are tied to the
@@ -90,6 +90,12 @@ crystal. It converged in seven accepted steps to a maximum force of
 `0.000312 A`. This is a bounded fixed-cell result, not variable-cell or broad
 materials certification.
 
+The same workflow is current-verified in one four-atom hexagonal 2H-Silicon
+cell. It converged in three accepted steps to a maximum force of
+`1.715e-5 Ha/bohr`. Full-rank geometry is implemented across grids, reciprocal
+bases, Ewald, GTH operators, forces, fingerprints, and state metadata. Stress
+and variable-cell optimization remain absent.
+
 Dense SCF restart files store density, orbitals, ion positions, cell lengths, spin metadata, and Γ k-point metadata for small-system continuation workflows.
 
 ## Reference Validation
@@ -105,8 +111,9 @@ boundary.
 | Feature | Local Status | Reference Family |
 | --- | --- | --- |
 | Plane-wave SCF core | verified for fixed-occupation bulk-Si EOS and one Fermi-Dirac fcc-Al EOS | CP2K Quickstep, QE PWscf |
+| Full-rank fixed periodic cells | verified for one bounded 2H-Si relaxation and low-symmetry numerical oracles | CP2K cell matrix, QE CELL_PARAMETERS |
 | UPF/GTH pseudopotentials and nonlocal projectors | proof-level | QE UPF, CP2K GTH |
-| Fixed-cell periodic geometry relaxation | verified for one bounded bulk-Si workload | CP2K MOTION/GEO_OPT, QE relax |
+| Fixed-cell periodic geometry relaxation | verified for bounded orthorhombic and hexagonal Si workloads | CP2K MOTION/GEO_OPT, QE relax |
 | Finite-difference stress | proof-level | CP2K stress, QE stress |
 | Static reference comparison | supported | static CP2K/QE fixture summaries |
 | QM/MM force-environment orchestration | deferred | CP2K FORCE_EVAL/QMMM |

--- a/docs/dft-roadmap.md
+++ b/docs/dft-roadmap.md
@@ -12,10 +12,12 @@ weighted k-points, block-Davidson eigensolves, fixed and Fermi-Dirac
 occupations, frozen-density bands, analytic fixed-cell forces, and atomic
 SCF checkpoint/resume. A fail-closed fixed-cell periodic ionic optimizer adds
 accepted-state electronic continuation and a separate atomic outer checkpoint.
+Real and reciprocal grids, k-points, Ewald terms, GTH operators, forces, and
+state identity share one full-rank periodic cell matrix contract.
 Material-level verification remains narrow: Silicon, Carbon, and simple-metal
 Aluminum have accepted equation-of-state workloads, Silicon has one accepted
-fixed-cell relaxation, and MgO retains a declared force and transferability
-boundary.
+orthorhombic relaxation and one accepted hexagonal relaxation, and MgO retains
+a declared force and transferability boundary.
 
 ## Program Boundary
 
@@ -34,11 +36,11 @@ only when its implementation and material-level evidence both pass.
 | --- | --- | --- | --- |
 | Exchange-correlation | PBE-PW92 production envelope | Implemented; verified material set is narrow | Every material phase |
 | Pseudopotentials | Broad, fingerprinted GTH transferability | GTH periodic path exists; broad transferability is not closed | Phase 7 |
-| Crystal geometry | Ordinary full-rank periodic cells | DFT grids and Ewald path remain orthorhombic | Phase 3 |
+| Crystal geometry | Ordinary full-rank periodic cells | Implemented; one source-bound hexagonal Silicon case and bounded low-symmetry oracles are verified | Phase 3 |
 | Electronic states | Insulators, simple metals, and collinear magnets | Insulators and one simple metal are verified; periodic spin is absent | Phases 1 and 5 |
 | Electronic observables | Energy, density, occupations, bands, total DOS, and Fermi level | Energy, density, occupations, and bands exist | Phase 6 |
 | Mechanical observables | Analytic forces and validated stress | Forces exist with a retained MgO boundary; periodic stress is absent | Phase 4 |
-| Structural workflows | Fixed-cell ionic and variable-cell relaxation | Fixed-cell periodic relaxation is verified for one bounded Silicon workload; variable-cell relaxation is absent | Phases 2 and 4 |
+| Structural workflows | Fixed-cell ionic and variable-cell relaxation | Fixed-cell periodic relaxation is verified in orthorhombic and hexagonal Silicon cells; variable-cell relaxation is absent | Phases 2 and 4 |
 | Lattice dynamics | Bounded finite-displacement phonons | Absent | Phase 8 |
 | Reproducibility | Source-bound inputs, convergence studies, restart, and explicit evidence labels | Periodic SCF and fixed-cell outer checkpoints exist; later workflow state remains incomplete | Every phase |
 | Runtime quality | Measured complete wall and peak memory on representative Apple Silicon workloads | Existing DFT controls cover a narrow workload set | Every phase |
@@ -118,8 +120,9 @@ checkpoint publication.
 
 ## Phase 3: Generalize Periodic Cell Geometry
 
-Status: next. Protocol research and the full-rank cell contract are not yet
-locked.
+Status: complete. The matrix convention, compatibility boundary, implementation
+and current-verified evidence are recorded in
+[DFT General Periodic Cell Geometry](./dft-general-cell-geometry.md).
 
 - Replace orthorhombic-only assumptions with one full-rank `3 x 3` cell matrix
   contract across real and reciprocal grids, plane-wave bases, k-points,
@@ -128,13 +131,15 @@ locked.
   compatibility case.
 - Add representative cubic, hexagonal, and low-symmetry cells.
 
-Exit gate: cell-coordinate transforms, reciprocal identities, energies, and
-forces pass analytic or finite-difference checks, and accepted orthorhombic
-goldens do not regress.
+Exit gate: closed. Cell-coordinate transforms, reciprocal identities, Ewald and
+GTH invariances, analytic force derivatives, SCF state identity, and the
+source-bound 2H-Silicon relaxation pass their locked gates. Existing
+orthorhombic compatibility tests remain unchanged.
 
 ## Phase 4: Add Stress And Variable-Cell Relaxation
 
-Status: blocked on Phase 3 cell geometry.
+Status: next. Phase 3 provides the required full-rank cell foundation; the
+stress convention and finite-difference protocol are not yet locked.
 
 - Establish a reliable periodic stress tensor with an explicit sign, unit, and
   free-energy convention.

--- a/scripts/sync_site_docs.py
+++ b/scripts/sync_site_docs.py
@@ -27,6 +27,7 @@ NARRATIVE_TARGETS = {
     "production-md.md": "mm/production-md.md",
     "real-mm-core.md": "mm/real-mm-core.md",
     "dft-geometry-optimization.md": "dft/dft-geometry-optimization.md",
+    "dft-general-cell-geometry.md": "dft/dft-general-cell-geometry.md",
     "dft-metallic-validation.md": "dft/dft-metallic-validation.md",
     "dft-periodic-relaxation.md": "dft/dft-periodic-relaxation.md",
     "dft-numerics.md": "dft/dft-numerics.md",

--- a/src/mlx_atomistic/benchmarks/dft_hexagonal_silicon.py
+++ b/src/mlx_atomistic/benchmarks/dft_hexagonal_silicon.py
@@ -1,0 +1,280 @@
+"""Source-bound 2H-Silicon validation for full-rank periodic DFT cells."""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+from collections.abc import Mapping
+from math import pi, sqrt
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_atomistic._artifact_identity import canonical_json_bytes, sha256_bytes
+from mlx_atomistic.benchmarks.dft_runtime_contract import (
+    build_source_fingerprints,
+    collect_host_provenance,
+    load_workload,
+)
+from mlx_atomistic.benchmarks.dft_silicon import ANGSTROM_TO_BOHR
+from mlx_atomistic.benchmarks.dft_silicon_relaxation import (
+    _optimization_config,
+    _scf_config,
+)
+from mlx_atomistic.dft import (
+    MonkhorstPackGrid,
+    PeriodicDFTSystem,
+    RuntimeObserver,
+    optimize_periodic_geometry,
+    read_gth,
+)
+
+REPORT_SCHEMA = "mlx-atomistic.hexagonal-silicon-cell-validation.v2"
+CUBIC_LATTICE_ANGSTROM = 5.460859
+INTERNAL_COORDINATE = 1.0 / 16.0
+CUTOFF_HARTREE = 25.0
+FFT_SHAPE = (40, 40, 64)
+KPOINT_MESH = (6, 6, 4)
+BAND_COUNT = 8
+MAX_NET_FORCE_HARTREE_PER_BOHR = 5.0e-5
+MAX_RECIPROCAL_DUALITY_ERROR = 2.0e-6
+
+_FRACTIONAL_POSITIONS = (
+    (1.0 / 3.0, 2.0 / 3.0, INTERNAL_COORDINATE),
+    (2.0 / 3.0, 1.0 / 3.0, 0.5 + INTERNAL_COORDINATE),
+    (2.0 / 3.0, 1.0 / 3.0, 1.0 - INTERNAL_COORDINATE),
+    (1.0 / 3.0, 2.0 / 3.0, 0.5 - INTERNAL_COORDINATE),
+)
+
+_SOURCE_CONTRACT = {
+    "structure": "ideal-2H-silicon-lonsdaleite",
+    "prototype": "A_hP4_194_f-001",
+    "space_group": "P63/mmc (194)",
+    "wyckoff_site": "4f",
+    "internal_coordinate": INTERNAL_COORDINATE,
+    "lattice_relation": {
+        "a_hexagonal": "a_cubic/sqrt(2)",
+        "c_over_a": "sqrt(8/3)",
+    },
+    "sources": [
+        {
+            "doi": "10.1088/0953-8984/26/4/045801",
+            "url": "https://arxiv.org/abs/1210.7392",
+        },
+        {
+            "prototype": "A_hP4_194_f-001",
+            "url": "https://aflowlib.duke.edu/p/A_hP4_194_f-001/",
+        },
+    ],
+}
+
+
+def hexagonal_silicon_geometry() -> tuple[np.ndarray, np.ndarray]:
+    """Return the ideal 2H-Silicon cell and Cartesian positions in bohr."""
+
+    a_angstrom = CUBIC_LATTICE_ANGSTROM / sqrt(2.0)
+    c_angstrom = sqrt(8.0 / 3.0) * a_angstrom
+    cell_angstrom = np.asarray(
+        (
+            (a_angstrom, 0.0, 0.0),
+            (-0.5 * a_angstrom, 0.5 * sqrt(3.0) * a_angstrom, 0.0),
+            (0.0, 0.0, c_angstrom),
+        ),
+        dtype=np.float64,
+    )
+    cell_bohr = cell_angstrom * ANGSTROM_TO_BOHR
+    positions_bohr = np.asarray(_FRACTIONAL_POSITIONS, dtype=np.float64) @ cell_bohr
+    return cell_bohr, positions_bohr
+
+
+def _write_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_bytes(canonical_json_bytes(dict(payload)))
+    temporary.replace(path)
+
+
+def _implementation_fingerprint() -> str:
+    contract = {
+        "schema_version": "mlx-atomistic.hexagonal-silicon-execution.v1",
+        "report_schema": REPORT_SCHEMA,
+        "geometry_source": inspect.getsource(hexagonal_silicon_geometry),
+        "scf_config_source": inspect.getsource(_scf_config),
+        "optimization_config_source": inspect.getsource(_optimization_config),
+        "run_source": inspect.getsource(run_hexagonal_silicon),
+    }
+    return sha256_bytes(canonical_json_bytes(contract))
+
+
+def run_hexagonal_silicon(
+    *,
+    manifest_path: str | Path,
+    gth_source: str | Path,
+    out: str | Path,
+) -> dict[str, Any]:
+    """Run the bounded 2H-Silicon full-rank cell validation."""
+
+    manifest, _selected = load_workload(manifest_path, gth_source=gth_source)
+    cell, positions = hexagonal_silicon_geometry()
+    scf_config = _scf_config(manifest)
+    optimization_config = _optimization_config(reuse_scf_state=True)
+    protocol = {
+        "source": _SOURCE_CONTRACT,
+        "source_fingerprint": sha256_bytes(canonical_json_bytes(_SOURCE_CONTRACT)),
+        "cell_matrix_bohr": cell.tolist(),
+        "fractional_positions": [list(values) for values in _FRACTIONAL_POSITIONS],
+        "cutoff_hartree": CUTOFF_HARTREE,
+        "fft_shape": list(FFT_SHAPE),
+        "kpoint_mesh": list(KPOINT_MESH),
+        "band_count": BAND_COUNT,
+        "solver": manifest["solver"],
+        "optimization_config": optimization_config.to_dict(),
+        "thresholds": {
+            "max_force_hartree_per_bohr": optimization_config.force_tolerance,
+            "max_net_force_hartree_per_bohr": MAX_NET_FORCE_HARTREE_PER_BOHR,
+            "max_reciprocal_duality_error": MAX_RECIPROCAL_DUALITY_ERROR,
+        },
+    }
+    workload = {
+        "schema_version": "mlx-atomistic.hexagonal-silicon-workload.v1",
+        "silicon_solver_resource_workload_fingerprint": manifest["workload_fingerprint"],
+        "protocol": protocol,
+    }
+    workload_fingerprint = sha256_bytes(canonical_json_bytes(workload))
+    source_fingerprints = build_source_fingerprints()
+    point = {
+        "workload_fingerprint": workload_fingerprint,
+        "runtime_fingerprint": source_fingerprints["runtime_fingerprint"],
+        "implementation_fingerprint": _implementation_fingerprint(),
+    }
+    point["point_fingerprint"] = sha256_bytes(canonical_json_bytes(point))
+
+    system = PeriodicDFTSystem(
+        cell,
+        FFT_SHAPE,
+        positions,
+        read_gth(gth_source, element="Si", name="GTH-PBE-q4"),
+        electron_count=16.0,
+    )
+    mesh = MonkhorstPackGrid(KPOINT_MESH)
+    observer = RuntimeObserver(detail_events=False)
+    started = perf_counter()
+    optimization = optimize_periodic_geometry(
+        system,
+        cutoff_hartree=CUTOFF_HARTREE,
+        kpoint_mesh=mesh,
+        n_bands=BAND_COUNT,
+        config=optimization_config,
+        scf_config=scf_config,
+        observer=observer,
+    )
+    mx.synchronize()
+    elapsed = perf_counter() - started
+
+    result = optimization.final_scf
+    force = optimization.final_force
+    reciprocal = 2.0 * pi * np.linalg.inv(cell).T
+    duality_error = float(np.max(np.abs(cell @ reciprocal.T - 2.0 * pi * np.eye(3))))
+    electron_error = (
+        float("inf")
+        if result is None
+        else abs(float(result.electron_count) - system.electron_count)
+    )
+    max_force = None if force is None else force.max_force
+    net_force_norm = (
+        None if force is None else float(np.linalg.norm(np.asarray(force.net_force)))
+    )
+    final_step = None if not optimization.steps else optimization.steps[-1]
+    initial_fractional = np.asarray(_FRACTIONAL_POSITIONS, dtype=np.float64)
+    final_fractional = optimization.final_positions @ np.linalg.inv(cell)
+    fractional_delta = final_fractional - initial_fractional
+    fractional_delta -= np.rint(fractional_delta)
+    cartesian_delta = fractional_delta @ cell
+    translation = np.mean(cartesian_delta, axis=0)
+    aligned_delta = cartesian_delta - translation
+    geometry = {
+        "final_fractional_positions": np.mod(final_fractional, 1.0).tolist(),
+        "removed_uniform_translation_bohr": translation.tolist(),
+        "maximum_aligned_displacement_angstrom": float(
+            np.max(np.linalg.norm(aligned_delta, axis=1)) / ANGSTROM_TO_BOHR
+        ),
+    }
+    gates = {
+        "optimization_converged": optimization.converged,
+        "scf_converged": bool(result is not None and result.converged),
+        "finite_energy": bool(result is not None and np.isfinite(result.total_energy)),
+        "electron_count": electron_error <= 1.0e-4,
+        "reciprocal_duality": duality_error <= MAX_RECIPROCAL_DUALITY_ERROR,
+        "analytic_force_available": force is not None,
+        "maximum_force": bool(
+            max_force is not None and max_force <= optimization_config.force_tolerance
+        ),
+        "net_force": bool(
+            net_force_norm is not None
+            and net_force_norm <= MAX_NET_FORCE_HARTREE_PER_BOHR
+        ),
+        "final_displacement": bool(
+            final_step is not None
+            and final_step.step_norm <= optimization_config.displacement_tolerance
+        ),
+        "armijo_history": bool(
+            optimization.steps
+            and all(step.energy <= step.armijo_limit for step in optimization.steps)
+        ),
+    }
+    payload = {
+        "schema_version": REPORT_SCHEMA,
+        "status": "passed" if all(gates.values()) else "failed",
+        "scientifically_verified": all(gates.values()),
+        "point": point,
+        "host": collect_host_provenance(),
+        "protocol": protocol,
+        "geometry": geometry,
+        "optimization": optimization.to_dict(),
+        "result": None if result is None else result.to_dict(),
+        "force": None if force is None else force.to_dict(),
+        "checks": {
+            "gates": gates,
+            "electron_count_error": electron_error,
+            "reciprocal_duality_error": duality_error,
+            "net_force_norm_hartree_per_bohr": net_force_norm,
+        },
+        "runtime": {
+            "complete_wall_seconds": elapsed,
+            "observation": observer.snapshot(),
+        },
+    }
+    _write_atomic(Path(out), payload)
+    return payload
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the bounded 2H-Silicon validation CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--gth-source", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    payload = run_hexagonal_silicon(
+        manifest_path=args.manifest,
+        gth_source=args.gth_source,
+        out=args.out,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            f"status={payload['status']} "
+            f"verified={payload['scientifically_verified']} "
+            f"wall_seconds={payload['runtime']['complete_wall_seconds']:.6f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mlx_atomistic/dft/_periodic_models.py
+++ b/src/mlx_atomistic/dft/_periodic_models.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import mlx.core as mx
 import numpy as np
 
+from mlx_atomistic.core import Cell
 from mlx_atomistic.dft._compact import (
     _CompactBatch,
     _CompactBatchPolicy,
@@ -64,10 +65,11 @@ def _time_reversed_compact_values(
 
 @dataclass(frozen=True)
 class PeriodicDFTSystem:
-    """Orthorhombic periodic DFT system with per-ion GTH pseudopotentials.
+    """Periodic DFT system with per-ion GTH pseudopotentials.
 
     Args:
-        cell_lengths: Orthorhombic cell lengths in bohr.
+        cell_lengths: A periodic `Cell`, three orthorhombic lengths, or a full
+            row-vector cell matrix in bohr.
         grid_shape: FFT grid shape.
         positions: Ionic Cartesian positions in bohr.
         pseudopotential: Shared GTH pseudopotential for every ion. Mutually
@@ -84,7 +86,7 @@ class PeriodicDFTSystem:
 
     def __init__(
         self,
-        cell_lengths: Sequence[float],
+        cell_lengths: Cell | Sequence[float] | Sequence[Sequence[float]],
         grid_shape: Sequence[int],
         positions: Sequence[Sequence[float]],
         pseudopotential: PseudopotentialData | None = None,
@@ -195,7 +197,7 @@ class PeriodicDFTSystem:
         """
 
         return PeriodicDFTSystem(
-            np.asarray(self.grid.lengths, dtype=np.float64),
+            self.grid.cell,
             self.grid.shape,
             positions,
             electron_count=self.electron_count,

--- a/src/mlx_atomistic/dft/_periodic_scf_engine.py
+++ b/src/mlx_atomistic/dft/_periodic_scf_engine.py
@@ -491,7 +491,7 @@ class _PeriodicSCFController:
             ewald = periodic_ewald_energy(
                 system.charges,
                 system.positions,
-                np.asarray(system.grid.lengths),
+                system.grid.cell,
             )
             eigensolver_tolerance = _scf_eigensolver_tolerance(
                 scf_config,

--- a/src/mlx_atomistic/dft/grids.py
+++ b/src/mlx_atomistic/dft/grids.py
@@ -26,17 +26,18 @@ def _shape_tuple(shape: Sequence[int]) -> tuple[int, int, int]:
 
 @dataclass(frozen=True)
 class RealSpaceGrid:
-    """Uniform orthorhombic real-space grid in atomic units."""
+    """Uniform fractional real-space grid in a periodic cell."""
 
     shape: tuple[int, int, int]
     cell: Cell
 
-    def __init__(self, shape: Sequence[int], cell: Cell | Sequence[float]):
+    def __init__(
+        self,
+        shape: Sequence[int],
+        cell: Cell | Sequence[float] | Sequence[Sequence[float]],
+    ):
         object.__setattr__(self, "shape", _shape_tuple(shape))
-        parsed_cell = cell if isinstance(cell, Cell) else Cell.orthorhombic(cell)
-        if not parsed_cell.is_orthorhombic:
-            msg = "DFT real-space grids currently require an orthorhombic cell"
-            raise ValueError(msg)
+        parsed_cell = cell if isinstance(cell, Cell) else Cell(cell)
         object.__setattr__(self, "cell", parsed_cell)
         lengths = np.array(parsed_cell.lengths, dtype=np.float64)
         if np.any(lengths <= 0.0):
@@ -63,7 +64,7 @@ class RealSpaceGrid:
 
     @property
     def spacing(self) -> mx.array:
-        """Grid spacing in atomic units."""
+        """Grid-vector step lengths in atomic units."""
 
         return self.cell.lengths / as_mx_array(self.shape)
 
@@ -71,7 +72,9 @@ class RealSpaceGrid:
     def volume(self) -> float:
         """Cell volume in bohr cubed."""
 
-        return float(np.prod(np.array(self.cell.lengths, dtype=np.float64)))
+        if self.cell.is_orthorhombic:
+            return float(np.prod(np.array(self.cell.lengths, dtype=np.float64)))
+        return float(np.linalg.det(np.asarray(self.cell.matrix, dtype=np.float64)))
 
     @property
     def dv(self) -> float:
@@ -82,13 +85,22 @@ class RealSpaceGrid:
     def coordinates(self) -> mx.array:
         """Return cell-centered Cartesian grid coordinates with shape ``(*shape, 3)``."""
 
-        lengths = np.array(self.cell.lengths, dtype=np.float64)
-        axes = [
-            (np.arange(count, dtype=np.float64) + 0.5) * length / count
-            for count, length in zip(self.shape, lengths, strict=True)
-        ]
-        mesh = np.meshgrid(*axes, indexing="ij")
-        return as_mx_array(np.stack(mesh, axis=-1).astype(np.float32))
+        if self.cell.is_orthorhombic:
+            lengths = np.array(self.cell.lengths, dtype=np.float64)
+            axes = [
+                (np.arange(count, dtype=np.float64) + 0.5) * length / count
+                for count, length in zip(self.shape, lengths, strict=True)
+            ]
+            mesh = np.meshgrid(*axes, indexing="ij")
+            coordinates = np.stack(mesh, axis=-1)
+        else:
+            axes = [
+                (np.arange(count, dtype=np.float64) + 0.5) / count
+                for count in self.shape
+            ]
+            fractional = np.stack(np.meshgrid(*axes, indexing="ij"), axis=-1)
+            coordinates = fractional @ np.asarray(self.cell.matrix, dtype=np.float64)
+        return as_mx_array(coordinates.astype(np.float32))
 
 
 def _fft_integer_g(shape: tuple[int, int, int]) -> mx.array:
@@ -126,6 +138,7 @@ class ReciprocalGrid:
     g2: mx.array
     zero_mask: mx.array
     integer_g: mx.array
+    basis_matrix: mx.array
     fingerprint: str
 
     def __init__(
@@ -135,6 +148,7 @@ class ReciprocalGrid:
         g2: mx.array,
         zero_mask: mx.array,
         integer_g: mx.array | None = None,
+        basis_matrix: mx.array | None = None,
         fingerprint: str | None = None,
     ) -> None:
         object.__setattr__(self, "real_grid", real_grid)
@@ -145,6 +159,18 @@ class ReciprocalGrid:
             self,
             "integer_g",
             _fft_integer_g(real_grid.shape) if integer_g is None else mx.array(integer_g),
+        )
+        reciprocal = (
+            2.0
+            * pi
+            * np.linalg.inv(np.asarray(real_grid.cell.matrix, dtype=np.float64)).T
+        )
+        object.__setattr__(
+            self,
+            "basis_matrix",
+            mx.array(reciprocal.astype(np.float32))
+            if basis_matrix is None
+            else mx.array(basis_matrix),
         )
         object.__setattr__(
             self,
@@ -166,21 +192,29 @@ class ReciprocalGrid:
         """
 
         integer_g = _fft_integer_g(grid.shape)
-        spacing = np.asarray(grid.spacing, dtype=np.float64)
-        reciprocal_axes = [
-            mx.array(
-                (2.0 * pi * np.fft.fftfreq(count, d=delta)).astype(np.float32)
+        basis_matrix = (
+            2.0
+            * pi
+            * np.linalg.inv(np.asarray(grid.cell.matrix, dtype=np.float64)).T
+        ).astype(np.float32)
+        if grid.cell.is_orthorhombic:
+            spacing = np.asarray(grid.spacing, dtype=np.float64)
+            reciprocal_axes = [
+                mx.array(
+                    (2.0 * pi * np.fft.fftfreq(count, d=delta)).astype(np.float32)
+                )
+                for count, delta in zip(grid.shape, spacing, strict=True)
+            ]
+            vectors = mx.stack(
+                [
+                    mx.broadcast_to(reciprocal_axes[0][:, None, None], grid.shape),
+                    mx.broadcast_to(reciprocal_axes[1][None, :, None], grid.shape),
+                    mx.broadcast_to(reciprocal_axes[2][None, None, :], grid.shape),
+                ],
+                axis=-1,
             )
-            for count, delta in zip(grid.shape, spacing, strict=True)
-        ]
-        vectors = mx.stack(
-            [
-                mx.broadcast_to(reciprocal_axes[0][:, None, None], grid.shape),
-                mx.broadcast_to(reciprocal_axes[1][None, :, None], grid.shape),
-                mx.broadcast_to(reciprocal_axes[2][None, None, :], grid.shape),
-            ],
-            axis=-1,
-        )
+        else:
+            vectors = integer_g.astype(mx.float32) @ mx.array(basis_matrix)
         g2 = mx.sum(vectors * vectors, axis=-1)
         return cls(
             real_grid=grid,
@@ -188,5 +222,6 @@ class ReciprocalGrid:
             g2=g2,
             zero_mask=g2 == 0.0,
             integer_g=integer_g,
+            basis_matrix=mx.array(basis_matrix),
             fingerprint=_reciprocal_fingerprint(grid),
         )

--- a/src/mlx_atomistic/dft/periodic_electrostatics.py
+++ b/src/mlx_atomistic/dft/periodic_electrostatics.py
@@ -1,12 +1,15 @@
-"""Periodic point-charge electrostatics for orthorhombic cells."""
+"""Periodic point-charge electrostatics for full-rank cells."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from itertools import product
 from math import erfc, pi, sqrt
 
 import numpy as np
+
+from mlx_atomistic.core import Cell
 
 
 def _positions(positions: Sequence[Sequence[float]]) -> np.ndarray:
@@ -22,7 +25,9 @@ def _positions(positions: Sequence[Sequence[float]]) -> np.ndarray:
 class _EwaldParameters:
     charge: np.ndarray
     centers: np.ndarray
-    lengths: np.ndarray
+    direct_matrix: np.ndarray
+    reciprocal_matrix: np.ndarray
+    direct_lengths: np.ndarray
     eta: float
     real_cutoff: float
     real_ranges: tuple[range, ...]
@@ -34,45 +39,58 @@ class _EwaldParameters:
 def _validated_ewald_parameters(
     charge: np.ndarray,
     centers: np.ndarray,
-    cell_lengths: Sequence[float],
+    cell_lengths: Cell | Sequence[float] | Sequence[Sequence[float]],
     *,
     eta: float | None,
     tolerance: float,
 ) -> _EwaldParameters:
-    lengths = np.asarray(cell_lengths, dtype=np.float64)
+    cell = cell_lengths if isinstance(cell_lengths, Cell) else Cell(cell_lengths)
+    direct = np.asarray(cell.matrix, dtype=np.float64)
+    reciprocal = 2.0 * pi * np.linalg.inv(direct).T
+    lengths = np.linalg.norm(direct, axis=1)
+    volume = float(np.linalg.det(direct))
     if charge.shape != (centers.shape[0],):
         msg = "charges length must match positions"
-        raise ValueError(msg)
-    if lengths.shape != (3,) or np.any(lengths <= 0.0):
-        msg = "cell_lengths must contain three positive values"
         raise ValueError(msg)
     if tolerance <= 0.0 or tolerance >= 1.0:
         msg = "tolerance must lie in (0, 1)"
         raise ValueError(msg)
-    eta_value = float(eta) if eta is not None else 5.0 / float(np.min(lengths))
+    if cell.is_orthorhombic:
+        minimum_height = float(np.min(lengths))
+    else:
+        face_areas = np.asarray(
+            [
+                np.linalg.norm(np.cross(direct[1], direct[2])),
+                np.linalg.norm(np.cross(direct[2], direct[0])),
+                np.linalg.norm(np.cross(direct[0], direct[1])),
+            ]
+        )
+        minimum_height = float(np.min(volume / face_areas))
+    eta_value = float(eta) if eta is not None else 5.0 / minimum_height
     if eta_value <= 0.0:
         msg = "eta must be positive"
         raise ValueError(msg)
     cutoff_factor = sqrt(-np.log(tolerance))
     real_cutoff = cutoff_factor / eta_value
-    real_ranges = tuple(
-        range(
-            -int(np.ceil(real_cutoff / length)) - 1,
-            int(np.ceil(real_cutoff / length)) + 2,
-        )
-        for length in lengths
-    )
+    if cell.is_orthorhombic:
+        real_max_indices = np.ceil(real_cutoff / lengths).astype(int) + 1
+    else:
+        reciprocal_norms = np.linalg.norm(reciprocal, axis=1)
+        real_max_indices = np.ceil(real_cutoff * reciprocal_norms / (2.0 * pi)).astype(int) + 1
+    real_ranges = tuple(range(-int(value), int(value) + 1) for value in real_max_indices)
     reciprocal_cutoff = 2.0 * eta_value * cutoff_factor
     return _EwaldParameters(
         charge=charge,
         centers=centers,
-        lengths=lengths,
+        direct_matrix=direct,
+        reciprocal_matrix=reciprocal,
+        direct_lengths=lengths,
         eta=eta_value,
         real_cutoff=real_cutoff,
         real_ranges=real_ranges,
         reciprocal_cutoff=reciprocal_cutoff,
         max_indices=np.ceil(reciprocal_cutoff * lengths / (2.0 * pi)).astype(int),
-        volume=float(np.prod(lengths)),
+        volume=volume,
     )
 
 
@@ -80,16 +98,29 @@ def _ewald_translation(
     parameters: _EwaldParameters,
     image: tuple[int, ...],
 ) -> np.ndarray:
-    return np.array(
-        [parameters.real_ranges[axis][image[axis]] * parameters.lengths[axis] for axis in range(3)]
+    return np.asarray(image, dtype=np.float64) @ parameters.direct_matrix
+
+
+def _ewald_reciprocal_vectors(
+    parameters: _EwaldParameters,
+):
+    ranges = tuple(
+        range(-int(value), int(value) + 1) for value in parameters.max_indices
     )
+    for indices in product(*ranges):
+        if indices == (0, 0, 0):
+            continue
+        vector = np.asarray(indices, dtype=np.float64) @ parameters.reciprocal_matrix
+        g2 = float(np.dot(vector, vector))
+        if sqrt(g2) <= parameters.reciprocal_cutoff:
+            yield vector, g2
 
 
 def _ewald_real_energy(parameters: _EwaldParameters) -> float:
     energy = 0.0
     for ion_index, first in enumerate(parameters.centers):
         for other_index, second in enumerate(parameters.centers):
-            for image in np.ndindex(*(len(values) for values in parameters.real_ranges)):
+            for image in product(*parameters.real_ranges):
                 displacement = first - second + _ewald_translation(parameters, image)
                 distance = float(np.linalg.norm(displacement))
                 if distance <= 1e-14 or distance > parameters.real_cutoff:
@@ -105,22 +136,13 @@ def _ewald_real_energy(parameters: _EwaldParameters) -> float:
 
 def _ewald_reciprocal_energy(parameters: _EwaldParameters) -> float:
     energy = 0.0
-    maximum = parameters.max_indices
-    for h in range(-int(maximum[0]), int(maximum[0]) + 1):
-        for k in range(-int(maximum[1]), int(maximum[1]) + 1):
-            for l_value in range(-int(maximum[2]), int(maximum[2]) + 1):
-                if h == 0 and k == 0 and l_value == 0:
-                    continue
-                vector = 2.0 * pi * np.array([h, k, l_value], dtype=np.float64) / parameters.lengths
-                g2 = float(np.dot(vector, vector))
-                if sqrt(g2) > parameters.reciprocal_cutoff:
-                    continue
-                structure = np.sum(parameters.charge * np.exp(-1j * (parameters.centers @ vector)))
-                energy += (
-                    np.exp(-g2 / (4.0 * parameters.eta * parameters.eta))
-                    * float(abs(structure) ** 2)
-                    / g2
-                )
+    for vector, g2 in _ewald_reciprocal_vectors(parameters):
+        structure = np.sum(parameters.charge * np.exp(-1j * (parameters.centers @ vector)))
+        energy += (
+            np.exp(-g2 / (4.0 * parameters.eta * parameters.eta))
+            * float(abs(structure) ** 2)
+            / g2
+        )
     return energy * 2.0 * pi / parameters.volume
 
 
@@ -128,7 +150,7 @@ def _ewald_real_forces(parameters: _EwaldParameters) -> np.ndarray:
     forces = np.zeros_like(parameters.centers)
     for ion_index, first in enumerate(parameters.centers):
         for other_index, second in enumerate(parameters.centers):
-            for image in np.ndindex(*(len(values) for values in parameters.real_ranges)):
+            for image in product(*parameters.real_ranges):
                 displacement = first - second + _ewald_translation(parameters, image)
                 distance = float(np.linalg.norm(displacement))
                 if distance <= 1e-14 or distance > parameters.real_cutoff:
@@ -154,28 +176,19 @@ def _add_ewald_reciprocal_forces(
     parameters: _EwaldParameters,
     forces: np.ndarray,
 ) -> np.ndarray:
-    maximum = parameters.max_indices
-    for h in range(-int(maximum[0]), int(maximum[0]) + 1):
-        for k in range(-int(maximum[1]), int(maximum[1]) + 1):
-            for l_value in range(-int(maximum[2]), int(maximum[2]) + 1):
-                if h == 0 and k == 0 and l_value == 0:
-                    continue
-                vector = 2.0 * pi * np.array([h, k, l_value], dtype=np.float64) / parameters.lengths
-                g2 = float(np.dot(vector, vector))
-                if sqrt(g2) > parameters.reciprocal_cutoff:
-                    continue
-                damping = np.exp(-g2 / (4.0 * parameters.eta * parameters.eta)) / g2
-                structure = np.sum(parameters.charge * np.exp(-1j * (parameters.centers @ vector)))
-                phase_imaginary = np.imag(np.exp(1j * (parameters.centers @ vector)) * structure)
-                forces += (
-                    4.0
-                    * pi
-                    / parameters.volume
-                    * damping
-                    * parameters.charge[:, None]
-                    * phase_imaginary[:, None]
-                    * vector[None, :]
-                )
+    for vector, g2 in _ewald_reciprocal_vectors(parameters):
+        damping = np.exp(-g2 / (4.0 * parameters.eta * parameters.eta)) / g2
+        structure = np.sum(parameters.charge * np.exp(-1j * (parameters.centers @ vector)))
+        phase_imaginary = np.imag(np.exp(1j * (parameters.centers @ vector)) * structure)
+        forces += (
+            4.0
+            * pi
+            / parameters.volume
+            * damping
+            * parameters.charge[:, None]
+            * phase_imaginary[:, None]
+            * vector[None, :]
+        )
     return forces
 
 
@@ -187,7 +200,7 @@ def _ewald_analytic_forces(parameters: _EwaldParameters) -> np.ndarray:
 def _ewald_finite_difference_forces(
     charges: Sequence[float],
     centers: np.ndarray,
-    cell_lengths: Sequence[float],
+    cell_lengths: Cell | Sequence[float] | Sequence[Sequence[float]],
     *,
     displacement: float,
     eta: float | None,
@@ -221,7 +234,7 @@ def _ewald_finite_difference_forces(
 def periodic_ewald_energy(
     charges: Sequence[float],
     positions: Sequence[Sequence[float]],
-    cell_lengths: Sequence[float],
+    cell_lengths: Cell | Sequence[float] | Sequence[Sequence[float]],
     *,
     eta: float | None = None,
     tolerance: float = 1e-10,
@@ -231,7 +244,8 @@ def periodic_ewald_energy(
     Args:
         charges: Point charges in atomic units.
         positions: Cartesian positions in bohr.
-        cell_lengths: Orthorhombic cell lengths in bohr.
+        cell_lengths: A periodic `Cell`, three orthorhombic lengths, or a full
+            row-vector cell matrix in bohr.
         eta: Optional Ewald splitting parameter in inverse bohr. Defaults to a
             cell-scaled value.
         tolerance: Real/reciprocal truncation target. Defaults to ``1e-10``.
@@ -259,7 +273,7 @@ def periodic_ewald_energy(
 def periodic_ewald_forces(
     charges: Sequence[float],
     positions: Sequence[Sequence[float]],
-    cell_lengths: Sequence[float],
+    cell_lengths: Cell | Sequence[float] | Sequence[Sequence[float]],
     *,
     displacement: float = 1e-4,
     eta: float | None = None,
@@ -271,7 +285,8 @@ def periodic_ewald_forces(
     Args:
         charges: Point charges in atomic units.
         positions: Cartesian positions in bohr.
-        cell_lengths: Orthorhombic cell lengths in bohr.
+        cell_lengths: A periodic `Cell`, three orthorhombic lengths, or a full
+            row-vector cell matrix in bohr.
         displacement: Central-difference step used only when
             ``method="finite_difference"``. Defaults to ``1e-4``.
         eta: Optional Ewald splitting parameter. Defaults to a cell-scaled value.

--- a/src/mlx_atomistic/dft/periodic_forces.py
+++ b/src/mlx_atomistic/dft/periodic_forces.py
@@ -250,7 +250,7 @@ def periodic_scf_forces(
         periodic_ewald_forces(
             system.charges,
             system.positions,
-            system.grid.lengths,
+            system.grid.cell,
             tolerance=ewald_tolerance,
             method="analytic",
         ).astype(np.float32)

--- a/src/mlx_atomistic/dft/plane_wave.py
+++ b/src/mlx_atomistic/dft/plane_wave.py
@@ -67,7 +67,7 @@ class PlaneWaveBasis:
     return full FFT grids, materializing them only at the call boundary.
 
     Args:
-        grid: Uniform orthorhombic real-space grid.
+        grid: Uniform fractional real-space grid.
         cutoff_hartree: Kinetic energy cutoff in Hartree.
         kpoint_cartesian: Bloch k-point in inverse bohr. Defaults to Gamma.
         reciprocal_grid: Optional shared reciprocal descriptor. Compatible
@@ -127,27 +127,35 @@ class PlaneWaveBasis:
         """Build a basis from fractional reciprocal coordinates.
 
         Args:
-            grid: Uniform orthorhombic real-space grid.
+            grid: Uniform fractional real-space grid.
             cutoff_hartree: Kinetic energy cutoff in Hartree.
             reduced_kpoint: Fractional coordinates along reciprocal cell axes.
             reciprocal_grid: Optional shared reciprocal descriptor.
             lane_label: Stable runtime lane label.
 
         Returns:
-            A basis whose Cartesian k-point is ``2*pi*k_i/L_i``.
+            A basis whose Cartesian k-point is the reduced row vector mapped
+            through the reciprocal cell matrix.
         """
 
         if len(reduced_kpoint) != 3:
             msg = "reduced_kpoint must have three components"
             raise ValueError(msg)
-        lengths = np.asarray(grid.lengths, dtype=np.float64)
         reduced = np.asarray(reduced_kpoint, dtype=np.float64)
-        cartesian = 2.0 * pi * reduced / lengths
+        reciprocal = (
+            _shared_reciprocal_grid(grid)
+            if reciprocal_grid is None
+            else reciprocal_grid
+        )
+        if grid.cell.is_orthorhombic:
+            cartesian = 2.0 * pi * reduced / np.asarray(grid.lengths, dtype=np.float64)
+        else:
+            cartesian = reduced @ np.asarray(reciprocal.basis_matrix, dtype=np.float64)
         return cls(
             grid,
             cutoff_hartree,
             cartesian,
-            reciprocal_grid=reciprocal_grid,
+            reciprocal_grid=reciprocal,
             lane_label=lane_label,
         )
 
@@ -450,11 +458,16 @@ class PlaneWaveBasis:
         """Return JSON-safe basis metadata.
 
         Returns:
-            Cutoff, k-point, FFT shape, active count, and normalization metadata.
+            Cutoff, cell, k-point, FFT shape, active count, and normalization
+            metadata.
         """
 
         return {
             "cutoff_hartree": self.cutoff_hartree,
+            "cell_matrix_bohr": np.asarray(
+                self.grid.cell.matrix,
+                dtype=np.float64,
+            ).tolist(),
             "kpoint_cartesian_bohr_inverse": list(self.kpoint_cartesian),
             "fft_shape": list(self.grid.shape),
             "active_count": self.active_count,

--- a/src/mlx_atomistic/dft/runtime_state.py
+++ b/src/mlx_atomistic/dft/runtime_state.py
@@ -59,6 +59,10 @@ def serialize_fixed_density_state(state: Mapping[str, Any]) -> dict[str, bytes]:
     basis = state["basis"]
     metadata = {
         "schema_version": "mlx-atomistic.dft-fixed-density-state.v1",
+        "cell_matrix_bohr": np.asarray(
+            basis.grid.cell.matrix,
+            dtype=np.float64,
+        ).tolist(),
         "grid_shape": list(basis.grid.shape),
         "cutoff_hartree": basis.cutoff_hartree,
         "kpoint_cartesian_bohr_inverse": list(basis.kpoint_cartesian),
@@ -131,6 +135,10 @@ def serialize_periodic_scf_state(result: Any) -> dict[str, bytes]:
 
     metadata = {
         "schema_version": "mlx-atomistic.periodic-scf-compact-state.v2",
+        "cell_matrix_bohr": np.asarray(
+            result.kpoints[0].basis.grid.cell.matrix,
+            dtype=np.float64,
+        ).tolist(),
         "grid_shape": list(result.density.shape),
         "status": result.status,
         "converged": result.converged,

--- a/src/mlx_atomistic/dft/system.py
+++ b/src/mlx_atomistic/dft/system.py
@@ -140,6 +140,8 @@ class DFTSystem:
         ions: IonCollection | None = None,
     ):
         parsed_cell = cell if isinstance(cell, Cell) else Cell.orthorhombic(cell)
+        if not parsed_cell.is_orthorhombic:
+            raise ValueError("legacy DFTSystem requires an orthorhombic cell")
         shape = _validated_grid_shape(grid_shape)
         pseudopotential, electron_count_value = _resolved_pseudopotential(
             ions=ions,

--- a/tests/test_dft.py
+++ b/tests/test_dft.py
@@ -54,17 +54,55 @@ def test_real_and_reciprocal_grid_geometry():
     assert float(np.array(reciprocal.g2)[0, 0, 0]) == pytest.approx(0.0)
 
 
-def test_real_space_grid_rejects_nonorthogonal_cells_until_supported():
-    cell = Cell.triclinic(
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        (
+            (6.0, 0.0, 0.0),
+            (-3.0, 3.0 * np.sqrt(3.0), 0.0),
+            (0.0, 0.0, 9.0),
+        ),
         (
             (8.0, 0.0, 0.0),
             (1.5, 7.5, 0.0),
             (0.5, 1.0, 9.0),
-        )
+        ),
+    ],
+    ids=("hexagonal", "low-symmetry"),
+)
+def test_real_and_reciprocal_grids_support_nonorthogonal_cells(matrix):
+    cell = Cell.triclinic(matrix)
+
+    grid = RealSpaceGrid((4, 4, 4), cell)
+    reciprocal = ReciprocalGrid.from_real_space(grid)
+    direct = np.asarray(cell.matrix, dtype=np.float64)
+    reciprocal_basis = np.asarray(reciprocal.basis_matrix, dtype=np.float64)
+    expected_first = np.asarray((0.125, 0.125, 0.125)) @ direct
+
+    assert grid.volume == pytest.approx(np.linalg.det(direct))
+    np.testing.assert_allclose(
+        np.asarray(grid.coordinates())[0, 0, 0],
+        expected_first,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        direct @ reciprocal_basis.T,
+        2.0 * np.pi * np.eye(3),
+        atol=2e-6,
+    )
+    np.testing.assert_allclose(
+        np.asarray(reciprocal.vectors)[1, 0, 0],
+        reciprocal_basis[0],
+        atol=1e-7,
+    )
+    np.testing.assert_allclose(
+        np.asarray(reciprocal.vectors)[0, 1, 0],
+        reciprocal_basis[1],
+        atol=1e-7,
     )
 
-    with pytest.raises(ValueError, match="require an orthorhombic cell"):
-        RealSpaceGrid((4, 4, 4), cell)
+    with pytest.raises(ValueError, match="legacy DFTSystem requires"):
+        DFTSystem.one_center(cell=cell)
 
 
 def test_fft_round_trip_preserves_real_field():

--- a/tests/test_dft_hexagonal_silicon.py
+++ b/tests/test_dft_hexagonal_silicon.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from math import pi, sqrt
+
+import numpy as np
+
+from mlx_atomistic.benchmarks.dft_hexagonal_silicon import (
+    CUBIC_LATTICE_ANGSTROM,
+    INTERNAL_COORDINATE,
+    hexagonal_silicon_geometry,
+)
+from mlx_atomistic.benchmarks.dft_silicon import ANGSTROM_TO_BOHR
+
+
+def test_hexagonal_silicon_geometry_locks_ideal_2h_contract():
+    cell, positions = hexagonal_silicon_geometry()
+    a = CUBIC_LATTICE_ANGSTROM / sqrt(2.0) * ANGSTROM_TO_BOHR
+    c = sqrt(8.0 / 3.0) * a
+    reciprocal = 2.0 * pi * np.linalg.inv(cell).T
+    fractional = positions @ np.linalg.inv(cell)
+
+    assert positions.shape == (4, 3)
+    assert np.isclose(np.linalg.norm(cell[0]), a)
+    assert np.isclose(np.linalg.norm(cell[1]), a)
+    assert np.isclose(np.linalg.norm(cell[2]), c)
+    assert np.isclose(np.dot(cell[0], cell[1]) / (a * a), -0.5)
+    assert np.isclose(fractional[0, 2], INTERNAL_COORDINATE)
+    np.testing.assert_allclose(cell @ reciprocal.T, 2.0 * pi * np.eye(3), atol=1e-12)

--- a/tests/test_dft_periodic.py
+++ b/tests/test_dft_periodic.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 from math import pi
 
 import mlx.core as mx
 import numpy as np
 import pytest
 
+from mlx_atomistic.core import Cell
 from mlx_atomistic.dft import (
     DiracExchange,
     GTHProjectorChannel,
@@ -26,11 +28,23 @@ from mlx_atomistic.dft import (
     periodic_ewald_energy,
     periodic_ewald_forces,
     periodic_gth_local_forces,
+    periodic_scf_calculation_contract,
     read_gth,
     run_periodic_scf,
     solve_periodic_eigenproblem,
 )
 from mlx_atomistic.dft.kpoints import KPoint, KPointMesh
+from mlx_atomistic.dft.runtime_state import serialize_periodic_scf_state
+
+
+def _skew_cell_matrix() -> np.ndarray:
+    return np.asarray(
+        (
+            (6.0, 0.0, 0.0),
+            (1.0, 5.5, 0.0),
+            (0.4, 0.7, 6.2),
+        )
+    )
 
 
 def test_runtime_observer_is_available_from_public_dft_api():
@@ -48,11 +62,33 @@ def test_plane_wave_basis_mask_and_metadata_are_deterministic():
     assert basis.active_count == expected
     assert basis.to_dict() == {
         "cutoff_hartree": 2.0,
+        "cell_matrix_bohr": [
+            [8.0, 0.0, 0.0],
+            [0.0, 8.0, 0.0],
+            [0.0, 0.0, 8.0],
+        ],
         "kpoint_cartesian_bohr_inverse": [pi / 16.0, 0.0, 0.0],
         "fft_shape": [8, 8, 8],
         "active_count": expected,
         "normalization": "unit-coefficients__real-integral-unit",
     }
+
+
+def test_nonorthogonal_reduced_kpoint_and_system_updates_preserve_cell_matrix():
+    matrix = _skew_cell_matrix()
+    cell = Cell.triclinic(matrix)
+    grid = RealSpaceGrid((6, 6, 6), cell)
+    reduced = np.asarray((0.25, -0.125, 0.375))
+    basis = PlaneWaveBasis.from_reduced_kpoint(grid, 3.0, reduced)
+    expected = reduced @ (2.0 * pi * np.linalg.inv(matrix).T)
+    positions = np.asarray(((0.2, 0.3, 0.4),)) @ matrix
+    system = PeriodicDFTSystem(cell, grid.shape, positions, _silicon_gth())
+    moved = system.with_positions(positions + np.asarray((0.01, -0.02, 0.03)))
+
+    np.testing.assert_allclose(basis.kpoint_cartesian, expected, atol=2e-8)
+    np.testing.assert_array_equal(system.grid.cell.matrix, cell.matrix)
+    np.testing.assert_array_equal(moved.grid.cell.matrix, cell.matrix)
+    assert moved.fingerprint != system.fingerprint
 
 
 def test_plane_wave_round_trip_preserves_masked_coefficients_and_norm():
@@ -460,6 +496,148 @@ def test_periodic_ewald_energy_translation_scaling_and_force_consistency():
     np.testing.assert_allclose(np.sum(forces, axis=0), 0.0, atol=2e-8)
     assert forces[0, 0] == pytest.approx(forces[0, 1], rel=2e-6)
     assert forces[0, 0] == pytest.approx(forces[0, 2], rel=2e-6)
+
+
+def test_nonorthogonal_ewald_translation_and_force_consistency():
+    charges = [1.0, -1.0]
+    matrix = _skew_cell_matrix()
+    cell = Cell.triclinic(matrix)
+    equivalent_cell = Cell.triclinic(
+        np.asarray(((1, 1, 0), (0, 1, 0), (0, 0, 1))) @ matrix
+    )
+    positions = np.asarray(((0.15, 0.2, 0.25), (0.62, 0.55, 0.48))) @ matrix
+    energy = periodic_ewald_energy(charges, positions, cell, tolerance=1e-8)
+    equivalent_energy = periodic_ewald_energy(
+        charges,
+        positions,
+        equivalent_cell,
+        tolerance=1e-8,
+    )
+    translated = periodic_ewald_energy(
+        charges,
+        positions + matrix[1],
+        cell,
+        tolerance=1e-8,
+    )
+    forces = periodic_ewald_forces(charges, positions, cell, tolerance=1e-8)
+    equivalent_forces = periodic_ewald_forces(
+        charges,
+        positions,
+        equivalent_cell,
+        tolerance=1e-8,
+    )
+    finite_difference = periodic_ewald_forces(
+        charges,
+        positions,
+        cell,
+        displacement=2e-4,
+        tolerance=1e-8,
+        method="finite_difference",
+    )
+
+    assert translated == pytest.approx(energy, abs=2e-9)
+    assert equivalent_energy == pytest.approx(energy, abs=2e-8)
+    np.testing.assert_allclose(equivalent_forces, forces, atol=2e-8)
+    np.testing.assert_allclose(forces, finite_difference, atol=3e-8, rtol=3e-7)
+    np.testing.assert_allclose(np.sum(forces, axis=0), 0.0, atol=2e-8)
+
+
+def test_nonorthogonal_gth_operators_preserve_lattice_translation():
+    matrix = _skew_cell_matrix()
+    grid = RealSpaceGrid((6, 6, 6), Cell.triclinic(matrix))
+    basis = PlaneWaveBasis.from_reduced_kpoint(grid, 3.0, (0.25, 0.125, -0.25))
+    positions = np.asarray(((0.15, 0.2, 0.25), (0.62, 0.55, 0.48))) @ matrix
+    shifted_positions = positions + matrix[1]
+    coordinates = np.asarray(grid.coordinates())
+    reciprocal = np.asarray(basis.reciprocal_grid.basis_matrix)
+    density = (
+        0.02
+        + 0.004 * np.cos(coordinates @ reciprocal[0])
+        + 0.003 * np.sin(coordinates @ reciprocal[1])
+    ).astype(np.float32)
+    local = np.asarray(gth_local_potential_grid(_silicon_gth(), basis, positions))
+    shifted_local = np.asarray(
+        gth_local_potential_grid(_silicon_gth(), basis, shifted_positions)
+    )
+    local_forces = np.asarray(
+        periodic_gth_local_forces(mx.array(density), _silicon_gth(), basis, positions)
+    )
+    rng = np.random.default_rng(203)
+    orbital = basis.normalize(
+        mx.array(
+            (rng.normal(size=grid.shape) + 1j * rng.normal(size=grid.shape)).astype(
+                np.complex64
+            )
+        )
+    )
+    operator = PeriodicGTHNonlocalOperator(_silicon_gth(), basis, positions)
+    shifted_operator = PeriodicGTHNonlocalOperator(
+        _silicon_gth(),
+        basis,
+        shifted_positions,
+    )
+    energy = float(operator.energy(orbital, occupations=[2.0]))
+    shifted_energy = float(shifted_operator.energy(orbital, occupations=[2.0]))
+    nonlocal_forces = np.asarray(operator.forces(orbital, occupations=[2.0]))
+    shifted_nonlocal_forces = np.asarray(
+        shifted_operator.forces(orbital, occupations=[2.0])
+    )
+
+    assert np.isfinite(local).all()
+    assert np.isfinite(local_forces).all()
+    assert np.isfinite(nonlocal_forces).all()
+    np.testing.assert_allclose(shifted_local, local, atol=2e-6)
+    assert shifted_energy == pytest.approx(energy, abs=2e-5)
+    np.testing.assert_allclose(shifted_nonlocal_forces, nonlocal_forces, atol=2e-5)
+
+
+def test_nonorthogonal_periodic_scf_and_state_metadata_preserve_cell_matrix():
+    matrix = _skew_cell_matrix()
+    positions = np.asarray(((0.25, 0.25, 0.25),)) @ matrix
+    system = PeriodicDFTSystem(
+        Cell.triclinic(matrix),
+        (6, 6, 6),
+        positions,
+        _silicon_gth(),
+    )
+    mesh = KPointMesh(
+        (KPoint((0.0, 0.0, 0.0), weight=1.0, coordinate_system="reduced"),)
+    )
+    config = PeriodicSCFConfig(
+        max_iterations=2,
+        min_iterations=2,
+        density_tolerance=1e-8,
+        energy_tolerance=1e-8,
+        orbital_tolerance=5e-3,
+        mixing_beta=0.5,
+        mixer="linear",
+        davidson=PeriodicDavidsonConfig(
+            max_iterations=16,
+            tolerance=5e-3,
+            max_subspace_size=12,
+        ),
+    )
+    contract = periodic_scf_calculation_contract(
+        system,
+        cutoff_hartree=2.5,
+        kpoint_mesh=mesh,
+        n_bands=2,
+        config=config,
+    )
+    result = run_periodic_scf(
+        system,
+        cutoff_hartree=2.5,
+        kpoint_mesh=mesh,
+        n_bands=2,
+        config=config,
+    )
+    metadata = json.loads(serialize_periodic_scf_state(result)["metadata.json"])
+
+    assert result.status in {"converged", "max_iterations"}
+    assert np.isfinite(result.total_energy)
+    np.testing.assert_allclose(contract["system"]["cell_matrix_bohr"], matrix)
+    np.testing.assert_allclose(metadata["cell_matrix_bohr"], matrix)
+    np.testing.assert_allclose(result.kpoints[0].basis.to_dict()["cell_matrix_bohr"], matrix)
 
 
 def test_periodic_davidson_matches_diagonal_kinetic_local_oracle():


### PR DESCRIPTION
## Summary

- generalize real and reciprocal DFT grids to full-rank row-vector cell matrices
- map FFT integer vectors and reduced k-points through the reciprocal basis
- generalize periodic Ewald energy and analytic forces without changing the orthorhombic path
- preserve complete cell identity through PeriodicDFTSystem, checkpoints, basis reports, and compact state metadata
- keep the legacy teaching DFTSystem fail-closed for nonorthogonal cells
- add source-bound 2H-Silicon validation and bounded low-symmetry numerical oracles

## Verification

- direct affected modules: 50 tests passed and 6 opt-in tests skipped in under one second
- focused 2H-Silicon protocol test passed
- ruff check src tests scripts
- API documentation generation check
- narrative documentation synchronization check
- git diff --check
- accepted report runtime and implementation fingerprints match the committed source

## Scientific evidence

The 2H-Silicon fixed-cell relaxation converged in three accepted ionic steps and four SCF evaluations. Final maximum force was 1.715e-5 Ha/bohr, final maximum step was 1.659e-4 bohr, and maximum translation-aligned internal relaxation was 0.003351 angstrom. Complete wall time was 28.744 seconds with 4.856 GB peak physical memory on AC power with low-power mode disabled.

This closes ordinary fixed full-rank cell execution. Stress and variable-cell relaxation remain Phase 4 work.