### PR TITLE
Establish source-bound UPF local fidelity

### DIFF
--- a/docs/dft-gth-transferability.md
+++ b/docs/dft-gth-transferability.md
@@ -135,3 +135,10 @@ curve gave `a₀ = 4.252650 Å`, `B₀ = 146.708 GPa`, `B₀′ = 3.35102`, and 
 `0.461 meV/atom`. Its bulk-derivative relative error was `18.09%`, above the
 unchanged `15%` gate and worse than the standard q2 result. The UZH candidate
 is therefore rejected, and its force ladder was not run.
+
+The matching UZH Mg-q10/O-q6 primitive central feasibility point was also
+rejected before a full-mesh oracle. It reached 80 SCF iterations in `39.286 s`
+with a `5.4187e-6` direct orbital residual, above the unchanged `2e-6` gate.
+Its density and energy criteria passed, so neither a full mesh nor an EOS curve
+was run. This closes the prepared UZH q10 candidate without weakening the
+eigensolver requirement.

--- a/docs/dft-production-core.md
+++ b/docs/dft-production-core.md
@@ -17,13 +17,18 @@ is not broadly chemically certified. Capability claims are tied to the
 
 ## Nonlocal Pseudopotentials
 
-UPF and GTH nonlocal metadata is converted into normalized real-space separable projectors. The operator applies:
+The legacy UPF and GTH metadata path converts projectors into normalized
+real-space separable forms. The operator applies:
 
 ```text
 V̂_NL ψ = Σᵢ |βᵢ⟩ Dᵢ ⟨βᵢ|ψ⟩
 ```
 
-For UPF, diagonal `PP_DIJ` values are used as projector couplings after Ry-to-Hartree conversion. For GTH, parsed projector coefficients seed the coupling. This gives a Hermitian validation path, but it is not yet a full chemically faithful reproduction of every format convention.
+The UPF parser now preserves radial quadrature and the complete `PP_DIJ` matrix
+after Ry-to-Hartree conversion, while the legacy proof operator still consumes
+only its diagonal. A source-matched compensated periodic local transform is
+available, but periodic UPF nonlocal SCF remains unimplemented. The production
+periodic GTH path retains its separate analytic operators.
 
 SCF applies nonlocal projectors by default when available. `SCFConfig(apply_nonlocal=False)` keeps the old local-only path available for debugging and comparison.
 

--- a/docs/dft-pseudopotentials.md
+++ b/docs/dft-pseudopotentials.md
@@ -25,13 +25,26 @@ local-potential SCF plus proof-level nonlocal projector application.
 sources. The current path uses:
 
 - `PP_HEADER` for element and valence charge.
-- `PP_MESH/PP_R` for radial samples.
+- `PP_MESH/PP_R` and `PP_RAB` for radial samples and quadrature weights.
 - `PP_LOCAL` for the local potential.
 - `PP_BETA.*` tags for nonlocal projector metadata.
+- The complete symmetric `PP_DIJ` matrix, converted from Rydberg to Hartree.
 
-The local UPF potential is interpolated onto the periodic real-space grid. UPF
-nonlocal projectors are parsed and applied by the ion-aware operator when
-`SCFConfig(apply_nonlocal=True)` is active.
+The legacy teaching path interpolates the local potential onto its real-space
+grid. Its proof-level nonlocal operator still consumes only the diagonal
+couplings and is not a production UPF implementation.
+
+The periodic layer now has a separate local-only UPF foundation. It follows
+Quantum ESPRESSO's compensated radial transform: subtract `erf(r) / r` before
+quadrature, restore the analytic reciprocal-space Coulomb tail, and use the
+finite `G=0` alpha term. Literal source oracles and a numerical GTH-equivalence
+test cover the transform and fixed-cell local force. Periodic SCF does not yet
+admit UPF nonlocal projectors.
+
+The future periodic boundary is fail-closed. Only scalar norm-conserving input
+without ultrasoft augmentation, PAW, spin-orbit terms, or nonlinear core
+correction is currently eligible. Parsing an unsupported file preserves its
+identity; it does not make that physics executable.
 
 ## GTH
 
@@ -76,8 +89,9 @@ production DFT force accuracy.
 
 ## Current Limits
 
-- Nonlocal projectors are a proof-level Hermitian separable operator path, not a
-  chemically certified reproduction of every UPF/GTH convention.
+- The legacy UPF nonlocal operator remains proof-level. Full `PP_DIJ` and radial
+  semantics are preserved, but compact periodic nonlocal execution is not yet
+  connected to SCF.
 - This pseudopotential milestone does not certify geometry or stress. The
   current periodic runtime separately provides verified fixed-cell Silicon
   relaxation and one bounded analytic-stress/variable-cell 2H-Silicon path;

--- a/docs/dft-roadmap.md
+++ b/docs/dft-roadmap.md
@@ -238,7 +238,9 @@ fails its locked orbital-residual gate after both cold and density-seeded runs,
 so the matched full oracle and full q10 EOS were not run. A bounded CP2K 2026.1
 UZH q2 alternative passed its conventional-cell reduced/full method oracle but
 was rejected because its seven-point bulk-derivative error was `18.09%`, above
-the unchanged `15%` gate.
+the unchanged `15%` gate. Its prepared UZH q10 alternative was also rejected
+at the primitive central feasibility point with a `5.4187e-6` direct orbital
+residual above the unchanged `2e-6` gate.
 
 ## Phase 8: Add Finite-Displacement Phonons
 
@@ -308,7 +310,7 @@ Current exit audit: every criterion above is implemented and has bounded
 evidence except the broad GTH production envelope. Phase 7 has complete
 coverage, but its strict matrix remains failed by the locked MgO q2
 bulk-derivative and total-force residuals, the rejected q10 candidate, and
-the rejected UZH q2 alternative, plus missing exact calculation/runtime
+the rejected UZH q2/q10 alternatives, plus missing exact calculation/runtime
 identities in older summaries. The Fe q16
 point-group method oracle now passes, but that does not erase the remaining
 identity and MgO blockers. The project therefore must not yet claim the general
@@ -334,8 +336,10 @@ above:
   DFT;
 - platform scale: automatic crystallographic symmetry discovery, distributed
   execution, multi-device scheduling, and broad molecular DFT;
-- alternate periodic pseudopotential envelopes: production UPF support beyond
-  the required GTH general-core envelope.
+- alternate periodic pseudopotential envelopes: production UPF nonlocal and SCF
+  admission beyond the required GTH general-core envelope. The retained radial,
+  full-`PP_DIJ`, fingerprint, and periodic-local foundation does not yet
+  constitute that envelope.
 
 Each item requires its own roadmap or bounded extension after the general-core
 exit audit. None is an implied blocker for the claim defined here.

--- a/src/mlx_atomistic/benchmarks/data/dft_gth_transferability_contract.json
+++ b/src/mlx_atomistic/benchmarks/data/dft_gth_transferability_contract.json
@@ -177,6 +177,22 @@
         {"name": "orbital_residual", "value": 0.0000030125518151180586, "maximum": 0.000002},
         {"name": "scf_iterations", "value": 80.0, "maximum": 79.0}
       ]
+    },
+    {
+      "candidate_id": "rocksalt-mgo-uzh-primitive-q10-q6-c40-k4",
+      "workload_fingerprint": "7990b1e9302d23dfab55059dac0242f80418c31bae406bb4f7627cbc9aba492b",
+      "calculation_fingerprint": "531b8cafa99d0f1adc3e83d150a7bfa4162ddc386384850144ae7892c0b9463a",
+      "implementation_fingerprint": "d22eaaad6c87a9476cc5a9a8dd1d21397a7363426db86ebd51a6fe70314c9d66",
+      "method_validation": {
+        "scope": "point_group_density_reconstruction_cold_full_oracle_skipped_after_numerical_failure",
+        "passed": false
+      },
+      "elapsed_wall_seconds": 39.28628162480891,
+      "peak_temporary_bytes": 63770520,
+      "metrics": [
+        {"name": "orbital_residual", "value": 0.000005418748514784966, "maximum": 0.000002},
+        {"name": "scf_iterations", "value": 80.0, "maximum": 79.0}
+      ]
     }
   ]
 }

--- a/src/mlx_atomistic/benchmarks/dft_gth_transferability.py
+++ b/src/mlx_atomistic/benchmarks/dft_gth_transferability.py
@@ -13,7 +13,7 @@ import numpy as np
 from mlx_atomistic._artifact_identity import sha256_bytes
 
 CONTRACT_SCHEMA = "mlx-atomistic.dft-gth-transferability.v1"
-CONTRACT_SHA256 = "c15a37644395e304f7deb19c112ca10dd3d6d0e00e552fb9166ff7fe74cf1ebe"
+CONTRACT_SHA256 = "906685a1ce847009c0a731fd733908684920dc643c442d6bc5b84bca67a7f319"
 
 
 def _contract_path() -> Path:

--- a/src/mlx_atomistic/dft/__init__.py
+++ b/src/mlx_atomistic/dft/__init__.py
@@ -180,6 +180,11 @@ from mlx_atomistic.dft.periodic_stress import (
     periodic_analytic_stress,
     periodic_finite_difference_stress,
 )
+from mlx_atomistic.dft.periodic_upf import (
+    periodic_upf_local_forces,
+    upf_local_potential_grid,
+    upf_local_reciprocal_coefficients,
+)
 from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
 from mlx_atomistic.dft.potentials import (
     LocalGaussianPseudopotential,
@@ -398,6 +403,7 @@ __all__ = [
     "periodic_scf_calculation_contract",
     "periodic_scf_execution_settings",
     "periodic_scf_forces",
+    "periodic_upf_local_forces",
     "periodic_scf_initialization_identity",
     "publish_periodic_scf_checkpoint",
     "plan_periodic_phonon_displacements",
@@ -420,6 +426,8 @@ __all__ = [
     "solve_periodic_eigenproblem",
     "spin_density_from_orbitals",
     "unfold_periodic_band_structure",
+    "upf_local_potential_grid",
+    "upf_local_reciprocal_coefficients",
     "write_periodic_density_volume",
     "write_periodic_phonon_samples",
 ]

--- a/src/mlx_atomistic/dft/_periodic_pseudopotential.py
+++ b/src/mlx_atomistic/dft/_periodic_pseudopotential.py
@@ -1,0 +1,51 @@
+"""Shared validation and geometry for periodic pseudopotential operators."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from mlx_atomistic.dft.pseudopotentials import (
+    PseudopotentialData,
+    PseudopotentialFormat,
+)
+
+
+def _periodic_positions(positions: Sequence[Sequence[float]]) -> np.ndarray:
+    values = np.array(positions, dtype=np.float64, copy=True)
+    if values.ndim != 2 or values.shape[1] != 3 or values.shape[0] == 0:
+        raise ValueError("positions must have shape (n_ions, 3)")
+    if not np.isfinite(values).all():
+        raise ValueError("positions must contain only finite values")
+    values.setflags(write=False)
+    return values
+
+
+def _periodic_pseudopotentials(
+    pseudopotential: PseudopotentialData | Sequence[PseudopotentialData],
+    ion_count: int,
+    *,
+    expected_format: PseudopotentialFormat,
+) -> tuple[PseudopotentialData, ...]:
+    if isinstance(pseudopotential, PseudopotentialData):
+        values = (pseudopotential,) * ion_count
+    else:
+        values = tuple(pseudopotential)
+        if len(values) != ion_count:
+            raise ValueError("pseudopotentials length must match the ion count")
+    if any(not isinstance(value, PseudopotentialData) for value in values):
+        raise TypeError("pseudopotentials must contain PseudopotentialData values")
+    if any(value.format != expected_format for value in values):
+        raise ValueError(
+            f"periodic operator requires {expected_format.value.upper()} pseudopotentials"
+        )
+    return values
+
+
+def _periodic_structure_factor(
+    vectors: np.ndarray,
+    positions: np.ndarray,
+) -> np.ndarray:
+    phase = np.einsum("...d,id->i...", vectors, positions, optimize=True)
+    return np.sum(np.exp(-1j * phase), axis=0)

--- a/src/mlx_atomistic/dft/_pseudopotential_identity.py
+++ b/src/mlx_atomistic/dft/_pseudopotential_identity.py
@@ -10,9 +10,64 @@ from mlx_atomistic.dft.pseudopotentials import PseudopotentialData
 
 
 def _pseudopotential_fingerprint(pseudopotential: PseudopotentialData) -> str:
-    """Return the canonical fingerprint for one GTH pseudopotential."""
+    """Return the canonical fingerprint for one parsed pseudopotential."""
 
     digest = sha256()
+    if str(pseudopotential.format) == "upf":
+        digest.update(b"mlx-atomistic.upf-nonlocal.v1\0")
+        digest.update(pseudopotential.element.encode("utf-8"))
+        digest.update(str(pseudopotential.format).encode("utf-8"))
+        digest.update(
+            np.asarray([pseudopotential.valence_charge], dtype=np.float64).tobytes()
+        )
+        local = pseudopotential.local_grid
+        if local is None:
+            raise ValueError("UPF pseudopotential identity requires a local radial grid")
+        digest.update(np.asarray(local.radii, dtype=np.float64).tobytes())
+        digest.update(np.asarray(local.values, dtype=np.float64).tobytes())
+        weights = local.integration_weights
+        if weights is None:
+            raise ValueError("UPF pseudopotential identity requires radial weights")
+        digest.update(np.asarray(weights, dtype=np.float64).tobytes())
+        for projector in pseudopotential.nonlocal_projectors:
+            digest.update(
+                np.asarray([projector.angular_momentum], dtype=np.int64).tobytes()
+            )
+            digest.update(np.asarray(projector.values, dtype=np.float64).tobytes())
+            has_cutoff = projector.cutoff_radius is not None
+            digest.update(np.asarray([has_cutoff], dtype=np.uint8).tobytes())
+            digest.update(
+                np.asarray(
+                    [
+                        0.0 if not has_cutoff else projector.cutoff_radius,
+                        projector.coupling,
+                    ],
+                    dtype=np.float64,
+                ).tobytes()
+            )
+            digest.update(np.asarray(projector.coefficients, dtype=np.float64).tobytes())
+        digest.update(
+            np.asarray(
+                pseudopotential.nonlocal_coupling_matrix,
+                dtype=np.float64,
+            ).tobytes()
+        )
+        metadata = pseudopotential.metadata or {}
+        for name in (
+            "version",
+            "pseudo_type",
+            "relativistic",
+            "functional",
+            "is_ultrasoft",
+            "is_paw",
+            "has_so",
+            "core_correction",
+        ):
+            digest.update(name.encode("ascii"))
+            digest.update(repr(metadata.get(name)).encode("utf-8"))
+            digest.update(b"\0")
+        return digest.hexdigest()
+
     digest.update(b"mlx-atomistic.gth-nonlocal.v1\0")
     digest.update(pseudopotential.element.encode("utf-8"))
     digest.update(str(pseudopotential.format).encode("utf-8"))

--- a/src/mlx_atomistic/dft/periodic_gth.py
+++ b/src/mlx_atomistic/dft/periodic_gth.py
@@ -12,6 +12,11 @@ import mlx.core as mx
 import numpy as np
 
 from mlx_atomistic.dft._compact import _CompactBatch, _CompactLaneState
+from mlx_atomistic.dft._periodic_pseudopotential import (
+    _periodic_positions,
+    _periodic_pseudopotentials,
+    _periodic_structure_factor,
+)
 from mlx_atomistic.dft._pseudopotential_identity import _pseudopotential_fingerprint
 from mlx_atomistic.dft.periodic_electrostatics import (
     periodic_ewald_energy as periodic_ewald_energy,
@@ -23,6 +28,7 @@ from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
 from mlx_atomistic.dft.pseudopotentials import (
     GTHProjectorChannel,
     PseudopotentialData,
+    PseudopotentialFormat,
 )
 
 _GTH_OVERLAP_CHUNK_SIZE = 1024
@@ -43,33 +49,18 @@ def _per_ion_pseudopotentials(
 ) -> tuple[PseudopotentialData, ...]:
     """Return one validated GTH pseudopotential per ion."""
 
-    if isinstance(pseudopotential, PseudopotentialData):
-        values = (pseudopotential,) * ion_count
-    else:
-        values = tuple(pseudopotential)
-        if len(values) != ion_count:
-            msg = "pseudopotentials length must match the ion count"
-            raise ValueError(msg)
-    if any(not isinstance(value, PseudopotentialData) for value in values):
-        msg = "pseudopotentials must contain PseudopotentialData values"
-        raise TypeError(msg)
+    values = _periodic_pseudopotentials(
+        pseudopotential,
+        ion_count,
+        expected_format=PseudopotentialFormat.GTH,
+    )
     for value in values:
         _validated_gth(value)
     return values
 
 
-def _positions(positions: Sequence[Sequence[float]]) -> np.ndarray:
-    values = np.array(positions, dtype=np.float64, copy=True)
-    if values.ndim != 2 or values.shape[1] != 3 or values.shape[0] == 0:
-        msg = "positions must have shape (n_ions, 3)"
-        raise ValueError(msg)
-    values.setflags(write=False)
-    return values
-
-
-def _structure_factor(vectors: np.ndarray, positions: np.ndarray) -> np.ndarray:
-    phase = np.einsum("...d,id->i...", vectors, positions, optimize=True)
-    return np.sum(np.exp(-1j * phase), axis=0)
+_positions = _periodic_positions
+_structure_factor = _periodic_structure_factor
 
 
 def gth_local_reciprocal_coefficients(

--- a/src/mlx_atomistic/dft/periodic_upf.py
+++ b/src/mlx_atomistic/dft/periodic_upf.py
@@ -1,0 +1,245 @@
+"""Periodic local operators for numerical UPF pseudopotentials."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from math import pi
+
+import mlx.core as mx
+import numpy as np
+from scipy.special import erf
+
+from mlx_atomistic.dft._periodic_pseudopotential import (
+    _periodic_positions,
+    _periodic_pseudopotentials,
+    _periodic_structure_factor,
+)
+from mlx_atomistic.dft._pseudopotential_identity import _pseudopotential_fingerprint
+from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
+from mlx_atomistic.dft.pseudopotentials import (
+    PseudopotentialData,
+    PseudopotentialFormat,
+    RadialGrid,
+)
+
+_RADIAL_TRANSFORM_CHUNK_SIZE = 1024
+
+
+def _simpson_radial(values: np.ndarray, grid: RadialGrid) -> np.ndarray:
+    """Integrate along the final axis with Quantum ESPRESSO's Simpson rule."""
+
+    samples = np.asarray(values, dtype=np.float64)
+    if samples.shape[-1] != grid.size:
+        raise ValueError("radial integrand size must match its grid")
+    if grid.size < 3:
+        raise ValueError("periodic UPF transforms require at least three radial samples")
+    weights = grid.integration_weights
+    if weights is None:
+        raise ValueError("periodic UPF transforms require PP_RAB weights")
+    coefficients = np.full(grid.size, 2.0 / 3.0, dtype=np.float64)
+    coefficients[1:-1:2] = 4.0 / 3.0
+    coefficients[0] = 1.0 / 3.0
+    coefficients[-1] = 1.0 / 3.0
+    if grid.size % 2 == 0:
+        coefficients[-3] -= 1.0 / 12.0
+        coefficients[-2] += 1.0 / 3.0
+        coefficients[-1] += 1.0 / 12.0
+    return np.sum(samples * (coefficients * weights), axis=-1, dtype=np.float64)
+
+
+def _upf_local_radial_transform(
+    pseudopotential: PseudopotentialData,
+    q: np.ndarray,
+    *,
+    volume: float,
+) -> np.ndarray:
+    grid = pseudopotential.local_grid
+    if grid is None:
+        raise ValueError("UPF local transform requires a radial local potential")
+    q_values = np.asarray(q, dtype=np.float64)
+    if q_values.ndim != 1 or not np.isfinite(q_values).all() or np.any(q_values < 0.0):
+        raise ValueError("UPF local transform magnitudes must be finite and non-negative")
+    radius = grid.radii
+    local = grid.values
+    charge = float(pseudopotential.valence_charge)
+    compensated = radius * local + charge * erf(radius)
+    transformed = np.empty_like(q_values)
+    zero = q_values <= 1.0e-14
+    if np.any(zero):
+        transformed[zero] = (
+            4.0
+            * pi
+            / volume
+            * _simpson_radial(radius * (radius * local + charge), grid)
+        )
+    positive_indices = np.flatnonzero(~zero)
+    for start in range(0, positive_indices.size, _RADIAL_TRANSFORM_CHUNK_SIZE):
+        indices = positive_indices[start : start + _RADIAL_TRANSFORM_CHUNK_SIZE]
+        selected = q_values[indices]
+        qr = selected[:, None] * radius[None, :]
+        short_range = _simpson_radial(
+            compensated[None, :] * np.sin(qr) / selected[:, None],
+            grid,
+        )
+        coulomb = charge * np.exp(-(selected**2) / 4.0) / selected**2
+        transformed[indices] = 4.0 * pi / volume * (short_range - coulomb)
+    return transformed
+
+
+def _single_upf_local_coefficients(
+    pseudopotential: PseudopotentialData,
+    basis: PlaneWaveBasis,
+    vectors: np.ndarray,
+) -> np.ndarray:
+    q = np.sqrt(np.sum(vectors * vectors, axis=-1))
+    return _upf_local_radial_transform(
+        pseudopotential,
+        q.reshape(-1),
+        volume=basis.volume,
+    ).reshape(basis.grid.shape)
+
+
+def upf_local_reciprocal_coefficients(
+    pseudopotential: PseudopotentialData | Sequence[PseudopotentialData],
+    basis: PlaneWaveBasis,
+    positions: Sequence[Sequence[float]],
+) -> mx.array:
+    """Return periodic UPF local-potential Fourier coefficients.
+
+    The numerical transform follows Quantum ESPRESSO's compensated ``vloc``
+    convention. It removes ``erf(r) / r`` before radial integration, restores
+    the analytic reciprocal-space Coulomb tail, and uses the finite ``G=0``
+    alpha term.
+
+    Args:
+        pseudopotential: One shared or one-per-ion parsed UPF pseudopotential.
+        basis: Plane-wave basis supplying reciprocal vectors and volume.
+        positions: Ionic Cartesian positions in bohr.
+
+    Returns:
+        Complex local-potential coefficients with shape ``basis.grid.shape``.
+    """
+
+    centers = _periodic_positions(positions)
+    per_ion = _periodic_pseudopotentials(
+        pseudopotential,
+        int(centers.shape[0]),
+        expected_format=PseudopotentialFormat.UPF,
+    )
+    vectors = np.asarray(basis.reciprocal_vectors, dtype=np.float64)
+    grouped: dict[str, tuple[PseudopotentialData, list[np.ndarray]]] = {}
+    for pseudo, center in zip(per_ion, centers, strict=True):
+        fingerprint = _pseudopotential_fingerprint(pseudo)
+        if fingerprint not in grouped:
+            grouped[fingerprint] = (pseudo, [])
+        grouped[fingerprint][1].append(center)
+    values = np.zeros(basis.grid.shape, dtype=np.complex128)
+    for pseudo, species_centers in grouped.values():
+        single = _single_upf_local_coefficients(
+            pseudo,
+            basis,
+            vectors,
+        )
+        values += single * _periodic_structure_factor(
+            vectors,
+            np.asarray(species_centers, dtype=np.float64),
+        )
+    return mx.array(values.astype(np.complex64))
+
+
+def upf_local_potential_grid(
+    pseudopotential: PseudopotentialData | Sequence[PseudopotentialData],
+    basis: PlaneWaveBasis,
+    positions: Sequence[Sequence[float]],
+) -> mx.array:
+    """Return the real periodic UPF local potential on the FFT grid.
+
+    Args:
+        pseudopotential: One shared or one-per-ion parsed UPF pseudopotential.
+        basis: Plane-wave basis supplying the FFT grid.
+        positions: Ionic Cartesian positions in bohr.
+
+    Returns:
+        Real local potential with shape ``basis.grid.shape``.
+    """
+
+    coefficients = upf_local_reciprocal_coefficients(
+        pseudopotential,
+        basis,
+        positions,
+    )
+    return mx.real(mx.fft.ifftn(coefficients) * basis.grid.size)
+
+
+def periodic_upf_local_forces(
+    density: mx.array,
+    pseudopotential: PseudopotentialData | Sequence[PseudopotentialData],
+    basis: PlaneWaveBasis,
+    positions: Sequence[Sequence[float]],
+) -> mx.array:
+    """Return analytic fixed-cell local-UPF Hellmann--Feynman forces.
+
+    Args:
+        density: Positive electron density on ``basis.grid``.
+        pseudopotential: One shared or one-per-ion parsed UPF pseudopotential.
+        basis: Plane-wave basis supplying reciprocal vectors and volume.
+        positions: Ionic Cartesian positions in bohr.
+
+    Returns:
+        Local electron-ion forces with shape ``(n_ions, 3)`` in Hartree/bohr.
+    """
+
+    centers = _periodic_positions(positions)
+    per_ion = _periodic_pseudopotentials(
+        pseudopotential,
+        int(centers.shape[0]),
+        expected_format=PseudopotentialFormat.UPF,
+    )
+    density_array = mx.real(mx.array(density)).astype(mx.float32)
+    if density_array.shape != basis.grid.shape:
+        raise ValueError("density shape must match the periodic FFT grid")
+    finite = mx.all(mx.isfinite(density_array))
+    mx.eval(finite)
+    if not bool(finite):
+        raise ValueError("density must contain only finite values")
+    density_reciprocal = mx.conjugate(mx.fft.fftn(density_array))
+    vectors_np = np.asarray(basis.reciprocal_vectors, dtype=np.float64)
+    vectors = mx.array(vectors_np.astype(np.float32))
+    imaginary = mx.array(1j, dtype=mx.complex64)
+    single_by_species: dict[str, np.ndarray] = {}
+    forces = []
+    for pseudo, center in zip(per_ion, centers, strict=True):
+        fingerprint = _pseudopotential_fingerprint(pseudo)
+        single = single_by_species.get(fingerprint)
+        if single is None:
+            single = _single_upf_local_coefficients(
+                pseudo,
+                basis,
+                vectors_np,
+            )
+            single_by_species[fingerprint] = single
+        phase = np.exp(
+            -1j
+            * np.einsum(
+                "...d,d->...",
+                vectors_np,
+                center,
+                optimize=True,
+            )
+        )
+        coefficients = mx.array((single * phase).astype(np.complex64))
+        forces.append(
+            mx.real(
+                mx.sum(
+                    density_reciprocal[..., None]
+                    * imaginary
+                    * vectors
+                    * coefficients[..., None],
+                    axis=(0, 1, 2),
+                )
+                * basis.grid.dv
+            )
+        )
+    result = mx.stack(forces, axis=0).astype(mx.float32)
+    mx.eval(result)
+    return result

--- a/src/mlx_atomistic/dft/pseudopotentials.py
+++ b/src/mlx_atomistic/dft/pseudopotentials.py
@@ -26,12 +26,19 @@ class PseudopotentialFormat(StrEnum):
 
 @dataclass(frozen=True)
 class RadialGrid:
-    """Radial samples for a local pseudopotential channel."""
+    """Radial samples and optional quadrature weights."""
 
     radii: np.ndarray
     values: np.ndarray
+    integration_weights: np.ndarray | None
 
-    def __init__(self, radii: Sequence[float], values: Sequence[float]):
+    def __init__(
+        self,
+        radii: Sequence[float],
+        values: Sequence[float],
+        *,
+        integration_weights: Sequence[float] | None = None,
+    ):
         radii_np = np.asarray(radii, dtype=np.float64)
         values_np = np.asarray(values, dtype=np.float64)
         if radii_np.ndim != 1 or values_np.ndim != 1:
@@ -43,11 +50,24 @@ class RadialGrid:
         if len(radii_np) < 2:
             msg = "radial grid requires at least two samples"
             raise ValueError(msg)
+        if not np.isfinite(radii_np).all() or not np.isfinite(values_np).all():
+            msg = "radial grid samples must be finite"
+            raise ValueError(msg)
         if np.any(np.diff(radii_np) <= 0.0):
             msg = "radial grid radii must be strictly increasing"
             raise ValueError(msg)
+        weights_np = None
+        if integration_weights is not None:
+            weights_np = np.asarray(integration_weights, dtype=np.float64)
+            if weights_np.ndim != 1 or weights_np.shape != radii_np.shape:
+                msg = "radial integration weights must match the radial grid"
+                raise ValueError(msg)
+            if not np.isfinite(weights_np).all() or np.any(weights_np <= 0.0):
+                msg = "radial integration weights must be finite and positive"
+                raise ValueError(msg)
         object.__setattr__(self, "radii", radii_np)
         object.__setattr__(self, "values", values_np)
+        object.__setattr__(self, "integration_weights", weights_np)
 
     @property
     def size(self) -> int:
@@ -156,6 +176,7 @@ class PseudopotentialData:
     gth_coefficients: tuple[float, ...] = ()
     gth_channels: tuple[GTHProjectorChannel, ...] = ()
     nonlocal_projectors: tuple[NonlocalProjectorData, ...] = ()
+    nonlocal_coupling_matrix: tuple[tuple[float, ...], ...] = ()
     metadata: dict[str, str | int | float | bool] | None = None
 
     @property
@@ -163,6 +184,24 @@ class PseudopotentialData:
         """Whether the source file contained nonlocal projector metadata."""
 
         return bool(self.gth_channels or self.nonlocal_projectors)
+
+    @property
+    def periodic_upf_compatible(self) -> bool:
+        """Whether this UPF is within the scalar norm-conserving core boundary."""
+
+        if self.format != PseudopotentialFormat.UPF or self.metadata is None:
+            return False
+        relativistic = str(self.metadata.get("relativistic", "")).strip().lower()
+        return (
+            str(self.metadata.get("pseudo_type", "")).strip().upper() == "NC"
+            and relativistic in {"", "no", "none", "scalar", "scalar-relativistic"}
+            and self.metadata.get("is_ultrasoft") is False
+            and self.metadata.get("is_paw") is False
+            and self.metadata.get("has_so") is False
+            and self.metadata.get("core_correction") is False
+            and bool(self.nonlocal_projectors)
+            and bool(self.nonlocal_coupling_matrix)
+        )
 
     def local_potential(self, radius: np.ndarray) -> np.ndarray:
         """Evaluate the local potential in Hartree on radii in bohr."""
@@ -360,62 +399,114 @@ def read_upf(path: str | Path) -> PseudopotentialData:
     element = _required_str(header.attrib.get("element"), "UPF element")
     valence = float(_required_str(header.attrib.get("z_valence"), "UPF z_valence"))
     radii_node = root.find("./PP_MESH/PP_R")
+    weights_node = root.find("./PP_MESH/PP_RAB")
     local_node = root.find("PP_LOCAL")
-    if radii_node is None or local_node is None:
-        msg = "UPF file is missing PP_R or PP_LOCAL"
+    if radii_node is None or weights_node is None or local_node is None:
+        msg = "UPF file is missing PP_R, PP_RAB, or PP_LOCAL"
         raise ValueError(msg)
     radii = _numbers(radii_node.text)
+    integration_weights = _numbers(weights_node.text)
     # QE UPF local potentials are conventionally stored in Ry; convert to Hartree.
     local = 0.5 * _numbers(local_node.text)
-    if radii.shape != local.shape:
-        msg = "UPF PP_R and PP_LOCAL sizes do not match"
+    if radii.shape != local.shape or radii.shape != integration_weights.shape:
+        msg = "UPF PP_R, PP_RAB, and PP_LOCAL sizes do not match"
         raise ValueError(msg)
-    radial_grid = RadialGrid(radii, local)
-    projectors = []
+    radial_grid = RadialGrid(
+        radii,
+        local,
+        integration_weights=integration_weights,
+    )
+    indexed_projectors: list[tuple[int, NonlocalProjectorData]] = []
     for node in root.iter():
         if not node.tag.startswith("PP_BETA"):
             continue
         angular = int(
             _required_str(node.attrib.get("angular_momentum"), "PP_BETA angular_momentum")
         )
-        values = tuple(float(item) for item in _numbers(node.text))
+        values_array = _numbers(node.text)
+        if not 2 <= values_array.size <= radial_grid.size:
+            raise ValueError("UPF PP_BETA size must lie within the radial grid")
+        values = tuple(float(item) for item in values_array)
+        index = int(node.attrib.get("index", len(indexed_projectors) + 1))
         metadata = {
-            "index": int(node.attrib.get("index", len(projectors) + 1)),
+            "index": index,
             "source": "upf",
         }
         cutoff = node.attrib.get("cutoff_radius")
-        projectors.append(
-            NonlocalProjectorData(
-                angular_momentum=angular,
-                values=values,
-                radial_grid=radial_grid,
-                cutoff_radius=None if cutoff is None else float(cutoff),
-                metadata=metadata,
+        projector_grid = (
+            radial_grid
+            if values_array.size == radial_grid.size
+            else RadialGrid(
+                radial_grid.radii[: values_array.size],
+                radial_grid.values[: values_array.size],
+                integration_weights=integration_weights[: values_array.size],
             )
         )
-    dij_node = root.find("./PP_NONLOCAL/PP_DIJ")
-    if dij_node is not None and projectors:
+        indexed_projectors.append(
+            (
+                index,
+                NonlocalProjectorData(
+                    angular_momentum=angular,
+                    values=values,
+                    radial_grid=projector_grid,
+                    cutoff_radius=None if cutoff is None else float(cutoff),
+                    metadata=metadata,
+                ),
+            )
+        )
+    indexed_projectors.sort(key=lambda item: item[0])
+    if [index for index, _projector in indexed_projectors] != list(
+        range(1, len(indexed_projectors) + 1)
+    ):
+        raise ValueError("UPF PP_BETA indices must be unique and contiguous")
+    projectors = [projector for _index, projector in indexed_projectors]
+    coupling_matrix: tuple[tuple[float, ...], ...] = ()
+    if projectors:
+        dij_node = root.find("./PP_NONLOCAL/PP_DIJ")
+        if dij_node is None:
+            raise ValueError("UPF nonlocal projectors require PP_DIJ")
         dij = 0.5 * _numbers(dij_node.text)
-        size = int(round(np.sqrt(float(dij.size))))
-        if size * size == dij.size and size >= len(projectors):
-            matrix = dij.reshape((size, size))
-            projectors = [
-                replace(
-                    projector,
-                    coupling=float(matrix[index, index]),
-                    coefficients=(float(matrix[index, index]),),
-                    metadata={
-                        **({} if projector.metadata is None else projector.metadata),
-                        "dij_diagonal_hartree": float(matrix[index, index]),
-                    },
-                )
-                for index, projector in enumerate(projectors)
-            ]
+        count = len(projectors)
+        if dij.size != count * count:
+            raise ValueError("UPF PP_DIJ size must match the projector count")
+        matrix = dij.reshape((count, count))
+        if not np.isfinite(matrix).all() or not np.allclose(
+            matrix,
+            matrix.T,
+            atol=1.0e-12,
+            rtol=0.0,
+        ):
+            raise ValueError("UPF PP_DIJ must be finite and symmetric")
+        coupling_matrix = tuple(
+            tuple(float(value) for value in row)
+            for row in matrix
+        )
+        projectors = [
+            replace(
+                projector,
+                coupling=float(matrix[index, index]),
+                coefficients=tuple(float(value) for value in matrix[index]),
+                metadata={
+                    **({} if projector.metadata is None else projector.metadata),
+                    "radial_representation": "r_beta",
+                    "dij_diagonal_hartree": float(matrix[index, index]),
+                },
+            )
+            for index, projector in enumerate(projectors)
+        ]
     metadata: dict[str, str | int | float | bool] = {
         "source_path": str(path),
         "version": root.attrib.get("version", ""),
         "pseudo_type": header.attrib.get("pseudo_type", ""),
+        "relativistic": header.attrib.get("relativistic", ""),
         "functional": header.attrib.get("functional", ""),
+        "is_ultrasoft": _upf_bool(header.attrib.get("is_ultrasoft"), default=False),
+        "is_paw": _upf_bool(header.attrib.get("is_paw"), default=False),
+        "has_so": _upf_bool(header.attrib.get("has_so"), default=False),
+        "core_correction": _upf_bool(
+            header.attrib.get("core_correction"),
+            default=False,
+        ),
         "nonlocal_applied": False,
     }
     return PseudopotentialData(
@@ -424,6 +515,7 @@ def read_upf(path: str | Path) -> PseudopotentialData:
         valence_charge=valence,
         local_grid=radial_grid,
         nonlocal_projectors=tuple(projectors),
+        nonlocal_coupling_matrix=coupling_matrix,
         metadata=metadata,
     )
 
@@ -741,6 +833,19 @@ def _required_str(value: str | None, name: str) -> str:
         msg = f"{name} is required"
         raise ValueError(msg)
     return value.strip()
+
+
+def _upf_bool(value: str | None, *, default: bool) -> bool:
+    """Parse one UPF logical attribute without accepting ambiguous values."""
+
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"t", "true", ".true.", "1"}:
+        return True
+    if normalized in {"f", "false", ".false.", "0"}:
+        return False
+    raise ValueError(f"invalid UPF logical value: {value!r}")
 
 
 def _element_from_filename(path: Path) -> str:

--- a/tests/test_dft_gth_qe_oracle.py
+++ b/tests/test_dft_gth_qe_oracle.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_atomistic.dft import (
+    GTHProjectorChannel,
+    PeriodicGTHNonlocalOperator,
+    PlaneWaveBasis,
+    PseudopotentialData,
+    PseudopotentialFormat,
+    RealSpaceGrid,
+    gth_local_reciprocal_coefficients,
+)
+from mlx_atomistic.dft.periodic_gth import _gth_radial
+
+# These values are independent numerical oracles evaluated from Quantum
+# ESPRESSO's upflib/gth.f90 vloc_gth and mk_ffnl_gth formulas. Keeping the
+# expected values literal prevents this test from reproducing the product
+# implementation as its own reference.
+_QE_RADIAL_ORACLES = (
+    (0, 0, 0.42, (1.0, 0.9879980252214315, 0.8712620380637395)),
+    (0, 1, 0.42, (1.5491933384829666, 1.518279058004542, 1.225744756829006)),
+    (0, 2, 0.42, (1.9518001458970664, 1.8974039100424047, 1.3966696177222717)),
+    (1, 0, 0.51, (0.0, 0.20985000556619063, 0.5889784296309902)),
+    (1, 1, 0.51, (0.0, 0.352185160471394, 0.9146352762065771)),
+    (1, 2, 0.51, (0.0, 0.4920069043499521, 1.1796919782667894)),
+    (2, 0, 0.63, (0.0, 0.03440004342534713, 0.29587561785430677)),
+    (2, 1, 0.63, (0.0, 0.0602049924684082, 0.47564062514140676)),
+)
+
+
+def test_gth_radial_projectors_match_quantum_espresso_source_oracles():
+    q = mx.array((0.0, 0.37, 1.25), dtype=mx.float32)
+
+    for angular_momentum, projector_index, radius, expected in _QE_RADIAL_ORACLES:
+        count = projector_index + 1
+        channel = GTHProjectorChannel(
+            angular_momentum,
+            radius,
+            np.eye(count, dtype=np.float64),
+        )
+        observed = np.asarray(_gth_radial(channel, projector_index, q))
+
+        np.testing.assert_allclose(observed, expected, rtol=2.0e-7, atol=2.0e-7)
+
+
+def test_gth_local_transform_matches_quantum_espresso_source_oracles():
+    grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
+    basis = PlaneWaveBasis(grid, 4.0)
+    oxygen = PseudopotentialData(
+        element="O",
+        format=PseudopotentialFormat.GTH,
+        valence_charge=6.0,
+        gth_rloc=0.24455430,
+        gth_coefficients=(-16.66721480, 2.48731132),
+    )
+
+    observed = np.asarray(
+        gth_local_reciprocal_coefficients(
+            oxygen,
+            basis,
+            ((1.1, 2.2, 3.3),),
+        )
+    )
+
+    np.testing.assert_allclose(
+        observed[0, 0, 0],
+        0.00026209065053374534 + 0.0j,
+        rtol=2.0e-7,
+        atol=2.0e-8,
+    )
+    np.testing.assert_allclose(
+        observed[1, 0, 0],
+        -0.1548774645904494 + 0.18133821221633792j,
+        rtol=2.0e-7,
+        atol=2.0e-8,
+    )
+    np.testing.assert_allclose(
+        observed[1, -1, 0],
+        -0.0773583086997834 - 0.0905749421763413j,
+        rtol=2.0e-7,
+        atol=2.0e-8,
+    )
+
+
+def test_gth_nonlocal_projectors_match_quantum_espresso_source_oracle():
+    grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
+    basis = PlaneWaveBasis(grid, 4.0)
+    coupling = (
+        (2.1, -0.3, 0.2),
+        (-0.3, 1.7, -0.4),
+        (0.2, -0.4, 1.2),
+    )
+    channel = GTHProjectorChannel(1, 0.51, coupling)
+    pseudo = PseudopotentialData(
+        element="X",
+        format=PseudopotentialFormat.GTH,
+        valence_charge=1.0,
+        gth_rloc=0.4,
+        gth_coefficients=(-1.0,),
+        gth_channels=(channel,),
+    )
+    position = np.asarray((0.4, -0.2, 0.7), dtype=np.float64)
+    operator = PeriodicGTHNonlocalOperator(pseudo, basis, (position,))
+    vectors = mx.array(((0.0, 0.0, 0.0), (0.3, -0.7, 1.1)))
+    q = mx.sqrt(mx.sum(vectors * vectors, axis=-1))
+    # The second value is QE's normalized real p_z harmonic for this vector.
+    harmonic = mx.array((0.0, 0.4017185301832866))
+
+    try:
+        observed = np.asarray(
+            operator._projector_group(position, channel, harmonic, vectors, q)
+        )
+        expected = np.asarray(
+            (
+                (0.0j, -0.0578946799103185 - 0.0347664847587711j),
+                (0.0j, -0.08874757001200705 - 0.05329403401106808j),
+                (0.0j, -0.11290381447094572 - 0.06780016317719822j),
+            ),
+            dtype=np.complex128,
+        )
+        np.testing.assert_allclose(observed, expected, rtol=3.0e-7, atol=3.0e-8)
+
+        expected_coupling = np.kron(np.eye(3), np.asarray(coupling))
+        np.testing.assert_allclose(
+            np.asarray(operator._flattened_coupling),
+            expected_coupling,
+            rtol=0.0,
+            atol=1.0e-7,
+        )
+    finally:
+        operator.close()

--- a/tests/test_dft_gth_transferability.py
+++ b/tests/test_dft_gth_transferability.py
@@ -31,7 +31,11 @@ def test_gth_transferability_matrix_separates_coverage_from_strict_science():
 
 def test_gth_transferability_matrix_retains_failed_q10_candidate():
     report = build_gth_transferability_report()
-    candidate = report["candidates"][0]
+    candidates = {
+        candidate["candidate_id"]: candidate
+        for candidate in report["candidates"]
+    }
+    candidate = candidates["rocksalt-mgo-primitive-q10-q6-c40-k4"]
 
     assert candidate["candidate_id"] == "rocksalt-mgo-primitive-q10-q6-c40-k4"
     assert candidate["passed"] is False
@@ -40,6 +44,15 @@ def test_gth_transferability_matrix_retains_failed_q10_candidate():
     assert candidate["peak_temporary_bytes"] == 63_770_520
     assert candidate["metrics"][0]["value"] == pytest.approx(
         3.0125518151180586e-6
+    )
+
+    uzh = candidates["rocksalt-mgo-uzh-primitive-q10-q6-c40-k4"]
+    assert uzh["passed"] is False
+    assert uzh["method_validation"]["passed"] is False
+    assert uzh["elapsed_wall_seconds"] == pytest.approx(39.28628162480891)
+    assert uzh["peak_temporary_bytes"] == 63_770_520
+    assert uzh["metrics"][0]["value"] == pytest.approx(
+        5.418748514784966e-6
     )
 
 

--- a/tests/test_dft_upf.py
+++ b/tests/test_dft_upf.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import mlx_atomistic.dft.periodic_upf as periodic_upf
+from mlx_atomistic.dft import (
+    PeriodicDFTSystem,
+    PlaneWaveBasis,
+    PseudopotentialData,
+    PseudopotentialFormat,
+    RadialGrid,
+    RealSpaceGrid,
+    gth_local_reciprocal_coefficients,
+    periodic_gth_local_forces,
+    periodic_upf_local_forces,
+    read_upf,
+    upf_local_potential_grid,
+    upf_local_reciprocal_coefficients,
+)
+
+
+def _upf_text(*, dij: str = "2.0 0.4 0.4 4.0", weights: str = "0.01 0.09 0.9") -> str:
+    return f"""<UPF version="2.0.1">
+<PP_HEADER element="Mg" z_valence="2" pseudo_type="NC"
+ relativistic="scalar" is_ultrasoft="F" is_paw="F" has_so="F"
+ core_correction="F" functional="PBE"/>
+<PP_MESH>
+  <PP_R>0.01 0.1 1.0</PP_R>
+  <PP_RAB>{weights}</PP_RAB>
+</PP_MESH>
+<PP_LOCAL>-2.0 -1.0 -0.2</PP_LOCAL>
+<PP_NONLOCAL>
+  <PP_BETA.1 index="1" angular_momentum="0" cutoff_radius="0.8">
+    0.0 0.2 0.0
+  </PP_BETA.1>
+  <PP_BETA.2 index="2" angular_momentum="1" cutoff_radius="0.9">
+    0.0 0.3 0.0
+  </PP_BETA.2>
+  <PP_DIJ>{dij}</PP_DIJ>
+</PP_NONLOCAL>
+</UPF>
+"""
+
+
+def test_upf_parser_preserves_radial_quadrature_and_full_dij(tmp_path):
+    source = tmp_path / "Mg.nc.UPF"
+    source.write_text(_upf_text())
+
+    pseudo = read_upf(source)
+
+    assert pseudo.format == PseudopotentialFormat.UPF
+    assert pseudo.periodic_upf_compatible is True
+    np.testing.assert_allclose(
+        pseudo.local_grid.integration_weights,
+        (0.01, 0.09, 0.9),
+    )
+    assert pseudo.nonlocal_coupling_matrix == ((1.0, 0.2), (0.2, 2.0))
+    assert pseudo.nonlocal_projectors[0].coefficients == (1.0, 0.2)
+    assert pseudo.nonlocal_projectors[1].coefficients == (0.2, 2.0)
+    assert pseudo.nonlocal_projectors[0].coupling == pytest.approx(1.0)
+    assert pseudo.nonlocal_projectors[1].coupling == pytest.approx(2.0)
+    assert all(
+        projector.metadata["radial_representation"] == "r_beta"
+        for projector in pseudo.nonlocal_projectors
+    )
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    (
+        ('pseudo_type="NC"', 'pseudo_type="US"'),
+        ('relativistic="scalar"', 'relativistic="full"'),
+        ('has_so="F"', 'has_so="T"'),
+        ('core_correction="F"', 'core_correction="T"'),
+    ),
+)
+def test_upf_periodic_boundary_rejects_unsupported_physics(tmp_path, old, new):
+    source = tmp_path / "unsupported.UPF"
+    source.write_text(_upf_text().replace(old, new))
+
+    assert read_upf(source).periodic_upf_compatible is False
+
+
+@pytest.mark.parametrize(
+    ("dij", "message"),
+    (
+        ("2.0 0.4 4.0", "size must match"),
+        ("2.0 0.3 0.4 4.0", "finite and symmetric"),
+    ),
+)
+def test_upf_parser_rejects_invalid_dij(tmp_path, dij, message):
+    source = tmp_path / "invalid-dij.UPF"
+    source.write_text(_upf_text(dij=dij))
+
+    with pytest.raises(ValueError, match=message):
+        read_upf(source)
+
+
+def test_upf_parser_rejects_mismatched_radial_quadrature(tmp_path):
+    source = tmp_path / "invalid-grid.UPF"
+    source.write_text(_upf_text(weights="0.01 0.99"))
+
+    with pytest.raises(ValueError, match="sizes do not match"):
+        read_upf(source)
+
+
+def test_upf_parser_rejects_ambiguous_projector_order(tmp_path):
+    source = tmp_path / "duplicate-projector.UPF"
+    source.write_text(_upf_text().replace('PP_BETA.1 index="1"', 'PP_BETA.1 index="2"'))
+
+    with pytest.raises(ValueError, match="unique and contiguous"):
+        read_upf(source)
+
+
+def _matched_gth_and_numerical_upf():
+    gth = PseudopotentialData(
+        element="Si",
+        format=PseudopotentialFormat.GTH,
+        valence_charge=4.0,
+        gth_rloc=0.44,
+        gth_coefficients=(-6.26928833,),
+    )
+    radii = np.linspace(0.0, 12.0, 6001, dtype=np.float64)
+    spacing = float(radii[1] - radii[0])
+    upf = PseudopotentialData(
+        element="Si",
+        format=PseudopotentialFormat.UPF,
+        valence_charge=4.0,
+        local_grid=RadialGrid(
+            radii,
+            gth.local_potential(radii),
+            integration_weights=np.full(radii.shape, spacing),
+        ),
+    )
+    return gth, upf
+
+
+def test_periodic_upf_local_transform_matches_qe_gth_oracle():
+    gth, upf = _matched_gth_and_numerical_upf()
+    grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
+    basis = PlaneWaveBasis(grid, 4.0)
+    position = ((1.1, 2.2, 3.3),)
+
+    expected = np.asarray(
+        gth_local_reciprocal_coefficients(gth, basis, position)
+    )
+    observed = np.asarray(
+        upf_local_reciprocal_coefficients(upf, basis, position)
+    )
+    potential = np.asarray(upf_local_potential_grid(upf, basis, position))
+
+    np.testing.assert_allclose(observed, expected, rtol=2.0e-5, atol=2.0e-7)
+    assert np.isfinite(potential).all()
+
+
+def test_periodic_upf_local_force_matches_qe_gth_oracle(monkeypatch):
+    gth, upf = _matched_gth_and_numerical_upf()
+    grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
+    basis = PlaneWaveBasis(grid, 4.0)
+    positions = ((1.1, 2.2, 3.3), (5.0, 4.0, 2.0))
+    coordinates = np.asarray(grid.coordinates())
+    density = (
+        0.02
+        + 0.004 * np.cos(2.0 * np.pi * coordinates[..., 0] / 8.0)
+        + 0.003 * np.sin(2.0 * np.pi * coordinates[..., 1] / 8.0)
+    ).astype(np.float32)
+    transform = periodic_upf._upf_local_radial_transform
+    transform_calls = 0
+
+    def observed_transform(*args, **kwargs):
+        nonlocal transform_calls
+        transform_calls += 1
+        return transform(*args, **kwargs)
+
+    monkeypatch.setattr(
+        periodic_upf,
+        "_upf_local_radial_transform",
+        observed_transform,
+    )
+
+    expected = np.asarray(
+        periodic_gth_local_forces(density, gth, basis, positions)
+    )
+    observed = np.asarray(
+        periodic_upf_local_forces(density, upf, basis, positions)
+    )
+
+    np.testing.assert_allclose(observed, expected, rtol=3.0e-5, atol=2.0e-7)
+    assert transform_calls == 1
+
+
+def test_periodic_upf_identity_is_content_bound_and_path_independent(tmp_path):
+    first_path = tmp_path / "first.UPF"
+    second_path = tmp_path / "nested" / "second.UPF"
+    changed_path = tmp_path / "changed.UPF"
+    second_path.parent.mkdir()
+    first_path.write_text(_upf_text())
+    second_path.write_text(_upf_text())
+    changed_path.write_text(_upf_text(dij="2.0 0.6 0.6 4.0"))
+
+    def system(path):
+        return PeriodicDFTSystem(
+            (8.0, 8.0, 8.0),
+            (8, 8, 8),
+            ((1.0, 2.0, 3.0),),
+            read_upf(path),
+        )
+
+    assert system(first_path).fingerprint == system(second_path).fingerprint
+    assert system(first_path).fingerprint != system(changed_path).fingerprint


### PR DESCRIPTION
## Summary
- add literal Quantum ESPRESSO source oracles for the existing GTH local and nonlocal formulas
- preserve UPF radial quadrature and the complete PP_DIJ coupling matrix with fail-closed physics metadata
- implement content-bound UPF identities plus the compensated periodic local transform and fixed-cell local forces
- retain the rejected UZH q10 feasibility result without weakening transferability gates

## Scope boundary
Periodic UPF nonlocal SCF is not enabled by this PR. Ultrasoft, PAW, spin-orbit, and nonlinear-core-correction inputs remain outside the admitted boundary.

## Verification
- uv run ruff check src tests/test_dft_upf.py tests/test_dft_gth_qe_oracle.py tests/test_dft_gth_transferability.py
- 29 targeted UPF/GTH regression tests
- real vendor Si UPF parser compatibility test
- narrative and API documentation generators