### PR TITLE
Add periodic norm-conserving UPF execution

### DIFF
--- a/docs/dft-production-core.md
+++ b/docs/dft-production-core.md
@@ -4,7 +4,8 @@ The DFT package contains two intentionally different surfaces. The legacy
 `DFTSystem`/`run_scf` surface supplies tiny Γ-point teaching, dense-reference,
 spin, occupation, finite-difference stress, and restart diagnostics. The
 periodic `PeriodicDFTSystem`/`run_periodic_scf` surface supplies the
-materials-workload path: PBE-PW92, reciprocal-space GTH operators,
+materials-workload path: PBE-PW92, reciprocal-space GTH and scalar
+norm-conserving UPF operators,
 Monkhorst-Pack integration, block-Davidson/Rayleigh-Ritz solves,
 fixed or Fermi-Dirac occupations, frozen-density band paths, and periodic
 forces across ordinary fixed full-rank cells. Analytic periodic stress and a
@@ -24,11 +25,14 @@ real-space separable forms. The operator applies:
 V̂_NL ψ = Σᵢ |βᵢ⟩ Dᵢ ⟨βᵢ|ψ⟩
 ```
 
-The UPF parser now preserves radial quadrature and the complete `PP_DIJ` matrix
+The UPF parser preserves radial quadrature and the complete `PP_DIJ` matrix
 after Ry-to-Hartree conversion, while the legacy proof operator still consumes
-only its diagonal. A source-matched compensated periodic local transform is
-available, but periodic UPF nonlocal SCF remains unimplemented. The production
-periodic GTH path retains its separate analytic operators.
+only its diagonal. The periodic scalar norm-conserving path implements the
+source-matched local transform, compact nonlocal SCF and bands, analytic
+fixed-cell forces, and content-bound checkpoints. Ultrasoft augmentation, PAW,
+spin-orbit terms, nonlinear core correction, and UPF analytic stress fail
+closed. The production periodic GTH path retains its separate analytic radial
+operators.
 
 SCF applies nonlocal projectors by default when available. `SCFConfig(apply_nonlocal=False)` keeps the old local-only path available for debugging and comparison.
 
@@ -86,7 +90,7 @@ occupations, so a converged smeared result yields the stationary free-energy
 force.
 
 Both paths use reduced-coordinate Monkhorst-Pack meshes and `0.5|G + k|²`,
-including Bloch-phase local and nonlocal GTH evaluation.
+including Bloch-phase local and nonlocal pseudopotential evaluation.
 `run_periodic_band_structure` reuses a converged SCF density and solves
 non-self-consistently along a high-symmetry path.
 
@@ -134,7 +138,7 @@ boundary.
 | --- | --- | --- |
 | Plane-wave SCF core | verified for fixed-occupation bulk-Si EOS and one Fermi-Dirac fcc-Al EOS | CP2K Quickstep, QE PWscf |
 | Full-rank fixed periodic cells | verified for one bounded 2H-Si relaxation and low-symmetry numerical oracles | CP2K cell matrix, QE CELL_PARAMETERS |
-| UPF/GTH pseudopotentials and nonlocal projectors | proof-level | QE UPF, CP2K GTH |
+| UPF/GTH pseudopotentials and nonlocal projectors | GTH material evidence remains blocked; scalar norm-conserving UPF has source-bound execution and numerical gates but no material certification | QE UPF, CP2K GTH |
 | Fixed-cell periodic geometry relaxation | verified for bounded orthorhombic and hexagonal Si workloads | CP2K MOTION/GEO_OPT, QE relax |
 | Analytic periodic stress | verified for deterministic derivatives and one cutoff-converged 2H-Si material path | CP2K stress, QE stress |
 | Variable-cell relaxation and restart | verified for one bounded 2H-Si cell-only path; deterministic coupled and resume gates pass | CP2K CELL_OPT, QE vc-relax |

--- a/docs/dft-pseudopotentials.md
+++ b/docs/dft-pseudopotentials.md
@@ -1,8 +1,8 @@
 # DFT Pseudopotentials
 
 The DFT layer includes an ion-model surface while keeping the engine small and
-inspectable. The code supports parsed UPF and GTH pseudopotential inputs for
-local-potential SCF plus proof-level nonlocal projector application.
+inspectable. The legacy teaching runtime and the periodic plane-wave runtime
+share parsed UPF and GTH data but retain separate execution boundaries.
 
 ## What Is Implemented
 
@@ -34,17 +34,28 @@ The legacy teaching path interpolates the local potential onto its real-space
 grid. Its proof-level nonlocal operator still consumes only the diagonal
 couplings and is not a production UPF implementation.
 
-The periodic layer now has a separate local-only UPF foundation. It follows
+The periodic layer implements a scalar norm-conserving UPF path. It follows
 Quantum ESPRESSO's compensated radial transform: subtract `erf(r) / r` before
 quadrature, restore the analytic reciprocal-space Coulomb tail, and use the
 finite `G=0` alpha term. Literal source oracles and a numerical GTH-equivalence
-test cover the transform and fixed-cell local force. Periodic SCF does not yet
-admit UPF nonlocal projectors.
+test cover the transform and fixed-cell local force. The compact nonlocal
+operator preserves the complete symmetric `PP_DIJ`, evaluates radial
+projectors with normalized real harmonics through `l=2`, and reuses the same
+bounded k-point batch backend as periodic GTH. Periodic SCF, frozen-density
+bands, analytic fixed-cell forces, and checkpoint identity dispatch through
+that format-neutral runtime boundary.
 
-The future periodic boundary is fail-closed. Only scalar norm-conserving input
+The periodic boundary is fail-closed. Only scalar norm-conserving input
 without ultrasoft augmentation, PAW, spin-orbit terms, or nonlinear core
 correction is currently eligible. Parsing an unsupported file preserves its
-identity; it does not make that physics executable.
+identity; it does not make that physics executable. Analytic stress and
+variable-cell workflows also remain GTH-only.
+
+UPF setup deduplicates identical `|G+k|` magnitudes and batches radial
+transforms by angular channel and radial grid. This removes repeated spherical
+Bessel evaluation without moving any SCF hot-path work off the device. A
+source-bound Quantum ESPRESSO Si ONCV input passes the periodic SCF smoke gate;
+that execution check is not material-accuracy certification.
 
 ## GTH
 
@@ -81,17 +92,18 @@ For ion-backed systems, reported forces include:
 F_total = F_local electron-ion + F_center-center + F_nonlocal correction
 ```
 
-The nonlocal term is a fixed-orbital finite-difference correction and is reported
-through `force_provenance["nonlocal_finite_difference"]`. The force validation
-in this milestone checks fixed-density local forces and SCF total-energy finite
-differences. This is a consistency check for the current model, not a claim of
-production DFT force accuracy.
+The legacy nonlocal term is a fixed-orbital finite-difference correction. The
+periodic GTH and scalar norm-conserving UPF paths instead use analytic
+projector-phase derivatives at a converged fixed-cell SCF state. These
+consistency gates do not by themselves establish broad material accuracy.
 
 ## Current Limits
 
-- The legacy UPF nonlocal operator remains proof-level. Full `PP_DIJ` and radial
-  semantics are preserved, but compact periodic nonlocal execution is not yet
-  connected to SCF.
+- The legacy UPF nonlocal operator remains proof-level and diagonal-only. The
+  separate periodic implementation consumes full `PP_DIJ` but is scientifically
+  verified only at source-oracle and execution-smoke level.
+- Ultrasoft, PAW, spin-orbit, nonlinear-core-correction, and UPF analytic-stress
+  terms are not implemented.
 - This pseudopotential milestone does not certify geometry or stress. The
   current periodic runtime separately provides verified fixed-cell Silicon
   relaxation and one bounded analytic-stress/variable-cell 2H-Silicon path;

--- a/docs/dft-roadmap.md
+++ b/docs/dft-roadmap.md
@@ -29,6 +29,11 @@ diagnostics, no-pickle partial-sample restart, and a verified two-atom Silicon
 material gate.
 Real and reciprocal grids, k-points, Ewald terms, GTH operators, forces, and
 state identity share one full-rank periodic cell matrix contract.
+Scalar norm-conserving UPF now has a separate periodic local/nonlocal path
+through SCF, bands, analytic fixed-cell forces, and content-bound checkpoints.
+Its current evidence is source-oracle and execution-smoke level, not material
+certification; ultrasoft, PAW, spin-orbit, nonlinear-core-correction, and UPF
+analytic-stress physics remain outside the admitted boundary.
 Material-level verification remains narrow: Silicon, Carbon, and simple-metal
 Aluminum have accepted equation-of-state workloads, Silicon has one accepted
 orthorhombic relaxation and one accepted hexagonal relaxation, and MgO retains
@@ -50,7 +55,7 @@ only when its implementation and material-level evidence both pass.
 | Capability | General-core commitment | Current boundary | Delivery |
 | --- | --- | --- | --- |
 | Exchange-correlation | PBE-PW92 production envelope | Implemented; verified material set is narrow | Every material phase |
-| Pseudopotentials | Broad, fingerprinted GTH transferability | s/p/d and chemistry coverage is complete; strict MgO and historical identity gates remain blocked | Phase 7 |
+| Pseudopotentials | Broad, fingerprinted GTH transferability | Scalar norm-conserving periodic UPF is implemented but not materially certified; GTH s/p/d coverage is complete while strict MgO and historical identity gates remain blocked | Phase 7 |
 | Crystal geometry | Ordinary full-rank periodic cells | Implemented; one source-bound hexagonal Silicon case and bounded low-symmetry oracles are verified | Phase 3 |
 | Electronic states | Insulators, simple metals, and collinear magnets | One simple metal and one collinear bcc Iron q16 workload are verified | Phases 1 and 5 |
 | Electronic observables | Energy, density, occupations, bands, total DOS, and Fermi level | Implemented; scalar/spin DOS, portable density volumes, and reusable convergence reports pass deterministic gates | Phase 6 |
@@ -218,8 +223,8 @@ matrix and efficient material decision policy are defined in
 [Periodic GTH Transferability](./dft-gth-transferability.md).
 
 - Strengthen periodic GTH convention fidelity instead of treating parser
-  success as scientific validation. Existing UPF support retains its separate
-  proof-level boundary.
+  success as scientific validation. Scalar norm-conserving periodic UPF retains
+  a separate implemented but scientifically proof-level boundary.
 - Cover representative `s`, `p`, and `d`-block elements, ionic compounds,
   multiple oxidation environments, and both local and nonlocal force terms.
 - Bind every claim to an exact resource fingerprint and matching reference
@@ -336,10 +341,10 @@ above:
   DFT;
 - platform scale: automatic crystallographic symmetry discovery, distributed
   execution, multi-device scheduling, and broad molecular DFT;
-- alternate periodic pseudopotential envelopes: production UPF nonlocal and SCF
-  admission beyond the required GTH general-core envelope. The retained radial,
-  full-`PP_DIJ`, fingerprint, and periodic-local foundation does not yet
-  constitute that envelope.
+- broader periodic pseudopotential envelopes: ultrasoft augmentation, PAW,
+  spin-orbit coupling, nonlinear core correction, analytic UPF stress, and
+  material-level transferability beyond the implemented scalar
+  norm-conserving boundary.
 
 Each item requires its own roadmap or bounded extension after the general-core
 exit audit. None is an implied blocker for the claim defined here.

--- a/src/mlx_atomistic/dft/__init__.py
+++ b/src/mlx_atomistic/dft/__init__.py
@@ -181,6 +181,7 @@ from mlx_atomistic.dft.periodic_stress import (
     periodic_finite_difference_stress,
 )
 from mlx_atomistic.dft.periodic_upf import (
+    PeriodicUPFNonlocalOperator,
     periodic_upf_local_forces,
     upf_local_potential_grid,
     upf_local_reciprocal_coefficients,
@@ -325,6 +326,7 @@ __all__ = [
     "PeriodicStressResult",
     "PeriodicStressSample",
     "PeriodicUnfoldedBandStructureResult",
+    "PeriodicUPFNonlocalOperator",
     "PlaneWaveBasis",
     "ProductionPBEExchangeCorrelation",
     "ProductionSpinPBEExchangeCorrelation",

--- a/src/mlx_atomistic/dft/_periodic_artifact_contracts.py
+++ b/src/mlx_atomistic/dft/_periodic_artifact_contracts.py
@@ -19,6 +19,9 @@ from mlx_atomistic.dft._periodic_models import (
     PeriodicSCFConfig,
     _eigensolve_provenance,
 )
+from mlx_atomistic.dft._pseudopotential_identity import (
+    _pseudopotential_fingerprint,
+)
 from mlx_atomistic.dft.kpoints import KPointMesh
 from mlx_atomistic.dft.pseudopotentials import (
     PseudopotentialData,
@@ -391,25 +394,60 @@ def _validate_initialization_binding(
 def _single_pseudopotential_payload(
     pseudo: PseudopotentialData,
 ) -> dict[str, object]:
-    """Return one canonical periodic GTH pseudopotential payload."""
+    """Return one canonical periodic pseudopotential payload."""
 
-    if pseudo.format != PseudopotentialFormat.GTH:
-        msg = "periodic SCF checkpoints require a GTH pseudopotential"
-        raise ValueError(msg)
-    return {
+    common = {
         "element": pseudo.element,
         "format": pseudo.format.value,
         "valence_charge": pseudo.valence_charge,
-        "gth_rloc": pseudo.gth_rloc,
-        "gth_coefficients": list(pseudo.gth_coefficients),
-        "gth_channels": [
+    }
+    if pseudo.format == PseudopotentialFormat.GTH:
+        return {
+            **common,
+            "gth_rloc": pseudo.gth_rloc,
+            "gth_coefficients": list(pseudo.gth_coefficients),
+            "gth_channels": [
+                {
+                    "angular_momentum": channel.angular_momentum,
+                    "radius": channel.radius,
+                    "coupling_matrix": [list(row) for row in channel.coupling_matrix],
+                }
+                for channel in pseudo.gth_channels
+            ],
+        }
+    if not pseudo.periodic_upf_compatible:
+        raise ValueError(
+            "periodic SCF checkpoints require executable scalar norm-conserving UPF"
+        )
+    local_grid = pseudo.local_grid
+    if local_grid is None:
+        raise ValueError("periodic UPF checkpoint identity requires a local grid")
+    metadata = pseudo.metadata or {}
+    return {
+        **common,
+        "content_sha256": _pseudopotential_fingerprint(pseudo),
+        "local_radial_sample_count": local_grid.size,
+        "nonlocal_projectors": [
             {
-                "angular_momentum": channel.angular_momentum,
-                "radius": channel.radius,
-                "coupling_matrix": [list(row) for row in channel.coupling_matrix],
+                "angular_momentum": projector.angular_momentum,
+                "radial_sample_count": len(projector.values),
+                "cutoff_radius": projector.cutoff_radius,
             }
-            for channel in pseudo.gth_channels
+            for projector in pseudo.nonlocal_projectors
         ],
+        "dij_dimension": len(pseudo.nonlocal_coupling_matrix),
+        "physics": {
+            name: metadata.get(name)
+            for name in (
+                "pseudo_type",
+                "relativistic",
+                "functional",
+                "is_ultrasoft",
+                "is_paw",
+                "has_so",
+                "core_correction",
+            )
+        },
     }
 
 
@@ -471,7 +509,7 @@ def periodic_scf_calculation_contract(
     """Build the path-independent calculation contract used by checkpoints.
 
     Args:
-        system: Periodic GTH system.
+        system: Periodic system with an executable pseudopotential format.
         cutoff_hartree: Plane-wave kinetic cutoff in Hartree.
         kpoint_mesh: Weighted reduced-coordinate k-point mesh.
         n_bands: Computed band count. Fixed occupations default to half the

--- a/src/mlx_atomistic/dft/_periodic_band.py
+++ b/src/mlx_atomistic/dft/_periodic_band.py
@@ -21,15 +21,15 @@ from mlx_atomistic.dft._periodic_models import (
     PeriodicFrozenDensity,
     PeriodicSCFResult,
 )
+from mlx_atomistic.dft._periodic_pseudopotential_runtime import (
+    _periodic_local_potential_grid,
+    _periodic_nonlocal_operator,
+)
 from mlx_atomistic.dft._runtime_observer import RuntimeObserver
 from mlx_atomistic.dft.gga import ProductionPBEExchangeCorrelation
 from mlx_atomistic.dft.grids import ReciprocalGrid
 from mlx_atomistic.dft.kpoints import BandPath, KPoint
-from mlx_atomistic.dft.periodic_gth import (
-    PeriodicGTHNonlocalOperator,
-    _GTHProjectorCache,
-    gth_local_potential_grid,
-)
+from mlx_atomistic.dft.periodic_gth import _ProjectorCache
 from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
 from mlx_atomistic.dft.potentials import hartree_potential
 from mlx_atomistic.dft.xc import ExchangeCorrelationFunctional
@@ -258,7 +258,7 @@ class _PeriodicBandController:
 
     def run(self) -> PeriodicBandStructureResult:
         total_start = perf_counter()
-        with _bounded_dft_allocator(), _GTHProjectorCache() as projector_cache:
+        with _bounded_dft_allocator(), _ProjectorCache() as projector_cache:
             reciprocal, effective_potential = self._build_effective_potential()
             points: list[PeriodicBandPointResult] = []
             solved_points: dict[
@@ -297,7 +297,7 @@ class _PeriodicBandController:
             reciprocal_grid=reciprocal,
             lane_label="band:local-potential",
         )
-        local_potential = gth_local_potential_grid(
+        local_potential = _periodic_local_potential_grid(
             request.system.pseudopotentials,
             gamma_basis,
             request.system.positions,
@@ -325,7 +325,7 @@ class _PeriodicBandController:
         *,
         reciprocal: ReciprocalGrid,
         effective_potential: mx.array,
-        projector_cache: _GTHProjectorCache,
+        projector_cache: _ProjectorCache,
     ) -> PeriodicBandPointResult:
         request = self.request
         basis = PlaneWaveBasis.from_reduced_kpoint(
@@ -341,7 +341,7 @@ class _PeriodicBandController:
                 f"basis size {basis.active_count} at path point {point_index}"
             )
             raise ValueError(msg)
-        nonlocal_operator = PeriodicGTHNonlocalOperator(
+        nonlocal_operator = _periodic_nonlocal_operator(
             request.system.pseudopotentials,
             basis,
             request.system.positions,

--- a/src/mlx_atomistic/dft/_periodic_hamiltonian.py
+++ b/src/mlx_atomistic/dft/_periodic_hamiltonian.py
@@ -15,12 +15,15 @@ from mlx_atomistic.dft._compact import (
     _CompactLaneState,
 )
 from mlx_atomistic.dft._periodic_execution import _detached_failure, _materialize
+from mlx_atomistic.dft._periodic_pseudopotential_runtime import (
+    _PERIODIC_NONLOCAL_TYPES,
+    _PeriodicNonlocalOperator,
+)
 from mlx_atomistic.dft._runtime_observer import (
     RuntimeObserver,
     add_observed_work,
     observed_phase,
 )
-from mlx_atomistic.dft.periodic_gth import PeriodicGTHNonlocalOperator
 from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
 
 
@@ -96,15 +99,18 @@ def _estimated_batch_transient_bytes(
     if not all(operator._effective_local_potential is first_potential for operator in operators):
         estimate += lane_count * batch.grid_size * 8
 
-    grouped_gth: dict[str, list[int]] = defaultdict(list)
+    grouped_nonlocal: dict[tuple[type, str], list[int]] = defaultdict(list)
     for index, operator in enumerate(operators):
         nonlocal_operator = operator.nonlocal_operator
-        if isinstance(nonlocal_operator, PeriodicGTHNonlocalOperator):
-            grouped_gth[nonlocal_operator._context_identity].append(index)
+        if isinstance(nonlocal_operator, _PERIODIC_NONLOCAL_TYPES):
+            grouped_nonlocal[
+                (type(nonlocal_operator), nonlocal_operator._context_identity)
+            ].append(index)
         elif nonlocal_operator is not None:
             estimate += padded_complex_bytes // lane_count
-    for indices in grouped_gth.values():
-        estimate += PeriodicGTHNonlocalOperator._estimated_batch_transient_bytes(
+    for indices in grouped_nonlocal.values():
+        nonlocal_type = type(operators[indices[0]].nonlocal_operator)
+        estimate += nonlocal_type._estimated_batch_transient_bytes(
             [operators[index].nonlocal_operator for index in indices],
             batch,
         )
@@ -209,7 +215,7 @@ class _CompactHamiltonianExecutor:
                 self.projector_metrics[lane_index] = _empty_projector_metrics()
                 if operator.nonlocal_operator is not None and not isinstance(
                     operator.nonlocal_operator,
-                    PeriodicGTHNonlocalOperator,
+                    _PERIODIC_NONLOCAL_TYPES,
                 ):
                     action, metrics = operator.nonlocal_operator._apply_compact(
                         state,
@@ -235,7 +241,7 @@ class _CompactHamiltonianExecutor:
         if self.estimated_transient_bytes > self.policy.max_transient_bytes:
             msg = "compact Hpsi batch exceeds the complete transient byte budget"
             raise ValueError(msg)
-        self._apply_gth_projectors()
+        self._apply_separable_projectors()
         self._assemble_actions(ready_states)
 
     def _prepare_batch(self, ready_states: Sequence[_CompactLaneState]) -> _CompactBatch:
@@ -260,40 +266,46 @@ class _CompactHamiltonianExecutor:
             return prepared
         return _CompactBatch.from_states(ready_states, policy=self.policy)
 
-    def _apply_gth_projectors(self) -> None:
-        grouped_gth: dict[str, list[int]] = defaultdict(list)
+    def _apply_separable_projectors(self) -> None:
+        grouped_nonlocal: dict[tuple[type, str], list[int]] = defaultdict(list)
         for lane_index in self.ready_indices:
             nonlocal_operator = self.operators[lane_index].nonlocal_operator
-            if isinstance(nonlocal_operator, PeriodicGTHNonlocalOperator):
-                grouped_gth[nonlocal_operator._context_identity].append(lane_index)
-        for gth_indices in grouped_gth.values():
-            gth_states = [self.coefficients[index] for index in gth_indices]
-            if gth_indices == self.ready_indices:
-                gth_batch = self.batch
+            if isinstance(nonlocal_operator, _PERIODIC_NONLOCAL_TYPES):
+                grouped_nonlocal[
+                    (type(nonlocal_operator), nonlocal_operator._context_identity)
+                ].append(lane_index)
+        for lane_indices in grouped_nonlocal.values():
+            states = [self.coefficients[index] for index in lane_indices]
+            if lane_indices == self.ready_indices:
+                nonlocal_batch = self.batch
             else:
-                gth_batch = _CompactBatch.from_states(gth_states, policy=self.policy)
+                nonlocal_batch = _CompactBatch.from_states(states, policy=self.policy)
+            nonlocal_type = type(self.operators[lane_indices[0]].nonlocal_operator)
             try:
-                gth_actions, gth_metrics = PeriodicGTHNonlocalOperator._apply_compact_batch(
-                    [self.operators[index].nonlocal_operator for index in gth_indices],
-                    gth_states,
-                    batch=gth_batch,
+                actions, metrics_by_lane = nonlocal_type._apply_compact_batch(
+                    [self.operators[index].nonlocal_operator for index in lane_indices],
+                    states,
+                    batch=nonlocal_batch,
                     # The combined Hpsi result is materialized below; evaluating
                     # this contribution alone would add a redundant device barrier.
                     evaluate=False,
                 )
             except Exception:
-                self._apply_gth_projectors_individually(gth_indices)
+                self._apply_separable_projectors_individually(lane_indices)
             else:
                 for lane_index, action, metrics in zip(
-                    gth_indices,
-                    gth_actions,
-                    gth_metrics,
+                    lane_indices,
+                    actions,
+                    metrics_by_lane,
                     strict=True,
                 ):
                     self.projector_actions[lane_index] = action
                     self.projector_metrics[lane_index] = metrics
 
-    def _apply_gth_projectors_individually(self, lane_indices: Sequence[int]) -> None:
+    def _apply_separable_projectors_individually(
+        self,
+        lane_indices: Sequence[int],
+    ) -> None:
         for lane_index in lane_indices:
             nonlocal_operator = self.operators[lane_index].nonlocal_operator
             try:
@@ -540,14 +552,14 @@ class PeriodicKohnShamOperator:
 
     basis: PlaneWaveBasis
     _effective_local_potential: mx.array = field(repr=False)
-    nonlocal_operator: PeriodicGTHNonlocalOperator | None = None
+    nonlocal_operator: _PeriodicNonlocalOperator | None = None
     observer: RuntimeObserver | None = None
 
     def __init__(
         self,
         basis: PlaneWaveBasis,
         effective_local_potential: mx.array,
-        nonlocal_operator: PeriodicGTHNonlocalOperator | None = None,
+        nonlocal_operator: _PeriodicNonlocalOperator | None = None,
         observer: RuntimeObserver | None = None,
     ) -> None:
         potential_snapshot = mx.array(effective_local_potential)
@@ -564,7 +576,7 @@ class PeriodicKohnShamOperator:
         cls,
         basis: PlaneWaveBasis,
         potential_snapshot: mx.array,
-        nonlocal_operator: PeriodicGTHNonlocalOperator | None = None,
+        nonlocal_operator: _PeriodicNonlocalOperator | None = None,
         observer: RuntimeObserver | None = None,
     ) -> PeriodicKohnShamOperator:
         """Bind a private SCF operator to one already evaluated potential."""
@@ -591,8 +603,11 @@ class PeriodicKohnShamOperator:
         nonlocal_operator = self.nonlocal_operator
         if nonlocal_operator is None:
             return None
-        if isinstance(nonlocal_operator, PeriodicGTHNonlocalOperator):
-            return ("gth", nonlocal_operator._context_identity)
+        if isinstance(nonlocal_operator, _PERIODIC_NONLOCAL_TYPES):
+            return (
+                str(nonlocal_operator.pseudopotentials[0].format),
+                nonlocal_operator._context_identity,
+            )
         return ("custom", id(nonlocal_operator))
 
     def apply(

--- a/src/mlx_atomistic/dft/_periodic_models.py
+++ b/src/mlx_atomistic/dft/_periodic_models.py
@@ -65,18 +65,18 @@ def _time_reversed_compact_values(
 
 @dataclass(frozen=True)
 class PeriodicDFTSystem:
-    """Periodic DFT system with per-ion GTH pseudopotentials.
+    """Periodic DFT system with ordered per-ion pseudopotentials.
 
     Args:
         cell_lengths: A periodic `Cell`, three orthorhombic lengths, or a full
             row-vector cell matrix in bohr.
         grid_shape: FFT grid shape.
         positions: Ionic Cartesian positions in bohr.
-        pseudopotential: Shared GTH pseudopotential for every ion. Mutually
+        pseudopotential: Shared pseudopotential for every ion. Mutually
             exclusive with ``pseudopotentials``.
         electron_count: Total valence electron count. Defaults to the neutral
             pseudopotential charge sum.
-        pseudopotentials: Ordered one-per-ion GTH pseudopotentials.
+        pseudopotentials: Ordered one-per-ion pseudopotentials.
     """
 
     grid: RealSpaceGrid

--- a/src/mlx_atomistic/dft/_periodic_pseudopotential_runtime.py
+++ b/src/mlx_atomistic/dft/_periodic_pseudopotential_runtime.py
@@ -1,0 +1,107 @@
+"""Format dispatch for production periodic pseudopotential operators."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import mlx.core as mx
+
+from mlx_atomistic.dft.periodic_gth import (
+    PeriodicGTHNonlocalOperator,
+    _ProjectorCache,
+    gth_local_potential_grid,
+    periodic_gth_local_forces,
+)
+from mlx_atomistic.dft.periodic_upf import (
+    PeriodicUPFNonlocalOperator,
+    periodic_upf_local_forces,
+    upf_local_potential_grid,
+)
+from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
+from mlx_atomistic.dft.pseudopotentials import (
+    PseudopotentialData,
+    PseudopotentialFormat,
+)
+
+_PeriodicNonlocalOperator = PeriodicGTHNonlocalOperator | PeriodicUPFNonlocalOperator
+_PERIODIC_NONLOCAL_TYPES = (
+    PeriodicGTHNonlocalOperator,
+    PeriodicUPFNonlocalOperator,
+)
+
+
+def _periodic_pseudopotential_format(
+    pseudopotentials: Sequence[PseudopotentialData],
+) -> PseudopotentialFormat:
+    """Return the single executable format assigned to a periodic system."""
+
+    formats = {pseudopotential.format for pseudopotential in pseudopotentials}
+    if len(formats) != 1:
+        raise ValueError(
+            "periodic execution requires one pseudopotential format per system"
+        )
+    format_value = next(iter(formats))
+    if format_value == PseudopotentialFormat.UPF and any(
+        not pseudopotential.periodic_upf_compatible
+        for pseudopotential in pseudopotentials
+    ):
+        raise ValueError(
+            "periodic UPF execution requires scalar norm-conserving input "
+            "without augmentation, SOC, or nonlinear core correction"
+        )
+    return format_value
+
+
+def _periodic_nonlocal_operator(
+    pseudopotentials: Sequence[PseudopotentialData],
+    basis: PlaneWaveBasis,
+    positions: Sequence[Sequence[float]],
+    *,
+    cache: _ProjectorCache,
+) -> _PeriodicNonlocalOperator:
+    """Build the format-specific compact nonlocal operator."""
+
+    format_value = _periodic_pseudopotential_format(pseudopotentials)
+    operator_type = (
+        PeriodicGTHNonlocalOperator
+        if format_value == PseudopotentialFormat.GTH
+        else PeriodicUPFNonlocalOperator
+    )
+    return operator_type(pseudopotentials, basis, positions, cache=cache)
+
+
+def _periodic_local_potential_grid(
+    pseudopotentials: Sequence[PseudopotentialData],
+    basis: PlaneWaveBasis,
+    positions: Sequence[Sequence[float]],
+) -> mx.array:
+    """Build the format-specific periodic local potential."""
+
+    format_value = _periodic_pseudopotential_format(pseudopotentials)
+    if format_value == PseudopotentialFormat.GTH:
+        return gth_local_potential_grid(pseudopotentials, basis, positions)
+    return upf_local_potential_grid(pseudopotentials, basis, positions)
+
+
+def _periodic_local_forces(
+    density: mx.array,
+    pseudopotentials: Sequence[PseudopotentialData],
+    basis: PlaneWaveBasis,
+    positions: Sequence[Sequence[float]],
+) -> mx.array:
+    """Evaluate the format-specific analytic local ionic forces."""
+
+    format_value = _periodic_pseudopotential_format(pseudopotentials)
+    if format_value == PseudopotentialFormat.GTH:
+        return periodic_gth_local_forces(
+            density,
+            pseudopotentials,
+            basis,
+            positions,
+        )
+    return periodic_upf_local_forces(
+        density,
+        pseudopotentials,
+        basis,
+        positions,
+    )

--- a/src/mlx_atomistic/dft/_periodic_scf_engine.py
+++ b/src/mlx_atomistic/dft/_periodic_scf_engine.py
@@ -50,6 +50,12 @@ from mlx_atomistic.dft._periodic_occupations import (
     _PeriodicOccupationResult,
     _resolve_periodic_occupations,
 )
+from mlx_atomistic.dft._periodic_pseudopotential_runtime import (
+    _periodic_local_potential_grid,
+    _periodic_nonlocal_operator,
+    _periodic_pseudopotential_format,
+    _PeriodicNonlocalOperator,
+)
 from mlx_atomistic.dft._periodic_spin_occupations import (
     _PeriodicSpinOccupationResult,
     _resolve_periodic_spin_occupations,
@@ -72,11 +78,7 @@ from mlx_atomistic.dft.kpoints import (
 )
 from mlx_atomistic.dft.mixing import LinearMixer, PulayDIISMixer
 from mlx_atomistic.dft.periodic_electrostatics import periodic_ewald_energy
-from mlx_atomistic.dft.periodic_gth import (
-    PeriodicGTHNonlocalOperator,
-    _GTHProjectorCache,
-    gth_local_potential_grid,
-)
+from mlx_atomistic.dft.periodic_gth import _ProjectorCache
 from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
 from mlx_atomistic.dft.potentials import hartree_potential
 from mlx_atomistic.dft.spin_gga import ProductionSpinPBEExchangeCorrelation, SpinXCResult
@@ -337,8 +339,8 @@ class _PeriodicSCFSetup:
     bases: tuple[PlaneWaveBasis, ...]
     spin_bases: tuple[tuple[PlaneWaveBasis, ...], ...]
     owned_indices: tuple[int, ...]
-    nonlocal_operators: dict[int, PeriodicGTHNonlocalOperator]
-    spin_nonlocal_operators: tuple[dict[int, PeriodicGTHNonlocalOperator], ...]
+    nonlocal_operators: dict[int, _PeriodicNonlocalOperator]
+    spin_nonlocal_operators: tuple[dict[int, _PeriodicNonlocalOperator], ...]
     local_potential: mx.array
     mixer: LinearMixer | PulayDIISMixer
     magnetization_mixer: LinearMixer | None
@@ -437,7 +439,7 @@ class _PeriodicSCFController:
         initial_coefficients: Sequence[mx.array] | None,
         basis_integer_g: Sequence[np.ndarray] | None,
         observer: RuntimeObserver | None,
-        projector_cache: _GTHProjectorCache,
+        projector_cache: _ProjectorCache,
         resume_state: _PeriodicSCFContinuationState | None,
         checkpoint_callback: Callable[[_PeriodicSCFContinuationState], bool] | None,
         checkpoint_iteration: int | None,
@@ -548,7 +550,7 @@ class _PeriodicSCFController:
                 lane_label="gamma-local-potential",
             )
             nonlocal_operators = {
-                point_index: PeriodicGTHNonlocalOperator(
+                point_index: _periodic_nonlocal_operator(
                     system.pseudopotentials,
                     bases[point_index],
                     system.positions,
@@ -561,7 +563,7 @@ class _PeriodicSCFController:
                 if spin is None
                 else tuple(
                     {
-                        point_index: PeriodicGTHNonlocalOperator(
+                        point_index: _periodic_nonlocal_operator(
                             system.pseudopotentials,
                             channel_bases[point_index],
                             system.positions,
@@ -572,7 +574,7 @@ class _PeriodicSCFController:
                     for channel_bases in spin_bases
                 )
             )
-            local_potential = gth_local_potential_grid(
+            local_potential = _periodic_local_potential_grid(
                 system.pseudopotentials,
                 gamma_basis,
                 system.positions,
@@ -709,6 +711,7 @@ class _PeriodicSCFController:
         resume_state: _PeriodicSCFContinuationState | None,
         config: PeriodicSCFConfig,
     ) -> None:
+        _periodic_pseudopotential_format(system.pseudopotentials)
         if type(band_count) is not int or band_count <= 0:
             msg = "n_bands must be a positive non-bool integer"
             raise ValueError(msg)
@@ -1922,7 +1925,7 @@ def _run_periodic_scf_with_projector_cache(
     initial_coefficients: Sequence[mx.array] | None = None,
     basis_integer_g: Sequence[np.ndarray] | None = None,
     observer: RuntimeObserver | None = None,
-    projector_cache: _GTHProjectorCache,
+    projector_cache: _ProjectorCache,
     resume_state: _PeriodicSCFContinuationState | None = None,
     checkpoint_callback: Callable[[_PeriodicSCFContinuationState], bool] | None = None,
     checkpoint_iteration: int | None = None,
@@ -1963,7 +1966,7 @@ def _run_periodic_scf_controlled(
     checkpoint_callback: Callable[[_PeriodicSCFContinuationState], bool] | None = None,
     checkpoint_iteration: int | None = None,
 ) -> PeriodicSCFResult:
-    with _bounded_dft_allocator(), _GTHProjectorCache() as projector_cache:
+    with _bounded_dft_allocator(), _ProjectorCache() as projector_cache:
         return _run_periodic_scf_with_projector_cache(
             system,
             cutoff_hartree=cutoff_hartree,

--- a/src/mlx_atomistic/dft/periodic_forces.py
+++ b/src/mlx_atomistic/dft/periodic_forces.py
@@ -16,12 +16,13 @@ from mlx_atomistic.dft._periodic_models import (
     PeriodicKPointResult,
     PeriodicSCFResult,
 )
-from mlx_atomistic.dft.periodic_electrostatics import periodic_ewald_forces
-from mlx_atomistic.dft.periodic_gth import (
-    PeriodicGTHNonlocalOperator,
-    _GTHProjectorCache,
-    periodic_gth_local_forces,
+from mlx_atomistic.dft._periodic_pseudopotential_runtime import (
+    _periodic_local_forces,
+    _periodic_nonlocal_operator,
+    _periodic_pseudopotential_format,
 )
+from mlx_atomistic.dft.periodic_electrostatics import periodic_ewald_forces
+from mlx_atomistic.dft.periodic_gth import _ProjectorCache
 
 _FORCE_KPOINT_MATERIALIZATION_BATCH_SIZE = 8
 
@@ -32,8 +33,8 @@ class PeriodicForceResult:
 
     Args:
         forces: Total ionic forces in Hartree/bohr.
-        local: Local GTH electron-ion contribution.
-        nonlocal_force: Nonlocal GTH projector contribution.
+        local: Local pseudopotential electron-ion contribution.
+        nonlocal_force: Nonlocal pseudopotential projector contribution.
         ion_ewald: Periodic ion-ion Ewald contribution.
         timings: Wall-clock phase timings in milliseconds.
         provenance: Method and stationarity metadata.
@@ -63,11 +64,17 @@ class PeriodicForceResult:
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-safe force decomposition."""
 
+        pseudopotential_format = self.provenance.get(
+            "pseudopotential_format",
+            "gth",
+        )
         return {
             "forces_hartree_per_bohr": np.asarray(self.forces).tolist(),
             "force_by_term_hartree_per_bohr": {
-                "local_gth": np.asarray(self.local).tolist(),
-                "nonlocal_gth": np.asarray(self.nonlocal_force).tolist(),
+                f"local_{pseudopotential_format}": np.asarray(self.local).tolist(),
+                f"nonlocal_{pseudopotential_format}": np.asarray(
+                    self.nonlocal_force
+                ).tolist(),
                 "ion_ewald": np.asarray(self.ion_ewald).tolist(),
             },
             "max_force_hartree_per_bohr": self.max_force,
@@ -134,7 +141,7 @@ def _periodic_nonlocal_forces(
     system: PeriodicDFTSystem,
     owned: Sequence[PeriodicKPointResult],
     *,
-    projector_cache: _GTHProjectorCache,
+    projector_cache: _ProjectorCache,
 ) -> mx.array:
     force = mx.zeros((system.ion_count, 3), dtype=mx.float32)
     for point_index, point in enumerate(owned, start=1):
@@ -142,7 +149,7 @@ def _periodic_nonlocal_forces(
         if not isinstance(compact, _CompactLaneState):
             msg = "periodic forces require compact occupied k-point states"
             raise ValueError(msg)
-        operator = PeriodicGTHNonlocalOperator(
+        operator = _periodic_nonlocal_operator(
             system.pseudopotentials,
             point.basis,
             system.positions,
@@ -196,7 +203,8 @@ def periodic_scf_forces(
     """Evaluate fixed-cell periodic forces from a converged SCF result.
 
     The local and nonlocal electron-ion terms use analytic derivatives of the
-    GTH phase factors. The ion-ion term uses the analytic Ewald derivative.
+    pseudopotential phase factors. The ion-ion term uses the analytic Ewald
+    derivative.
     There is no ionic Pulay term because the fixed-cell plane-wave basis does
     not depend on ion positions. Finite-temperature results use their resolved
     occupations, yielding the stationary electronic free-energy force.
@@ -230,9 +238,12 @@ def periodic_scf_forces(
         "total": 0.0,
     }
     total_start = perf_counter()
-    with _bounded_dft_allocator(), _GTHProjectorCache() as projector_cache:
+    pseudopotential_format = _periodic_pseudopotential_format(
+        system.pseudopotentials
+    ).value
+    with _bounded_dft_allocator(), _ProjectorCache() as projector_cache:
         phase_start = perf_counter()
-        local = periodic_gth_local_forces(
+        local = _periodic_local_forces(
             density,
             system.pseudopotentials,
             owned[0].basis,
@@ -270,8 +281,13 @@ def periodic_scf_forces(
         ion_ewald=ion_ewald,
         timings=timings,
         provenance={
-            "local_gth": "analytic_reciprocal_density_phase_derivative",
-            "nonlocal_gth": "analytic_projector_phase_derivative",
+            "pseudopotential_format": pseudopotential_format,
+            f"local_{pseudopotential_format}": (
+                "analytic_reciprocal_density_phase_derivative"
+            ),
+            f"nonlocal_{pseudopotential_format}": (
+                "analytic_projector_phase_derivative"
+            ),
             "ion_ewald": "analytic_ewald_derivative",
             "pulay": "zero_for_fixed_cell_plane_wave_basis",
             "stationarity": "converged_scf_required",

--- a/src/mlx_atomistic/dft/periodic_gth.py
+++ b/src/mlx_atomistic/dft/periodic_gth.py
@@ -277,14 +277,14 @@ class _ProjectorCacheEntry:
     byte_count: int
 
 
-class _GTHProjectorCache:
-    """Bounded context-owned LRU cache for compact GTH projector groups."""
+class _ProjectorCache:
+    """Bounded context-owned LRU cache for compact nonlocal projectors."""
 
     DEFAULT_BUDGET_BYTES = 256 * 1024 * 1024
 
     def __init__(self, byte_budget: int = DEFAULT_BUDGET_BYTES):
         if byte_budget <= 0:
-            msg = "GTH projector cache byte budget must be positive"
+            msg = "projector cache byte budget must be positive"
             raise ValueError(msg)
         self.byte_budget = int(byte_budget)
         self._entries: OrderedDict[tuple[object, ...], _ProjectorCacheEntry] = OrderedDict()
@@ -329,7 +329,7 @@ class _GTHProjectorCache:
         """Bind the cache to one geometry/cell/pseudopotential context."""
 
         if self._closed:
-            msg = "closed GTH projector cache cannot be rebound"
+            msg = "closed projector cache cannot be rebound"
             raise RuntimeError(msg)
         if self._context_identity is None:
             self._context_identity = context_identity
@@ -338,11 +338,11 @@ class _GTHProjectorCache:
             self._context_identity = context_identity
             self._invalidations += 1
 
-    def __enter__(self) -> _GTHProjectorCache:
+    def __enter__(self) -> _ProjectorCache:
         """Enter this cache's deterministic lifetime boundary."""
 
         if self._closed:
-            msg = "closed GTH projector cache cannot be entered"
+            msg = "closed projector cache cannot be entered"
             raise RuntimeError(msg)
         return self
 
@@ -355,7 +355,7 @@ class _GTHProjectorCache:
         """Return and refresh one cached projector group."""
 
         if self._closed:
-            msg = "closed GTH projector cache cannot be read"
+            msg = "closed projector cache cannot be read"
             raise RuntimeError(msg)
         entry = self._entries.get(key)
         if entry is None:
@@ -373,7 +373,7 @@ class _GTHProjectorCache:
         """Insert one group without evicting inputs of the active lazy action."""
 
         if self._closed:
-            msg = "closed GTH projector cache cannot be written"
+            msg = "closed projector cache cannot be written"
             raise RuntimeError(msg)
         payload = mx.array(values)
         byte_count = int(np.prod(payload.shape)) * 8
@@ -420,6 +420,11 @@ class _GTHProjectorCache:
         self._closed = True
 
 
+# Preserve the old private name for existing internal callers and downstream
+# diagnostics while the shared periodic runtime adopts the format-neutral name.
+_GTHProjectorCache = _ProjectorCache
+
+
 def _projector_context_identity(
     pseudopotentials: Sequence[PseudopotentialData],
     basis: PlaneWaveBasis,
@@ -464,11 +469,13 @@ class PeriodicGTHNonlocalOperator:
     pseudopotentials: tuple[PseudopotentialData, ...]
     basis: PlaneWaveBasis
     positions: np.ndarray
-    _cache: _GTHProjectorCache
+    _cache: _ProjectorCache
     _context_identity: str
     _owns_cache: bool
     _flattened_coupling: mx.array
     _projector_count: int
+    _projector_group_count: int
+    _harmonic_width: int
 
     def __init__(
         self,
@@ -476,15 +483,15 @@ class PeriodicGTHNonlocalOperator:
         basis: PlaneWaveBasis,
         positions: Sequence[Sequence[float]],
         *,
-        cache: _GTHProjectorCache | None = None,
-        cache_budget_bytes: int = _GTHProjectorCache.DEFAULT_BUDGET_BYTES,
+        cache: _ProjectorCache | None = None,
+        cache_budget_bytes: int = _ProjectorCache.DEFAULT_BUDGET_BYTES,
     ):
         centers = _positions(positions)
         per_ion = _per_ion_pseudopotentials(pseudopotential, int(centers.shape[0]))
         if any(not value.gth_channels for value in per_ion):
             msg = "every GTH pseudopotential must have complete nonlocal channels"
             raise ValueError(msg)
-        projector_cache = _GTHProjectorCache(cache_budget_bytes) if cache is None else cache
+        projector_cache = _ProjectorCache(cache_budget_bytes) if cache is None else cache
         context_identity = _projector_context_identity(
             per_ion,
             basis,
@@ -500,6 +507,27 @@ class PeriodicGTHNonlocalOperator:
         object.__setattr__(self, "_owns_cache", cache is None)
         object.__setattr__(self, "_flattened_coupling", flattened_coupling)
         object.__setattr__(self, "_projector_count", projector_count)
+        object.__setattr__(
+            self,
+            "_projector_group_count",
+            sum(
+                2 * channel.angular_momentum + 1
+                for pseudo in per_ion
+                for channel in pseudo.gth_channels
+            ),
+        )
+        object.__setattr__(
+            self,
+            "_harmonic_width",
+            sum(
+                2 * angular_momentum + 1
+                for angular_momentum in {
+                    channel.angular_momentum
+                    for pseudo in per_ion
+                    for channel in pseudo.gth_channels
+                }
+            ),
+        )
 
     def _projector_group(
         self,
@@ -560,27 +588,20 @@ class PeriodicGTHNonlocalOperator:
         operators: Sequence[PeriodicGTHNonlocalOperator],
         batch: _CompactBatch,
     ) -> int:
-        """Return a conservative logical workspace bound for batched GTH."""
+        """Return a conservative workspace bound for separable projectors."""
 
         if not operators:
             return 0
         logical_lane_count = len(operators)
         if logical_lane_count > batch.lane_capacity:
-            msg = "GTH operator count exceeds the compact capacity"
+            msg = "nonlocal operator count exceeds the compact capacity"
             raise ValueError(msg)
         lane_count = batch.lane_capacity
         vector_count = batch.vector_count
         bucket_size = batch.bucket_size
         output_bytes = lane_count * vector_count * bucket_size * 8
         reference = operators[0]
-        harmonic_width = sum(
-            2 * angular_momentum + 1
-            for angular_momentum in {
-                channel.angular_momentum
-                for pseudopotential in reference.pseudopotentials
-                for channel in pseudopotential.gth_channels
-            }
-        )
+        harmonic_width = reference._harmonic_width
         estimate = lane_count * bucket_size * (1 + harmonic_width) * 4
         projector_bytes = lane_count * reference._projector_count * bucket_size * 8
         overlap_bytes = lane_count * reference._projector_count * vector_count * 8
@@ -616,20 +637,20 @@ class PeriodicGTHNonlocalOperator:
         PeriodicGTHNonlocalOperator,
         list[tuple[PeriodicGTHNonlocalOperator, mx.array]],
         list[dict[str, int]],
-        dict[int, tuple[_GTHProjectorCache, set[tuple[object, ...]]]],
+        dict[int, tuple[_ProjectorCache, set[tuple[object, ...]]]],
     ]:
         if not operators or len(operators) != len(coefficients):
-            msg = "GTH batches require matching non-empty operator lanes"
+            msg = "nonlocal batches require matching non-empty operator lanes"
             raise ValueError(msg)
         if batch.lane_count != len(operators):
-            msg = "GTH batch lane count does not match its operators"
+            msg = "nonlocal batch lane count does not match its operators"
             raise ValueError(msg)
         reference = operators[0]
         lane_data: list[tuple[PeriodicGTHNonlocalOperator, mx.array]] = []
         metrics: list[dict[str, int]] = []
         protected_by_cache: dict[
             int,
-            tuple[_GTHProjectorCache, set[tuple[object, ...]]],
+            tuple[_ProjectorCache, set[tuple[object, ...]]],
         ] = {}
         for operator, state, layout in zip(
             operators,
@@ -638,18 +659,18 @@ class PeriodicGTHNonlocalOperator:
             strict=True,
         ):
             if operator._context_identity != reference._context_identity:
-                msg = "GTH batch operators must share one physical context"
+                msg = "nonlocal batch operators must share one physical context"
                 raise ValueError(msg)
             if layout is not state.layout:
-                msg = "GTH batch layout does not match its coefficient lane"
+                msg = "nonlocal batch layout does not match its coefficient lane"
                 raise ValueError(msg)
             operator._cache.bind(operator._context_identity)
             operator.basis._validate_state(state)
             if state.kind != "coefficients":
-                msg = "GTH input must be coefficient state"
+                msg = "nonlocal input must be coefficient state"
                 raise ValueError(msg)
             if state.vector_count > batch.vector_count:
-                msg = "GTH batch coefficient width exceeds its capacity"
+                msg = "nonlocal batch coefficient width exceeds its capacity"
                 raise ValueError(msg)
             lane_data.append((operator, operator.basis._layout._active_shifted_vectors))
             metrics.append(PeriodicGTHNonlocalOperator._initial_batch_metrics(state))
@@ -703,7 +724,7 @@ class PeriodicGTHNonlocalOperator:
         group_count: int,
         protected_by_cache: dict[
             int,
-            tuple[_GTHProjectorCache, set[tuple[object, ...]]],
+            tuple[_ProjectorCache, set[tuple[object, ...]]],
         ],
         metrics: dict[str, int],
     ) -> mx.array:
@@ -729,7 +750,7 @@ class PeriodicGTHNonlocalOperator:
             metrics["projector_cache_hits"] = group_count
             protected_keys.add(key)
         if int(beta.shape[0]) != projector_count:
-            msg = "flattened GTH projector count is inconsistent"
+            msg = "flattened nonlocal projector count is inconsistent"
             raise RuntimeError(msg)
         padding = batch.bucket_size - operator.basis.active_count
         if padding:
@@ -820,7 +841,7 @@ class PeriodicGTHNonlocalOperator:
         batch: _CompactBatch,
         evaluate: bool = True,
     ) -> tuple[tuple[_CompactLaneState, ...], tuple[dict[str, int], ...]]:
-        """Apply GTH projectors with one padded k-lane matrix path."""
+        """Apply separable projectors with one padded k-lane matrix path."""
 
         (
             reference,
@@ -832,11 +853,7 @@ class PeriodicGTHNonlocalOperator:
             coefficients,
             batch,
         )
-        group_count = sum(
-            2 * channel.angular_momentum + 1
-            for pseudopotential in reference.pseudopotentials
-            for channel in pseudopotential.gth_channels
-        )
+        group_count = reference._projector_group_count
         flattened_projectors = [
             PeriodicGTHNonlocalOperator._projectors_for_batch_lane(
                 operator,

--- a/src/mlx_atomistic/dft/periodic_stress.py
+++ b/src/mlx_atomistic/dft/periodic_stress.py
@@ -19,6 +19,9 @@ from mlx_atomistic.dft._periodic_models import (
     PeriodicSCFConfig,
     PeriodicSCFResult,
 )
+from mlx_atomistic.dft._periodic_pseudopotential_runtime import (
+    _periodic_pseudopotential_format,
+)
 from mlx_atomistic.dft._runtime_observer import RuntimeObserver
 from mlx_atomistic.dft.gga import ProductionPBEExchangeCorrelation
 from mlx_atomistic.dft.kpoints import KPointMesh
@@ -26,6 +29,7 @@ from mlx_atomistic.dft.periodic_scf import (
     _run_periodic_scf_fixed_topology,
     run_periodic_scf,
 )
+from mlx_atomistic.dft.pseudopotentials import PseudopotentialFormat
 from mlx_atomistic.dft.xc import ExchangeCorrelationFunctional
 
 HARTREE_PER_BOHR3_TO_GPA = 29421.02648438959
@@ -326,6 +330,11 @@ def periodic_analytic_stress(
         raise TypeError("system must be PeriodicDFTSystem")
     if not isinstance(kpoint_mesh, KPointMesh):
         raise TypeError("kpoint_mesh must be KPointMesh")
+    if (
+        _periodic_pseudopotential_format(system.pseudopotentials)
+        != PseudopotentialFormat.GTH
+    ):
+        raise ValueError("analytic periodic stress currently requires GTH input")
     if kpoint_mesh.point_group_symmetry_reduced:
         raise ValueError("analytic stress does not support point-group-reduced k-point meshes")
     if (
@@ -428,6 +437,11 @@ def periodic_finite_difference_stress(
         raise TypeError("system must be PeriodicDFTSystem")
     if not isinstance(kpoint_mesh, KPointMesh):
         raise TypeError("kpoint_mesh must be KPointMesh")
+    if (
+        _periodic_pseudopotential_format(system.pseudopotentials)
+        != PseudopotentialFormat.GTH
+    ):
+        raise ValueError("periodic stress currently requires GTH input")
     if kpoint_mesh.point_group_symmetry_reduced:
         raise ValueError(
             "finite-difference stress does not support point-group-reduced k-point meshes"

--- a/src/mlx_atomistic/dft/periodic_upf.py
+++ b/src/mlx_atomistic/dft/periodic_upf.py
@@ -1,22 +1,31 @@
-"""Periodic local operators for numerical UPF pseudopotentials."""
+"""Periodic local and nonlocal operators for numerical UPF data."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from math import pi
+from dataclasses import dataclass
+from hashlib import sha256
+from math import pi, sqrt
 
 import mlx.core as mx
 import numpy as np
-from scipy.special import erf
+from scipy.special import erf, spherical_jn
 
+from mlx_atomistic.dft._compact import _CompactBatch, _CompactLaneState
 from mlx_atomistic.dft._periodic_pseudopotential import (
     _periodic_positions,
     _periodic_pseudopotentials,
     _periodic_structure_factor,
 )
 from mlx_atomistic.dft._pseudopotential_identity import _pseudopotential_fingerprint
+from mlx_atomistic.dft.periodic_gth import (
+    PeriodicGTHNonlocalOperator,
+    _ProjectorCache,
+    _real_spherical_harmonics,
+)
 from mlx_atomistic.dft.plane_wave import PlaneWaveBasis
 from mlx_atomistic.dft.pseudopotentials import (
+    NonlocalProjectorData,
     PseudopotentialData,
     PseudopotentialFormat,
     RadialGrid,
@@ -97,6 +106,137 @@ def _single_upf_local_coefficients(
         q.reshape(-1),
         volume=basis.volume,
     ).reshape(basis.grid.shape)
+
+
+def _upf_projector_radial_transforms(
+    projectors: Sequence[NonlocalProjectorData],
+    q: np.ndarray,
+    *,
+    volume: float,
+) -> tuple[np.ndarray, ...]:
+    """Transform radial projectors while sharing angular Bessel work."""
+
+    q_values = np.asarray(q, dtype=np.float64)
+    if q_values.ndim != 1 or not np.isfinite(q_values).all() or np.any(q_values < 0.0):
+        raise ValueError("UPF projector magnitudes must be finite and non-negative")
+    validated = []
+    groups: dict[tuple[int, int], list[int]] = {}
+    for index, projector in enumerate(projectors):
+        radial_grid = projector.radial_grid
+        if not isinstance(radial_grid, RadialGrid):
+            raise ValueError("UPF projector transform requires a radial grid")
+        values = np.asarray(projector.values, dtype=np.float64)
+        if values.shape != radial_grid.radii.shape:
+            raise ValueError("UPF projector samples must match their radial grid")
+        validated.append((projector.angular_momentum, radial_grid, values))
+        groups.setdefault(
+            (projector.angular_momentum, id(radial_grid)),
+            [],
+        ).append(index)
+    transformed = [np.empty_like(q_values) for _projector in projectors]
+    prefactor = 4.0 * pi / sqrt(volume)
+    for indices in groups.values():
+        angular_momentum, radial_grid, _values = validated[indices[0]]
+        radius = radial_grid.radii
+        values = np.stack([validated[index][2] for index in indices], axis=0)
+        for start in range(0, q_values.size, _RADIAL_TRANSFORM_CHUNK_SIZE):
+            selected = q_values[start : start + _RADIAL_TRANSFORM_CHUNK_SIZE]
+            bessel = spherical_jn(
+                angular_momentum,
+                selected[:, None] * radius[None, :],
+            )
+            observed = prefactor * _simpson_radial(
+                values[:, None, :] * bessel[None, :, :] * radius[None, None, :],
+                radial_grid,
+            )
+            for local_index, projector_index in enumerate(indices):
+                transformed[projector_index][start : start + selected.size] = (
+                    observed[local_index]
+                )
+    return tuple(transformed)
+
+
+def _upf_projector_radial_transform(
+    projector: NonlocalProjectorData,
+    q: np.ndarray,
+    *,
+    volume: float,
+) -> np.ndarray:
+    """Transform one UPF radial projector for source-oracle diagnostics."""
+
+    return _upf_projector_radial_transforms(
+        (projector,),
+        q,
+        volume=volume,
+    )[0]
+
+
+def _upf_angular_blocks(
+    pseudopotential: PseudopotentialData,
+) -> tuple[tuple[int, tuple[int, ...], np.ndarray], ...]:
+    projectors = pseudopotential.nonlocal_projectors
+    coupling = np.asarray(
+        pseudopotential.nonlocal_coupling_matrix,
+        dtype=np.float64,
+    )
+    count = len(projectors)
+    if coupling.shape != (count, count):
+        raise ValueError("UPF coupling matrix must match its projector count")
+    angular = np.asarray(
+        [projector.angular_momentum for projector in projectors],
+        dtype=np.int64,
+    )
+    if np.any((angular < 0) | (angular > 2)):
+        raise ValueError("periodic UPF nonlocal projectors require 0 <= l <= 2")
+    cross_channel = angular[:, None] != angular[None, :]
+    if np.any(np.abs(coupling[cross_channel]) > 1.0e-12):
+        raise ValueError("scalar UPF PP_DIJ cannot couple different angular channels")
+    blocks = []
+    for l_value in sorted(set(int(value) for value in angular)):
+        indices = np.flatnonzero(angular == l_value)
+        blocks.append(
+            (
+                l_value,
+                tuple(int(index) for index in indices),
+                coupling[np.ix_(indices, indices)],
+            )
+        )
+    return tuple(blocks)
+
+
+def _flattened_upf_coupling(
+    pseudopotentials: Sequence[PseudopotentialData],
+) -> tuple[mx.array, int, int]:
+    blocks = [
+        np.asarray(block, dtype=np.float32)
+        for pseudo in pseudopotentials
+        for l_value, _indices, block in _upf_angular_blocks(pseudo)
+        for _harmonic in range(2 * l_value + 1)
+    ]
+    projector_count = sum(int(block.shape[0]) for block in blocks)
+    coupling = np.zeros((projector_count, projector_count), dtype=np.float32)
+    offset = 0
+    for block in blocks:
+        width = int(block.shape[0])
+        coupling[offset : offset + width, offset : offset + width] = block
+        offset += width
+    return mx.array(coupling), projector_count, len(blocks)
+
+
+def _upf_projector_context_identity(
+    pseudopotentials: Sequence[PseudopotentialData],
+    basis: PlaneWaveBasis,
+    positions: np.ndarray,
+) -> str:
+    digest = sha256()
+    digest.update(b"mlx-atomistic.upf-projector-context.v1\0")
+    for pseudo in pseudopotentials:
+        digest.update(_pseudopotential_fingerprint(pseudo).encode("ascii"))
+        digest.update(b"\0")
+    digest.update(basis.reciprocal_grid.fingerprint.encode("ascii"))
+    digest.update(np.asarray(positions, dtype=np.float64).tobytes())
+    digest.update(b"complex64-float32\0")
+    return digest.hexdigest()
 
 
 def upf_local_reciprocal_coefficients(
@@ -243,3 +383,408 @@ def periodic_upf_local_forces(
     result = mx.stack(forces, axis=0).astype(mx.float32)
     mx.eval(result)
     return result
+
+
+@dataclass(frozen=True)
+class PeriodicUPFNonlocalOperator:
+    """Compact separable scalar norm-conserving UPF operator."""
+
+    pseudopotentials: tuple[PseudopotentialData, ...]
+    basis: PlaneWaveBasis
+    positions: np.ndarray
+    _cache: _ProjectorCache
+    _context_identity: str
+    _owns_cache: bool
+    _flattened_coupling: mx.array
+    _projector_count: int
+    _projector_group_count: int
+    _harmonic_width: int
+    _radial_projectors_by_ion: tuple[tuple[mx.array, ...], ...]
+    _angular_blocks_by_ion: tuple[
+        tuple[tuple[int, tuple[int, ...], np.ndarray], ...],
+        ...,
+    ]
+    _coupling_by_ion: tuple[mx.array, ...]
+
+    def __init__(
+        self,
+        pseudopotential: PseudopotentialData | Sequence[PseudopotentialData],
+        basis: PlaneWaveBasis,
+        positions: Sequence[Sequence[float]],
+        *,
+        cache: _ProjectorCache | None = None,
+        cache_budget_bytes: int = _ProjectorCache.DEFAULT_BUDGET_BYTES,
+    ):
+        centers = _periodic_positions(positions)
+        per_ion = _periodic_pseudopotentials(
+            pseudopotential,
+            int(centers.shape[0]),
+            expected_format=PseudopotentialFormat.UPF,
+        )
+        if any(not pseudo.periodic_upf_compatible for pseudo in per_ion):
+            raise ValueError(
+                "periodic UPF nonlocal execution requires scalar norm-conserving "
+                "input without augmentation, SOC, or nonlinear core correction"
+            )
+        flattened_coupling, projector_count, group_count = (
+            _flattened_upf_coupling(per_ion)
+        )
+        projector_cache = (
+            _ProjectorCache(cache_budget_bytes) if cache is None else cache
+        )
+        context_identity = _upf_projector_context_identity(
+            per_ion,
+            basis,
+            centers,
+        )
+        projector_cache.bind(context_identity)
+        vectors = np.asarray(
+            basis._layout._active_shifted_vectors,
+            dtype=np.float64,
+        )
+        q = np.sqrt(np.sum(vectors * vectors, axis=-1))
+        unique_q, q_inverse = np.unique(q, return_inverse=True)
+        radial_by_species: dict[str, tuple[mx.array, ...]] = {}
+        blocks_by_species: dict[
+            str,
+            tuple[tuple[int, tuple[int, ...], np.ndarray], ...],
+        ] = {}
+        coupling_by_species: dict[str, mx.array] = {}
+        radial_by_ion = []
+        angular_blocks_by_ion = []
+        coupling_by_ion = []
+        for pseudo in per_ion:
+            fingerprint = _pseudopotential_fingerprint(pseudo)
+            radials = radial_by_species.get(fingerprint)
+            if radials is None:
+                transformed = _upf_projector_radial_transforms(
+                    pseudo.nonlocal_projectors,
+                    unique_q,
+                    volume=basis.volume,
+                )
+                radials = tuple(
+                    mx.array(values[q_inverse].astype(np.float32))
+                    for values in transformed
+                )
+                radial_by_species[fingerprint] = radials
+            blocks = blocks_by_species.get(fingerprint)
+            coupling = coupling_by_species.get(fingerprint)
+            if blocks is None or coupling is None:
+                blocks = _upf_angular_blocks(pseudo)
+                coupling, _projector_count, _group_count = (
+                    _flattened_upf_coupling((pseudo,))
+                )
+                blocks_by_species[fingerprint] = blocks
+                coupling_by_species[fingerprint] = coupling
+            radial_by_ion.append(radials)
+            angular_blocks_by_ion.append(blocks)
+            coupling_by_ion.append(coupling)
+        mx.eval(
+            flattened_coupling,
+            *(radial for radials in radial_by_species.values() for radial in radials),
+            *coupling_by_species.values(),
+        )
+        object.__setattr__(self, "pseudopotentials", per_ion)
+        object.__setattr__(self, "basis", basis)
+        object.__setattr__(self, "positions", centers)
+        object.__setattr__(self, "_cache", projector_cache)
+        object.__setattr__(self, "_context_identity", context_identity)
+        object.__setattr__(self, "_owns_cache", cache is None)
+        object.__setattr__(self, "_flattened_coupling", flattened_coupling)
+        object.__setattr__(self, "_projector_count", projector_count)
+        object.__setattr__(self, "_projector_group_count", group_count)
+        object.__setattr__(
+            self,
+            "_harmonic_width",
+            sum(
+                2 * l_value + 1
+                for l_value in {
+                    projector.angular_momentum
+                    for pseudo in per_ion
+                    for projector in pseudo.nonlocal_projectors
+                }
+            ),
+        )
+        object.__setattr__(self, "_radial_projectors_by_ion", tuple(radial_by_ion))
+        object.__setattr__(self, "_angular_blocks_by_ion", tuple(angular_blocks_by_ion))
+        object.__setattr__(self, "_coupling_by_ion", tuple(coupling_by_ion))
+
+    def _flattened_cache_key(self) -> tuple[object, ...]:
+        return (
+            self._context_identity,
+            self.basis.basis_fingerprint,
+            self.basis.order_fingerprint,
+            "flattened-projectors",
+            "complex64",
+        )
+
+    @staticmethod
+    def _estimated_batch_transient_bytes(
+        operators: Sequence[PeriodicUPFNonlocalOperator],
+        batch: _CompactBatch,
+    ) -> int:
+        """Return a conservative logical workspace bound for batched UPF."""
+
+        return PeriodicGTHNonlocalOperator._estimated_batch_transient_bytes(
+            operators,
+            batch,
+        )
+
+    @staticmethod
+    def _apply_compact_batch(
+        operators: Sequence[PeriodicUPFNonlocalOperator],
+        coefficients: Sequence[_CompactLaneState],
+        *,
+        batch: _CompactBatch,
+        evaluate: bool = True,
+    ) -> tuple[tuple[_CompactLaneState, ...], tuple[dict[str, int], ...]]:
+        """Apply UPF projectors through the shared compensated batch backend."""
+
+        return PeriodicGTHNonlocalOperator._apply_compact_batch(
+            operators,
+            coefficients,
+            batch=batch,
+            evaluate=evaluate,
+        )
+
+    def _ion_projectors(
+        self,
+        position: np.ndarray,
+        radials: tuple[mx.array, ...],
+        angular_blocks: tuple[tuple[int, tuple[int, ...], np.ndarray], ...],
+        harmonics: dict[int, tuple[mx.array, ...]],
+        vectors: mx.array,
+    ) -> mx.array:
+        center = mx.array(np.asarray(position, dtype=np.float32))
+        phase = mx.exp(
+            mx.array(-1j, dtype=mx.complex64)
+            * mx.sum(vectors * center[None, :], axis=-1)
+        )
+        rows = []
+        for l_value, indices, _block in angular_blocks:
+            radial = mx.stack([radials[index] for index in indices], axis=0)
+            angular_phase = (-1j) ** l_value
+            for harmonic in harmonics[l_value]:
+                rows.append(
+                    (
+                        radial
+                        * harmonic[None, :]
+                        * phase[None, :]
+                        * angular_phase
+                    ).astype(mx.complex64)
+                )
+        return mx.concatenate(rows, axis=0)
+
+    def _generate_flattened_projectors(self, vectors: mx.array) -> mx.array:
+        q = mx.sqrt(mx.sum(vectors * vectors, axis=-1))
+        harmonics = {
+            l_value: _real_spherical_harmonics(l_value, vectors, q)
+            for angular_blocks in self._angular_blocks_by_ion
+            for l_value, _indices, _block in angular_blocks
+        }
+        rows = [
+            self._ion_projectors(
+                position,
+                radials,
+                angular_blocks,
+                harmonics,
+                vectors,
+            )
+            for position, radials, angular_blocks in zip(
+                self.positions,
+                self._radial_projectors_by_ion,
+                self._angular_blocks_by_ion,
+                strict=True,
+            )
+        ]
+        beta = mx.concatenate(rows, axis=0)
+        if int(beta.shape[0]) != self._projector_count:
+            raise RuntimeError("flattened UPF projector count is inconsistent")
+        return beta
+
+    def _apply_compact(
+        self,
+        coefficients: _CompactLaneState,
+        *,
+        evaluate: bool = True,
+    ) -> tuple[_CompactLaneState, dict[str, int]]:
+        batch = _CompactBatch.from_states((coefficients,))
+        actions, metrics = self._apply_compact_batch(
+            (self,),
+            (coefficients,),
+            batch=batch,
+            evaluate=evaluate,
+        )
+        return actions[0], metrics[0]
+
+    def apply(self, coefficients: mx.array) -> mx.array:
+        """Apply the nonlocal UPF operator to one orbital or a stack.
+
+        Args:
+            coefficients: One admitted coefficient grid or a stack.
+
+        Returns:
+            Nonlocal operator action with the same shape.
+        """
+
+        state, was_single = self.basis._state_from_full(coefficients)
+        applied, _metrics = self._apply_compact(state)
+        return self.basis._layout.unpack_fresh(applied.values, single=was_single)
+
+    def energy(
+        self,
+        coefficients: mx.array,
+        *,
+        occupations: Sequence[float],
+    ) -> mx.array:
+        """Return occupied nonlocal UPF energy in Hartree.
+
+        Args:
+            coefficients: Orbital stack in the admitted basis.
+            occupations: One occupation per orbital.
+
+        Returns:
+            Real occupied nonlocal energy.
+        """
+
+        state, _was_single = self.basis._state_from_full(coefficients)
+        if len(occupations) != state.vector_count:
+            raise ValueError("occupations length must match the orbital count")
+        applied, _metrics = self._apply_compact(state)
+        expectations = mx.real(
+            mx.sum(mx.conjugate(state.values) * applied.values, axis=1)
+        )
+        return mx.sum(
+            expectations * mx.array(np.asarray(occupations, dtype=np.float32))
+        )
+
+    def _forces_compact(
+        self,
+        coefficients: _CompactLaneState,
+        *,
+        occupations: Sequence[float],
+        evaluate: bool = True,
+    ) -> mx.array:
+        self.basis._validate_state(coefficients)
+        if coefficients.kind != "coefficients":
+            raise ValueError("UPF force input must be coefficient state")
+        occupation_values = np.asarray(occupations, dtype=np.float32)
+        if occupation_values.shape != (coefficients.vector_count,):
+            raise ValueError("occupations length must match the orbital count")
+        if not np.all(np.isfinite(occupation_values)):
+            raise ValueError("occupations must contain only finite values")
+        vectors = self.basis._layout._active_shifted_vectors
+        q = mx.sqrt(mx.sum(vectors * vectors, axis=-1))
+        harmonics = {
+            l_value: _real_spherical_harmonics(l_value, vectors, q)
+            for angular_blocks in self._angular_blocks_by_ion
+            for l_value, _indices, _block in angular_blocks
+        }
+        coefficient_matrix = mx.transpose(coefficients.values)
+        occupation_array = mx.array(occupation_values)
+        imaginary = mx.array(1j, dtype=mx.complex64)
+        forces = []
+        for position, radials, angular_blocks, coupling in zip(
+            self.positions,
+            self._radial_projectors_by_ion,
+            self._angular_blocks_by_ion,
+            self._coupling_by_ion,
+            strict=True,
+        ):
+            beta = self._ion_projectors(
+                position,
+                radials,
+                angular_blocks,
+                harmonics,
+                vectors,
+            )
+            overlaps = mx.matmul(mx.conjugate(beta), coefficient_matrix)
+            mixed = mx.matmul(coupling, overlaps)
+            derivative_bras = (
+                imaginary
+                * mx.transpose(vectors)[:, None, :]
+                * mx.conjugate(beta)[None, :, :]
+            )
+            derivative_overlaps = mx.matmul(derivative_bras, coefficient_matrix)
+            derivative_energy = 2.0 * mx.real(
+                mx.sum(
+                    mx.conjugate(derivative_overlaps)
+                    * (mixed * occupation_array[None, :])[None, :, :],
+                    axis=(1, 2),
+                )
+            )
+            forces.append(-derivative_energy)
+        result = mx.stack(forces, axis=0).astype(mx.float32)
+        if evaluate:
+            mx.eval(result)
+        return result
+
+    def forces(
+        self,
+        coefficients: mx.array,
+        *,
+        occupations: Sequence[float],
+    ) -> mx.array:
+        """Return analytic nonlocal-UPF Hellmann--Feynman forces.
+
+        Args:
+            coefficients: Orbital stack in the admitted basis.
+            occupations: One occupation per orbital.
+
+        Returns:
+            Nonlocal forces with shape ``(n_ions, 3)`` in Hartree/bohr.
+        """
+
+        state, _was_single = self.basis._state_from_full(coefficients)
+        return self._forces_compact(state, occupations=occupations)
+
+    def cache_info(self) -> dict[str, int]:
+        """Return bounded projector-cache accounting."""
+
+        return {
+            "byte_budget": self._cache.byte_budget,
+            "current_bytes": self._cache.current_bytes,
+            "peak_bytes": self._cache.peak_bytes,
+            "entry_count": self._cache.entry_count,
+            "evictions": self._cache.evictions,
+            "invalidations": self._cache.invalidations,
+        }
+
+    def close(self) -> None:
+        """Release an operator-owned projector cache context."""
+
+        if self._owns_cache:
+            self._cache.close()
+
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-safe nonlocal UPF metadata."""
+
+        fingerprints = [
+            _pseudopotential_fingerprint(pseudo)
+            for pseudo in self.pseudopotentials
+        ]
+        radial_by_ion = [
+            len(pseudo.nonlocal_projectors)
+            for pseudo in self.pseudopotentials
+        ]
+        angular_by_ion = [
+            sum(
+                2 * projector.angular_momentum + 1
+                for projector in pseudo.nonlocal_projectors
+            )
+            for pseudo in self.pseudopotentials
+        ]
+        homogeneous = len(set(fingerprints)) == 1
+        return {
+            "format": "upf",
+            "ion_count": int(self.positions.shape[0]),
+            "species_count": len(set(fingerprints)),
+            "radial_projector_count_per_ion": (
+                radial_by_ion[0] if homogeneous else radial_by_ion
+            ),
+            "angular_projector_count_per_ion": (
+                angular_by_ion[0] if homogeneous else angular_by_ion
+            ),
+            "angular_projector_count_total": sum(angular_by_ion),
+            "kpoint_cartesian_bohr_inverse": list(self.basis.kpoint_cartesian),
+        }

--- a/src/mlx_atomistic/dft/pseudopotentials.py
+++ b/src/mlx_atomistic/dft/pseudopotentials.py
@@ -201,6 +201,10 @@ class PseudopotentialData:
             and self.metadata.get("core_correction") is False
             and bool(self.nonlocal_projectors)
             and bool(self.nonlocal_coupling_matrix)
+            and all(
+                0 <= projector.angular_momentum <= 2
+                for projector in self.nonlocal_projectors
+            )
         )
 
     def local_potential(self, radius: np.ndarray) -> np.ndarray:

--- a/src/mlx_atomistic/dft/references.py
+++ b/src/mlx_atomistic/dft/references.py
@@ -147,11 +147,18 @@ def get_dft_qm_scope_report() -> DFTQMScopeReport:
             DFTQMScopeEntry(
                 feature="pseudopotentials",
                 status="proof-level",
-                local_surface=("read_upf", "read_gth", "NonlocalPseudopotentialOperator"),
+                local_surface=(
+                    "read_upf",
+                    "read_gth",
+                    "NonlocalPseudopotentialOperator",
+                    "PeriodicUPFNonlocalOperator",
+                ),
                 reference_families=("Quantum ESPRESSO UPF", "CP2K GTH"),
                 rationale=(
-                    "UPF and GTH parsing plus nonlocal projector application are "
-                    "covered by fixtures, with format-convention limits documented."
+                    "GTH and scalar norm-conserving UPF parsing, periodic local and "
+                    "nonlocal application, fixed-cell forces, and identity gates are "
+                    "covered. UPF material transferability and augmentation physics "
+                    "remain unverified."
                 ),
             ),
             DFTQMScopeEntry(

--- a/tests/test_dft_upf.py
+++ b/tests/test_dft_upf.py
@@ -1,23 +1,45 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from hashlib import sha256
+from math import pi, sqrt
+from pathlib import Path
+
+import mlx.core as mx
 import numpy as np
 import pytest
 
 import mlx_atomistic.dft.periodic_upf as periodic_upf
 from mlx_atomistic.dft import (
+    BandPath,
+    KPoint,
+    KPointMesh,
+    NonlocalProjectorData,
+    PeriodicDavidsonConfig,
     PeriodicDFTSystem,
+    PeriodicKohnShamOperator,
+    PeriodicSCFConfig,
+    PeriodicUPFNonlocalOperator,
     PlaneWaveBasis,
     PseudopotentialData,
     PseudopotentialFormat,
     RadialGrid,
     RealSpaceGrid,
+    RuntimeObserver,
     gth_local_reciprocal_coefficients,
+    periodic_analytic_stress,
+    periodic_finite_difference_stress,
     periodic_gth_local_forces,
+    periodic_scf_calculation_contract,
+    periodic_scf_forces,
     periodic_upf_local_forces,
     read_upf,
+    run_periodic_band_structure,
+    run_periodic_scf,
     upf_local_potential_grid,
     upf_local_reciprocal_coefficients,
 )
+from mlx_atomistic.dft._compact import _CompactBatch
 
 
 def _upf_text(*, dij: str = "2.0 0.4 0.4 4.0", weights: str = "0.01 0.09 0.9") -> str:
@@ -136,6 +158,45 @@ def _matched_gth_and_numerical_upf():
     return gth, upf
 
 
+def _synthetic_periodic_upf() -> PseudopotentialData:
+    _gth, local_upf = _matched_gth_and_numerical_upf()
+    radii = local_upf.local_grid.radii
+
+    def projector(l_value: int, alpha: float) -> NonlocalProjectorData:
+        return NonlocalProjectorData(
+            angular_momentum=l_value,
+            values=tuple(radii ** (l_value + 1) * np.exp(-alpha * radii**2)),
+            radial_grid=local_upf.local_grid,
+            metadata={"radial_representation": "r_beta"},
+        )
+
+    return replace(
+        local_upf,
+        nonlocal_projectors=(
+            projector(0, 0.65),
+            projector(0, 1.10),
+            projector(1, 0.80),
+            projector(2, 0.95),
+        ),
+        nonlocal_coupling_matrix=(
+            (1.20, -0.15, 0.0, 0.0),
+            (-0.15, 0.85, 0.0, 0.0),
+            (0.0, 0.0, 0.70, 0.0),
+            (0.0, 0.0, 0.0, 0.45),
+        ),
+        metadata={
+            "version": "synthetic-test-v1",
+            "pseudo_type": "NC",
+            "relativistic": "scalar",
+            "functional": "PBE",
+            "is_ultrasoft": False,
+            "is_paw": False,
+            "has_so": False,
+            "core_correction": False,
+        },
+    )
+
+
 def test_periodic_upf_local_transform_matches_qe_gth_oracle():
     gth, upf = _matched_gth_and_numerical_upf()
     grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
@@ -209,3 +270,421 @@ def test_periodic_upf_identity_is_content_bound_and_path_independent(tmp_path):
 
     assert system(first_path).fingerprint == system(second_path).fingerprint
     assert system(first_path).fingerprint != system(changed_path).fingerprint
+
+
+@pytest.mark.parametrize("angular_momentum", (0, 1, 2))
+def test_upf_nonlocal_radial_transform_matches_analytic_oracle(
+    angular_momentum,
+):
+    alpha = 0.73
+    radii = np.linspace(0.0, 12.0, 12001, dtype=np.float64)
+    spacing = float(radii[1] - radii[0])
+    stored_beta = radii ** (angular_momentum + 1) * np.exp(-alpha * radii**2)
+    projector = NonlocalProjectorData(
+        angular_momentum=angular_momentum,
+        values=tuple(stored_beta),
+        radial_grid=RadialGrid(
+            radii,
+            np.zeros_like(radii),
+            integration_weights=np.full(radii.shape, spacing),
+        ),
+    )
+    q = np.asarray((0.0, 0.37, 1.25), dtype=np.float64)
+    volume = 91.0
+
+    observed = periodic_upf._upf_projector_radial_transform(
+        projector,
+        q,
+        volume=volume,
+    )
+    expected = (
+        4.0
+        * pi
+        / sqrt(volume)
+        * sqrt(pi)
+        * q**angular_momentum
+        / (2.0 ** (angular_momentum + 2) * alpha ** (angular_momentum + 1.5))
+        * np.exp(-(q**2) / (4.0 * alpha))
+    )
+
+    np.testing.assert_allclose(observed, expected, rtol=2.0e-11, atol=2.0e-12)
+
+
+def test_periodic_upf_batches_radial_setup_by_q_and_angular_channel(monkeypatch):
+    grid = RealSpaceGrid((12, 12, 12), (8.0, 8.0, 8.0))
+    basis = PlaneWaveBasis(grid, 8.0)
+    pseudo = _synthetic_periodic_upf()
+    calls = []
+    original = periodic_upf.spherical_jn
+
+    def observed_spherical_jn(angular_momentum, values):
+        calls.append((angular_momentum, values.shape[0]))
+        return original(angular_momentum, values)
+
+    monkeypatch.setattr(periodic_upf, "spherical_jn", observed_spherical_jn)
+    operator = PeriodicUPFNonlocalOperator(
+        pseudo,
+        basis,
+        ((1.0, 2.0, 3.0),),
+    )
+
+    assert [angular_momentum for angular_momentum, _size in calls] == [0, 1, 2]
+    assert max(size for _angular_momentum, size in calls) < basis.active_count
+    operator.close()
+
+
+def test_periodic_upf_nonlocal_is_hermitian_and_preserves_full_dij():
+    grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
+    basis = PlaneWaveBasis.from_reduced_kpoint(grid, 4.0, (0.25, 0.125, -0.25))
+    pseudo = _synthetic_periodic_upf()
+    operator = PeriodicUPFNonlocalOperator(pseudo, basis, ((1.0, 2.0, 3.0),))
+    rng = np.random.default_rng(72)
+    left = basis.normalize(
+        mx.array(
+            (rng.normal(size=grid.shape) + 1j * rng.normal(size=grid.shape)).astype(
+                np.complex64
+            )
+        )
+    )
+    right = basis.normalize(
+        mx.array(
+            (rng.normal(size=grid.shape) + 1j * rng.normal(size=grid.shape)).astype(
+                np.complex64
+            )
+        )
+    )
+
+    left_right = mx.sum(mx.conjugate(left) * operator.apply(right))
+    right_left = mx.sum(mx.conjugate(right) * operator.apply(left))
+    expected_coupling = np.zeros((10, 10), dtype=np.float32)
+    expected_coupling[:2, :2] = ((1.20, -0.15), (-0.15, 0.85))
+    expected_coupling[2:5, 2:5] = np.eye(3, dtype=np.float32) * 0.70
+    expected_coupling[5:, 5:] = np.eye(5, dtype=np.float32) * 0.45
+
+    np.testing.assert_allclose(
+        np.asarray(left_right),
+        np.asarray(mx.conjugate(right_left)),
+        atol=2.0e-5,
+    )
+    np.testing.assert_allclose(
+        np.asarray(operator._flattened_coupling),
+        expected_coupling,
+        atol=1.0e-7,
+    )
+    assert operator.to_dict()["angular_projector_count_per_ion"] == 10
+
+
+def test_periodic_upf_nonlocal_forces_match_fixed_orbital_derivative():
+    grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
+    basis = PlaneWaveBasis.from_reduced_kpoint(grid, 4.0, (0.25, 0.125, -0.25))
+    pseudo = _synthetic_periodic_upf()
+    position = np.asarray(((1.0, 2.0, 3.0),), dtype=np.float64)
+    rng = np.random.default_rng(81)
+    trial = rng.normal(size=(2, *grid.shape)) + 1j * rng.normal(
+        size=(2, *grid.shape)
+    )
+    orbitals = basis.orthonormalize(mx.array(trial.astype(np.complex64)))
+    occupations = (2.0, 0.75)
+
+    observed = np.asarray(
+        PeriodicUPFNonlocalOperator(pseudo, basis, position).forces(
+            orbitals,
+            occupations=occupations,
+        )
+    )
+    reference = np.zeros_like(position)
+    displacement = 2.0e-3
+    for axis in range(3):
+        plus = position.copy()
+        minus = position.copy()
+        plus[0, axis] += displacement
+        minus[0, axis] -= displacement
+        energy_plus = float(
+            PeriodicUPFNonlocalOperator(pseudo, basis, plus).energy(
+                orbitals,
+                occupations=occupations,
+            )
+        )
+        energy_minus = float(
+            PeriodicUPFNonlocalOperator(pseudo, basis, minus).energy(
+                orbitals,
+                occupations=occupations,
+            )
+        )
+        reference[0, axis] = -(energy_plus - energy_minus) / (2.0 * displacement)
+
+    np.testing.assert_allclose(observed, reference, atol=8.0e-5, rtol=5.0e-4)
+
+
+def test_periodic_upf_nonlocal_uses_shared_kpoint_batch_path(monkeypatch):
+    grid = RealSpaceGrid((8, 8, 8), (8.0, 8.0, 8.0))
+    bases = (
+        PlaneWaveBasis.from_reduced_kpoint(grid, 3.0, (0.0, 0.0, 0.0)),
+        PlaneWaveBasis.from_reduced_kpoint(grid, 3.0, (0.25, 0.0, 0.0)),
+    )
+    pseudo = _synthetic_periodic_upf()
+    rng = np.random.default_rng(91)
+    states = tuple(
+        basis._state_from_compact(
+            mx.array(
+                (
+                    rng.normal(size=(2, basis.active_count))
+                    + 1j * rng.normal(size=(2, basis.active_count))
+                ).astype(np.complex64)
+            )
+        )
+        for basis in bases
+    )
+    nonlocal_operators = tuple(
+        PeriodicUPFNonlocalOperator(pseudo, basis, ((1.0, 2.0, 3.0),))
+        for basis in bases
+    )
+    potential = mx.full(grid.shape, 0.2, dtype=mx.float32)
+    operators = tuple(
+        PeriodicKohnShamOperator(basis, potential, nonlocal_operator)
+        for basis, nonlocal_operator in zip(bases, nonlocal_operators, strict=True)
+    )
+    expected = tuple(
+        operator._apply_compact(state)
+        for operator, state in zip(operators, states, strict=True)
+    )
+    matmul_calls = 0
+    original_matmul = mx.matmul
+
+    def counted_matmul(*args, **kwargs):
+        nonlocal matmul_calls
+        matmul_calls += 1
+        return original_matmul(*args, **kwargs)
+
+    monkeypatch.setattr(mx, "matmul", counted_matmul)
+    outcome = PeriodicKohnShamOperator._apply_compact_batch(
+        operators,
+        states,
+        prepared_batch=_CompactBatch.from_states(states),
+    )
+
+    assert not outcome.failures
+    assert matmul_calls == 3
+    for index, reference in enumerate(expected):
+        np.testing.assert_allclose(
+            np.asarray(outcome.action_for(index).values),
+            np.asarray(reference.values),
+            atol=3.0e-6,
+        )
+
+
+def test_periodic_upf_nonlocal_rejects_cross_angular_dij():
+    pseudo = replace(
+        _synthetic_periodic_upf(),
+        nonlocal_coupling_matrix=(
+            (1.20, -0.15, 0.10, 0.0),
+            (-0.15, 0.85, 0.0, 0.0),
+            (0.10, 0.0, 0.70, 0.0),
+            (0.0, 0.0, 0.0, 0.45),
+        ),
+    )
+    grid = RealSpaceGrid((6, 6, 6), (6.0, 6.0, 6.0))
+
+    with pytest.raises(ValueError, match="cannot couple different angular"):
+        PeriodicUPFNonlocalOperator(
+            pseudo,
+            PlaneWaveBasis(grid, 2.0),
+            ((1.0, 2.0, 3.0),),
+        )
+
+
+def test_periodic_upf_executes_through_scf_and_records_projector_work():
+    pseudo = _synthetic_periodic_upf()
+    system = PeriodicDFTSystem(
+        (6.0, 6.0, 6.0),
+        (6, 6, 6),
+        ((3.0, 3.0, 3.0),),
+        pseudo,
+    )
+    mesh = KPointMesh(
+        [KPoint((0.0, 0.0, 0.0), coordinate_system="reduced")]
+    )
+    observer = RuntimeObserver(detail_events=False)
+
+    result = run_periodic_scf(
+        system,
+        cutoff_hartree=2.0,
+        kpoint_mesh=mesh,
+        n_bands=2,
+        config=PeriodicSCFConfig(
+            max_iterations=2,
+            min_iterations=2,
+            density_tolerance=1.0e6,
+            energy_tolerance=1.0e6,
+            orbital_tolerance=1.0e6,
+            mixer="linear",
+            davidson=PeriodicDavidsonConfig(
+                max_iterations=12,
+                tolerance=5.0e-3,
+                max_subspace_size=12,
+            ),
+        ),
+        observer=observer,
+    )
+
+    assert result.system_fingerprint == system.fingerprint
+    assert result.converged
+    assert np.isfinite(result.total_energy)
+    work = observer.snapshot()["work_counters"]
+    assert work["projector_elements_generated"] > 0
+    assert work["projector_traffic_elements"] > 0
+    forces = periodic_scf_forces(system, result)
+    assert np.isfinite(np.asarray(forces.forces)).all()
+    assert forces.provenance["pseudopotential_format"] == "upf"
+    assert set(forces.to_dict()["force_by_term_hartree_per_bohr"]) == {
+        "local_upf",
+        "nonlocal_upf",
+        "ion_ewald",
+    }
+    bands = run_periodic_band_structure(
+        system,
+        result,
+        BandPath(
+            [KPoint((0.0, 0.0, 0.0), coordinate_system="reduced")]
+        ),
+        n_bands=2,
+        config=PeriodicDavidsonConfig(
+            max_iterations=12,
+            tolerance=5.0e-3,
+            max_subspace_size=12,
+        ),
+    )
+    assert np.isfinite(np.asarray(bands.eigenvalues)).all()
+
+
+@pytest.mark.data
+def test_qe_oncv_silicon_executes_periodic_upf_scf():
+    source = Path(
+        "vendors/quantum-espresso/QEHeat/examples/pseudo/Si_ONCV_PBE-1.1.upf"
+    )
+    assert sha256(source.read_bytes()).hexdigest() == (
+        "d66fa1bb73367f9a2fc34286ecd0876fa1c8c79b25f3b12b30b5b8dc2164148c"
+    )
+    pseudo = read_upf(source)
+    assert pseudo.periodic_upf_compatible
+    system = PeriodicDFTSystem(
+        (10.26, 10.26, 10.26),
+        (16, 16, 16),
+        ((0.0, 0.0, 0.0), (5.13, 5.13, 5.13)),
+        pseudo,
+    )
+    mesh = KPointMesh(
+        [KPoint((0.0, 0.0, 0.0), coordinate_system="reduced")]
+    )
+    observer = RuntimeObserver(detail_events=False)
+
+    result = run_periodic_scf(
+        system,
+        cutoff_hartree=4.0,
+        kpoint_mesh=mesh,
+        n_bands=4,
+        config=PeriodicSCFConfig(
+            max_iterations=1,
+            min_iterations=1,
+            density_tolerance=1.0,
+            energy_tolerance=1.0,
+            orbital_tolerance=1.0,
+            mixer="linear",
+            davidson=PeriodicDavidsonConfig(
+                max_iterations=12,
+                tolerance=5.0e-3,
+                max_subspace_size=16,
+            ),
+        ),
+        observer=observer,
+    )
+
+    assert result.system_fingerprint == system.fingerprint
+    assert np.isfinite(result.total_energy)
+    assert observer.snapshot()["work_counters"]["projector_elements_generated"] > 0
+
+
+def test_periodic_scf_rejects_mixed_pseudopotential_formats_before_execution():
+    upf = _synthetic_periodic_upf()
+    gth, _local_upf = _matched_gth_and_numerical_upf()
+    system = PeriodicDFTSystem(
+        (6.0, 6.0, 6.0),
+        (6, 6, 6),
+        ((2.0, 3.0, 3.0), (4.0, 3.0, 3.0)),
+        pseudopotentials=(upf, gth),
+    )
+    mesh = KPointMesh(
+        [KPoint((0.0, 0.0, 0.0), coordinate_system="reduced")]
+    )
+
+    with pytest.raises(ValueError, match="one pseudopotential format"):
+        run_periodic_scf(
+            system,
+            cutoff_hartree=2.0,
+            kpoint_mesh=mesh,
+            n_bands=4,
+            config=PeriodicSCFConfig(max_iterations=1),
+        )
+
+
+def test_periodic_upf_stress_fails_closed_before_electronic_work():
+    pseudo = _synthetic_periodic_upf()
+    system = PeriodicDFTSystem(
+        (6.0, 6.0, 6.0),
+        (6, 6, 6),
+        ((3.0, 3.0, 3.0),),
+        pseudo,
+    )
+    mesh = KPointMesh(
+        [KPoint((0.0, 0.0, 0.0), coordinate_system="reduced")]
+    )
+
+    for evaluator in (periodic_analytic_stress, periodic_finite_difference_stress):
+        with pytest.raises(ValueError, match="requires GTH input"):
+            evaluator(
+                system,
+                cutoff_hartree=2.0,
+                kpoint_mesh=mesh,
+                n_bands=2,
+            )
+
+
+def test_periodic_upf_checkpoint_contract_is_content_bound():
+    pseudo = _synthetic_periodic_upf()
+    changed_coupling = list(list(row) for row in pseudo.nonlocal_coupling_matrix)
+    changed_coupling[0][0] += 0.01
+    systems = tuple(
+        PeriodicDFTSystem(
+            (6.0, 6.0, 6.0),
+            (6, 6, 6),
+            ((3.0, 3.0, 3.0),),
+            candidate,
+        )
+        for candidate in (
+            pseudo,
+            replace(
+                pseudo,
+                nonlocal_coupling_matrix=tuple(
+                    tuple(row) for row in changed_coupling
+                ),
+            ),
+        )
+    )
+    mesh = KPointMesh(
+        [KPoint((0.0, 0.0, 0.0), coordinate_system="reduced")]
+    )
+    contracts = tuple(
+        periodic_scf_calculation_contract(
+            system,
+            cutoff_hartree=2.0,
+            kpoint_mesh=mesh,
+            n_bands=2,
+        )
+        for system in systems
+    )
+    species = contracts[0]["system"]["pseudopotentials"]["species"][0]
+
+    assert species["format"] == "upf"
+    assert len(species["content_sha256"]) == 64
+    assert species["dij_dimension"] == 4
+    assert contracts[0] != contracts[1]


### PR DESCRIPTION
## Summary

- implement full-DIJ scalar norm-conserving periodic UPF local and nonlocal operators
- dispatch periodic SCF, bands, fixed-cell forces, batching, and checkpoint identity by pseudopotential format
- fail closed for mixed formats, augmentation physics, spin-orbit terms, nonlinear core correction, and UPF stress
- deduplicate |G+k| values and batch spherical-Bessel transforms by angular channel during UPF setup
- update canonical DFT capability and roadmap documentation without widening scientific certification

## Evidence

- 24 UPF tests passed; the opt-in vendor-data test is skipped by default
- source-bound Quantum ESPRESSO Si ONCV data test passed separately
- 8 focused GTH, batching, checkpoint, bands, stress, and scope regressions passed
- Ruff passed for src and the focused test surface
- 39 narrative and 69 API documentation pages generated successfully
- same-workload Si ONCV setup diagnostic improved from about 189.4 ms to 4.52 ms; warm apply remains governed by projector count and the shared device batch path

## Scientific boundary

This does not certify broad UPF material transferability. SSSP 1.3 PBE precision selects Ultrasoft Mg and PAW O for MgO, which remain outside the admitted scalar norm-conserving boundary.